### PR TITLE
Add GCA converter and GURPS connector system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: arm64
+            suffix: ''
+          - goos: darwin
+            goarch: amd64
+            suffix: ''
+          - goos: linux
+            goarch: amd64
+            suffix: ''
+          - goos: windows
+            goarch: amd64
+            suffix: '.exe'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -ldflags="-s -w" \
+            -o gca-converter-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }} \
+            ./cmd/gca-converter
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gca-converter-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: gca-converter-*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: gca-converter-*

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ data/
 
 # Backup copies of refactored files
 _backup/
+
+# Git worktrees
+.worktrees/

--- a/cmd/gca-converter/main.go
+++ b/cmd/gca-converter/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AntTheLimey/gm-apprentice/internal/converter"
+)
+
+func main() {
+	input := flag.String("input", "",
+		"Path to GCA4 data files directory")
+	output := flag.String("output", "",
+		"Output directory for converted markdown")
+	flag.Parse()
+
+	if *input == "" || *output == "" {
+		fmt.Fprintln(os.Stderr,
+			"Usage: gca-converter --input <path> --output <path>")
+		fmt.Fprintln(os.Stderr,
+			"  --input   Path to GCA4 data files directory")
+		fmt.Fprintln(os.Stderr,
+			"  --output  Output directory for markdown files")
+		os.Exit(1)
+	}
+
+	// Expand ~ in output path
+	expandedOutput := expandHome(*output)
+
+	// Find all .gdf files
+	entries, err := os.ReadDir(*input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"Error reading input directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	converted := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(
+			strings.ToLower(entry.Name()), ".gdf") {
+			continue
+		}
+
+		gdfPath := filepath.Join(*input, entry.Name())
+		fmt.Printf("Converting: %s\n", entry.Name())
+
+		if err := converter.ConvertFile(
+			gdfPath, expandedOutput); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"  Error: %v\n", err)
+			continue
+		}
+		converted++
+	}
+
+	fmt.Printf("\nDone. Converted %d books to %s\n",
+		converted, expandedOutput)
+}
+
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[1:])
+	}
+	return path
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,6 +38,7 @@ gm-apprentice supports four systems:
 
 - **Call of Cthulhu 7th Edition** (CoC 7e) — percentile-based investigation and cosmic horror
 - **GURPS 4th Edition** — point-buy, any-genre, 3d6 roll-under
+  - *If you have GURPS Character Assistant (GCA4), Claude will set up access to your data files automatically the first time you ask a GURPS question.*
 - **Forged in the Dark** (Blades in the Dark) — d6 dice pool, position and effect
 - **D&D 5th Edition, 2024 Revision** — d20 core, classes and spell slots
 

--- a/docs/ttrpg-expert.md
+++ b/docs/ttrpg-expert.md
@@ -105,10 +105,14 @@ and a character sheet template.
   sheet. Built into the skill.
 
 - **GURPS 4e** — `systems/gurps-4e/`. No open license exists
-  for GURPS. A future update will add a connector to read
-  your own GCA4 data files for full mechanical support.
-  Currently includes workflow guidance and embedded reference
-  data.
+  for GURPS. If you have GURPS Character Assistant (GCA4)
+  installed, the first time you ask a GURPS question, a setup
+  wizard runs automatically. It downloads a converter tool and
+  processes your GCA4 data into markdown. Your converted data
+  stays on your machine. With GCA4, you get full mechanical
+  support including character validation and point tracking.
+  Without it, ttrpg-expert provides workflow guidance and
+  embedded reference data.
 
 - **Other systems** — `systems/generic/`. Universal RPG
   guidance for any system not listed above. Covers common

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/AntTheLimey/gm-apprentice
+
+go 1.24.4

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -1,0 +1,131 @@
+package converter
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AntTheLimey/gm-apprentice/internal/gdf"
+)
+
+// ConvertSection writes a GDF section as a markdown file
+func ConvertSection(section gdf.Section, outputDir string) error {
+	filename := strings.ToLower(section.Name) + ".md"
+	outPath := filepath.Join(outputDir, filename)
+
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	title := formatTitle(section.Name)
+	fmt.Fprintf(f, "# %s\n\n", title)
+
+	currentSub := ""
+	for _, entry := range section.Entries {
+		if entry.Subsection != currentSub {
+			currentSub = entry.Subsection
+			if currentSub != "" {
+				fmt.Fprintf(f, "## %s\n\n", currentSub)
+			}
+		}
+		writeEntry(f, entry)
+	}
+
+	return nil
+}
+
+// ConvertFile parses a GDF file and writes all sections
+// as markdown files into a subdirectory named after the book
+func ConvertFile(gdfPath string, outputDir string) error {
+	f, err := os.Open(gdfPath)
+	if err != nil {
+		return fmt.Errorf("open gdf: %w", err)
+	}
+	defer f.Close()
+
+	sections, err := gdf.Parse(f)
+	if err != nil {
+		return fmt.Errorf("parse gdf: %w", err)
+	}
+
+	// Create book subdirectory from filename
+	base := filepath.Base(gdfPath)
+	bookName := strings.TrimSuffix(base, filepath.Ext(base))
+	bookName = sanitizeDirName(bookName)
+	bookDir := filepath.Join(outputDir, bookName)
+
+	for _, section := range sections {
+		// Skip non-content sections
+		if skipSection(section.Name) {
+			continue
+		}
+		if len(section.Entries) == 0 {
+			continue
+		}
+		if err := ConvertSection(section, bookDir); err != nil {
+			return fmt.Errorf("convert %s: %w",
+				section.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func writeEntry(w io.Writer, entry gdf.Entry) {
+	fmt.Fprintf(w, "### %s\n", entry.Name)
+	if entry.Cost != "" {
+		fmt.Fprintf(w, "- **Cost:** %s\n", entry.Cost)
+	}
+	if page, ok := entry.Fields["page"]; ok {
+		fmt.Fprintf(w, "- **Page:** %s\n", page)
+	}
+	if cat, ok := entry.Fields["cat"]; ok {
+		fmt.Fprintf(w, "- **Category:** %s\n", cat)
+	}
+	if desc, ok := entry.Fields["description"]; ok && desc != "" {
+		fmt.Fprintf(w, "\n%s\n", desc)
+	}
+	fmt.Fprintln(w)
+}
+
+func formatTitle(name string) string {
+	if name == "" {
+		return ""
+	}
+	lower := strings.ToLower(name)
+	return strings.ToUpper(lower[:1]) + lower[1:]
+}
+
+func sanitizeDirName(name string) string {
+	// Replace spaces and special chars with hyphens
+	replacer := strings.NewReplacer(
+		" ", "-",
+		".", "",
+		"'", "",
+		",", "",
+	)
+	result := replacer.Replace(strings.ToLower(name))
+	// Clean up double hyphens
+	for strings.Contains(result, "--") {
+		result = strings.ReplaceAll(result, "--", "-")
+	}
+	return result
+}
+
+var skipSections = map[string]bool{
+	"AUTHOR":      true,
+	"Settings":    true,
+	"SKILLTYPES":  true,
+	"CONVERTDICE": true,
+	"BODY":        true,
+}
+
+func skipSection(name string) bool { return skipSections[name] }

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -1,0 +1,120 @@
+package converter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AntTheLimey/gm-apprentice/internal/gdf"
+)
+
+func TestConvertFile(t *testing.T) {
+	gdfContent := `[SKILLTYPES]
+Combat, Physical
+
+[ADVANTAGES]
+<General>
+Combat Reflexes, 15, page(B43), cat(Mental, Physical),
+    description(Never freeze in a surprise situation.)
+
+[SKILLS]
+Karate, DX/H, page(B203), cat(Combat)
+`
+	// Write GDF content to a temp file with a name that exercises sanitizeDirName
+	tmpDir := t.TempDir()
+	gdfFile := filepath.Join(tmpDir, "My Book--4th Ed.gdf")
+	if err := os.WriteFile(gdfFile, []byte(gdfContent), 0644); err != nil {
+		t.Fatalf("write temp gdf: %v", err)
+	}
+
+	outDir := t.TempDir()
+	if err := ConvertFile(gdfFile, outDir); err != nil {
+		t.Fatalf("ConvertFile error: %v", err)
+	}
+
+	// The sanitized book subdirectory name should be "my-book-4th-ed"
+	bookDir := filepath.Join(outDir, "my-book-4th-ed")
+	info, err := os.Stat(bookDir)
+	if err != nil {
+		t.Fatalf("book subdirectory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected a directory for book subdirectory")
+	}
+
+	// At least one markdown file must exist in the subdirectory
+	entries, err := os.ReadDir(bookDir)
+	if err != nil {
+		t.Fatalf("read book dir: %v", err)
+	}
+	var mdFiles []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			mdFiles = append(mdFiles, e.Name())
+		}
+	}
+	if len(mdFiles) == 0 {
+		t.Fatal("no markdown files found in book subdirectory")
+	}
+
+	// SKILLTYPES is in the skip list — skilltypes.md must not exist
+	for _, name := range mdFiles {
+		if name == "skilltypes.md" {
+			t.Error("skilltypes.md should have been skipped")
+		}
+	}
+
+	// advantages.md and skills.md should both be present
+	want := []string{"advantages.md", "skills.md"}
+	fileSet := make(map[string]bool, len(mdFiles))
+	for _, name := range mdFiles {
+		fileSet[name] = true
+	}
+	for _, w := range want {
+		if !fileSet[w] {
+			t.Errorf("expected %s to be created, got files: %v", w, mdFiles)
+		}
+	}
+}
+
+func TestConvertSection(t *testing.T) {
+	section := gdf.Section{
+		Name: "ADVANTAGES",
+		Entries: []gdf.Entry{
+			{
+				Name:       "Combat Reflexes",
+				Cost:       "15",
+				Subsection: "General",
+				Fields: map[string]string{
+					"page":        "B43",
+					"cat":         "Mental, Physical",
+					"description": "Never freeze in a surprise situation.",
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	err := ConvertSection(section, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "advantages.md")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Combat Reflexes") {
+		t.Error("missing entry name")
+	}
+	if !strings.Contains(content, "15") {
+		t.Error("missing cost")
+	}
+	if !strings.Contains(content, "B43") {
+		t.Error("missing page reference")
+	}
+}

--- a/internal/gdf/parser.go
+++ b/internal/gdf/parser.go
@@ -1,0 +1,187 @@
+package gdf
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// Section represents a GDF section like [ADVANTAGES]
+type Section struct {
+	Name    string
+	Entries []Entry
+}
+
+// Entry represents a single item in a section
+type Entry struct {
+	Name       string
+	Cost       string
+	Fields     map[string]string
+	Subsection string
+	Raw        string
+}
+
+// Parse reads a GDF file and returns structured sections
+func Parse(r io.Reader) ([]Section, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var sections []Section
+	currentIdx := -1
+	currentSubsection := ""
+	var lineBuf strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip empty lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Skip comments (lines starting with *)
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+
+		// Skip header lines (double slashes)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+
+		// Section header
+		if strings.HasPrefix(trimmed, "[") &&
+			strings.HasSuffix(trimmed, "]") {
+			name := trimmed[1 : len(trimmed)-1]
+			sections = append(sections, Section{Name: name})
+			currentIdx = len(sections) - 1
+			currentSubsection = ""
+			continue
+		}
+
+		// Subsection tag
+		if strings.HasPrefix(trimmed, "<") &&
+			strings.HasSuffix(trimmed, ">") {
+			currentSubsection = trimmed[1 : len(trimmed)-1]
+			continue
+		}
+
+		// Skip if no current section
+		if currentIdx == -1 {
+			continue
+		}
+
+		// Handle continuation lines:
+		// A trailing _ signals explicit continuation.
+		// A trailing , signals implicit continuation (next line
+		// is part of the same entry).
+		if strings.HasSuffix(trimmed, "_") {
+			// Remove trailing _ and accumulate
+			lineBuf.WriteString(
+				strings.TrimSuffix(trimmed, "_"))
+			lineBuf.WriteString(" ")
+			continue
+		}
+		if strings.HasSuffix(trimmed, ",") {
+			lineBuf.WriteString(trimmed)
+			lineBuf.WriteString(" ")
+			continue
+		}
+
+		// Complete line (possibly with accumulated buffer)
+		fullLine := ""
+		if lineBuf.Len() > 0 {
+			lineBuf.WriteString(trimmed)
+			fullLine = lineBuf.String()
+			lineBuf.Reset()
+		} else {
+			fullLine = trimmed
+		}
+
+		entry := parseEntry(fullLine, currentSubsection)
+		if entry.Name != "" {
+			sections[currentIdx].Entries = append(sections[currentIdx].Entries, entry)
+		}
+	}
+
+	return sections, scanner.Err()
+}
+
+func parseEntry(line string, subsection string) Entry {
+	entry := Entry{
+		Fields:     make(map[string]string),
+		Subsection: subsection,
+		Raw:        line,
+	}
+
+	// Parse the comma-separated fields
+	// First field is the name, second is cost
+	parts := splitRespectingParens(line)
+	if len(parts) == 0 {
+		return entry
+	}
+
+	entry.Name = strings.TrimSpace(parts[0])
+
+	if len(parts) > 1 {
+		entry.Cost = strings.TrimSpace(parts[1])
+	}
+
+	// Parse remaining fields as key(value) pairs
+	for i := 2; i < len(parts); i++ {
+		part := strings.TrimSpace(parts[i])
+		if idx := strings.Index(part, "("); idx != -1 {
+			key := part[:idx]
+			// Find matching closing paren
+			val := extractParenValue(part[idx:])
+			entry.Fields[key] = val
+		}
+	}
+
+	return entry
+}
+
+func splitRespectingParens(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(s) {
+		parts = append(parts, s[start:])
+	}
+	return parts
+}
+
+func extractParenValue(s string) string {
+	if len(s) < 2 || s[0] != '(' {
+		return s
+	}
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[1:i]
+			}
+		}
+	}
+	// Unmatched paren — return everything after first (
+	return s[1:]
+}

--- a/internal/gdf/parser_test.go
+++ b/internal/gdf/parser_test.go
@@ -1,0 +1,141 @@
+package gdf
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseSection(t *testing.T) {
+	input := `[ADVANTAGES]
+Combat Reflexes, 15, page(B43), cat(Mental, Physical),
+    description(Never "freeze" in a surprise situation.)
+High Pain Threshold, 10, page(B59), cat(Physical),
+    description(You are as pointed as _
+    you like.)
+`
+	sections, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	sec := sections[0]
+	if sec.Name != "ADVANTAGES" {
+		t.Errorf("expected section ADVANTAGES, got %s", sec.Name)
+	}
+	if len(sec.Entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(sec.Entries))
+	}
+	if sec.Entries[0].Name != "Combat Reflexes" {
+		t.Errorf("expected Combat Reflexes, got %s",
+			sec.Entries[0].Name)
+	}
+	if sec.Entries[0].Fields["page"] != "B43" {
+		t.Errorf("expected page B43, got %s",
+			sec.Entries[0].Fields["page"])
+	}
+}
+
+func TestParseMultipleSections(t *testing.T) {
+	input := `[ADVANTAGES]
+Combat Reflexes, 15, page(B43)
+
+[SKILLS]
+Karate, DX/H, page(B203), cat(Combat)
+`
+	sections, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(sections))
+	}
+	if sections[0].Name != "ADVANTAGES" {
+		t.Errorf("expected ADVANTAGES, got %s", sections[0].Name)
+	}
+	if sections[1].Name != "SKILLS" {
+		t.Errorf("expected SKILLS, got %s", sections[1].Name)
+	}
+}
+
+func TestSkipComments(t *testing.T) {
+	input := `[ADVANTAGES]
+* This is a comment
+Combat Reflexes, 15, page(B43)
+`
+	sections, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sections[0].Entries) != 1 {
+		t.Errorf("expected 1 entry (comment skipped), got %d",
+			len(sections[0].Entries))
+	}
+}
+
+func TestContinuationLines(t *testing.T) {
+	input := `[ADVANTAGES]
+High Pain Threshold, 10, page(B59), _
+    description(You are as tough as they come.)
+`
+	sections, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sections[0].Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d",
+			len(sections[0].Entries))
+	}
+	if sections[0].Entries[0].Fields["description"] !=
+		"You are as tough as they come." {
+		t.Errorf("unexpected description: %s",
+			sections[0].Entries[0].Fields["description"])
+	}
+}
+
+func TestSubsections(t *testing.T) {
+	input := `[ADVANTAGES]
+<General>
+Combat Reflexes, 15, page(B43)
+<Mental>
+Eidetic Memory, 5, page(B51)
+`
+	sections, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sections[0].Entries[0].Subsection != "General" {
+		t.Errorf("expected General subsection, got %s",
+			sections[0].Entries[0].Subsection)
+	}
+	if sections[0].Entries[1].Subsection != "Mental" {
+		t.Errorf("expected Mental subsection, got %s",
+			sections[0].Entries[1].Subsection)
+	}
+}
+
+func TestRealFile(t *testing.T) {
+	path := "/Users/antonypegg/Downloads/GCA4/data files/GURPS Basic Set 4th Ed.--Characters.gdf"
+	f, err := os.Open(path)
+	if err != nil {
+		t.Skip("GCA data file not available:", err)
+	}
+	defer f.Close()
+
+	sections, err := Parse(f)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	t.Logf("Parsed %d sections", len(sections))
+	for _, s := range sections {
+		t.Logf("  [%s]: %d entries", s.Name, len(s.Entries))
+	}
+
+	// Sanity checks
+	if len(sections) < 5 {
+		t.Error("expected at least 5 sections")
+	}
+}

--- a/skills/ttrpg-expert/SKILL.md
+++ b/skills/ttrpg-expert/SKILL.md
@@ -152,6 +152,54 @@ Handbook, p.73" for D&D). The rules reference files within
 each system subfolder contain all the mechanics needed for
 accurate rulings.
 
+## Game System Data
+
+### Built-in Systems (No Setup Required)
+
+D&D 5e 2024, Forged in the Dark, and Call of Cthulhu 7e
+have open SRD content built into their system subfolders.
+No additional setup is needed.
+
+### GURPS 4e (Connector Required)
+
+GURPS has no open license. For full mechanical support
+(point costs, trait lookups, damage tables), this skill
+reads from converted GCA4 data files.
+
+**On first GURPS request, check `~/.gm-apprentice/config.json`.**
+
+If GURPS is not configured (or `converted` is false):
+
+1. Ask the user: "GURPS doesn't have an open SRD, so I need
+   access to your game data for full mechanical support.
+   Do you have GCA4 (GURPS Character Assistant) data files?"
+
+2. If yes: get the path to their GCA data files directory.
+
+3. Determine the user's OS and architecture.
+
+4. Download the correct `gca-converter` binary from the
+   latest GitHub Release at
+   `github.com/AntTheLimey/gm-apprentice/releases`.
+
+5. Run: `gca-converter --input <path> --output ~/.gm-apprentice/data/gurps-4e`
+
+6. Create/update `~/.gm-apprentice/config.json` with the
+   GURPS entry (type: gca-data, paths, book list, timestamp).
+
+7. Announce completion and proceed with the request.
+
+If no GCA data: fall back to the workflow-only content in
+`systems/gurps-4e/`. The skill still works for session
+planning, encounter design, and general GURPS guidance —
+just without precise mechanical lookups.
+
+**Reading converted data:** When you need a specific GURPS
+mechanical value (point cost, damage, skill default), read
+the relevant file from `~/.gm-apprentice/data/gurps-4e/`.
+The files are organized by source book and section:
+`{book-name}/advantages.md`, `{book-name}/skills.md`, etc.
+
 ## Content Generation Workflow
 
 1. **Clarify** — What type, which system, what depth, what

--- a/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
@@ -1,12 +1,5 @@
 # GURPS 4e Character Generation
 
-> **Copyright Notice:** GURPS is a registered trademark of
-> Steve Jackson Games Incorporated. The mechanical data in
-> this section is derived from GURPS sourcebooks and is
-> included for personal reference only. A future update will
-> replace embedded data with a connector to the user's own
-> licensed GCA data files. See ATTRIBUTION.md for details.
-
 Comprehensive character creation assistant for GURPS 4th Edition.
 Supports any genre, power level, and campaign style. Works for
 both players building PCs and GMs drafting NPCs.
@@ -47,18 +40,13 @@ parameters. These constrain every decision that follows.
 | Special rules | Magic, psionics, powers, supers | None |
 | House rules | GM-specific modifications | None |
 
-**Point Total Guidelines** (Basic Set Characters p.487):
+Point totals range from low (ordinary people) through heroic
+(action heroes, special forces) to legendary and superheroic.
+Higher budgets allow more extreme attributes and exotic abilities.
 
-| Points | Power Level | Examples |
-|--------|------------|---------|
-| 25 | Ordinary person | Civilians, bystanders |
-| 50 | Competent normal | Trained professional |
-| 75 | Experienced | Veteran, skilled expert |
-| 100 | Exceptional | Elite professional |
-| 150 | Heroic | Action hero, special forces |
-| 200 | Larger-than-life | Cinematic hero, low supers |
-| 300 | Legendary | Comic book hero |
-| 500+ | Superheroic | Major supers, demigods |
+Look up the full point-total-to-power-level guidelines in your
+converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/campaign-settings.md`
 
 ### Step 1: Character Concept
 
@@ -85,16 +73,23 @@ page number.
 
 Four primary attributes, each defaulting to 10 (human average).
 
-| Attribute | Cost per Level | Governs |
-|-----------|---------------|---------|
-| ST (Strength) | 10 pts/level | Damage, lifting, HP base |
-| DX (Dexterity) | 20 pts/level | Physical skills, Basic Speed |
-| IQ (Intelligence) | 20 pts/level | Mental skills, Will, Per |
-| HT (Health) | 10 pts/level | Endurance, FP base, Basic Speed |
+- **ST (Strength)** — Governs damage, lifting capacity, and HP
+  base. One of the cheaper attributes per level.
+- **DX (Dexterity)** — Governs physical skills and contributes
+  to Basic Speed. One of the more expensive attributes per
+  level because it broadly affects many skills.
+- **IQ (Intelligence)** — Governs mental skills, Will, and
+  Perception. Same cost tier as DX.
+- **HT (Health)** — Governs endurance, FP base, and contributes
+  to Basic Speed. Same cost tier as ST.
 
 **Size Modifier affects ST cost**: For SM +1 or larger, ST cost
-drops to 9/level; for SM -1 or smaller, cost is unchanged but
-check specific rules.
+is reduced; for SM -1 or smaller, cost is unchanged but check
+specific rules.
+
+Look up attribute point costs per level in your converted GCA
+data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/attributes.md`
 
 **Guidance by archetype:**
 - Combat-focused: ST 12-14, DX 12-14, HT 12+
@@ -115,19 +110,21 @@ costs the listed amount; each -1 below 10 gives back that amount.
 
 Derive from primary attributes; can be bought up or down.
 
-| Characteristic | Base | Cost to Modify |
-|---------------|------|---------------|
-| HP (Hit Points) | = ST | 2 pts/level |
-| Will | = IQ | 5 pts/level |
-| Perception (Per) | = IQ | 5 pts/level |
-| FP (Fatigue Points) | = HT | 3 pts/level |
-| Basic Speed | = (HT+DX)/4 | 5 pts/+0.25 |
-| Basic Move | = Basic Speed (drop fractions) | 5 pts/level |
+- **HP (Hit Points)** — Defaults to ST
+- **Will** — Defaults to IQ
+- **Perception (Per)** — Defaults to IQ
+- **FP (Fatigue Points)** — Defaults to HT
+- **Basic Speed** — Derived from (HT+DX)/4
+- **Basic Move** — Derived from Basic Speed (drop fractions)
+
+Look up cost-to-modify values for each secondary characteristic
+in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/attributes.md`
 
 **Derived values to calculate:**
-- **Damage**: Based on ST via the Damage Table (Characters p.16).
-  Key breakpoints: ST 10 = 1d-2 thr / 1d sw; ST 12 = 1d-1 / 1d+2;
-  ST 14 = 1d / 2d; ST 16 = 1d+1 / 2d+2
+- **Damage**: Based on ST via the Damage Table. Look up in your
+  converted GCA data:
+  `~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/damage-table.md`
 - **Basic Lift**: ST×ST/5 lbs
 - **Dodge**: floor(Basic Speed) + 3
 - **Size Modifier (SM)**: 0 for humans
@@ -156,22 +153,23 @@ limitations (-% cost). Net modifier cannot reduce cost below
 
 **Common Advantages by Genre:**
 
-*Modern Military/Action*: Combat Reflexes [15], High Pain
-Threshold [10], Fit/Very Fit [5/15], Danger Sense [15],
-Luck [15], Military Rank [5/level], Legal Enforcement Powers
-[varies], Trained by a Master [30] (cinematic only)
+*Modern Military/Action*: Combat Reflexes, High Pain Threshold,
+Fit/Very Fit, Danger Sense, Luck, Military Rank, Legal
+Enforcement Powers, Trained by a Master (cinematic only)
 
-*Fantasy*: Magery [varies], Power Investiture [10/level],
-Eidetic Memory [5], Luck [15], Patron [varies]
+*Fantasy*: Magery, Power Investiture, Eidetic Memory, Luck,
+Patron
 
-*Supers*: Innate Attack [varies], DR [varies], Enhanced Move
-[20/level], Flight [40], Super ST/DX [varies with power
-modifier]. For power modifiers and supers-specific rules,
-reference `gurps-rules-reference.md` (Powers and Supers
-  section).
+*Supers*: Innate Attack, DR, Enhanced Move, Flight, Super
+ST/DX (with power modifier). For power modifiers and
+supers-specific rules, reference `gurps-rules-reference.md`
+(Powers and Supers section).
 
-*Horror*: Medium [10], Oracle [15], Spirit Empathy [10],
-Luck [15], Danger Sense [15]
+*Horror*: Medium, Oracle, Spirit Empathy, Luck, Danger Sense
+
+Look up specific advantage point costs in your converted GCA
+data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/advantages.md`
 
 **Validation:**
 - Some advantages require GM permission (Unkillable, Modular
@@ -186,25 +184,28 @@ Luck [15], Danger Sense [15]
 Disadvantages give back character points up to the campaign
 limit (typically -50 to -75 pts).
 
-**Self-Control Rolls (CR)**: Many mental disadvantages use CR:
+**Self-Control Rolls (CR)**: Many mental disadvantages use a
+self-control roll. Worse self-control (rolling less often to
+resist) increases the point value of the disadvantage through
+a multiplier.
 
-| CR | Resist On | Point Multiplier |
-|----|----------|-----------------|
-| 6 | Almost never | ×2 |
-| 9 | Quite rarely | ×1.5 |
-| 12 | Fairly often | ×1 (base) |
-| 15 | Almost always | ×0.5 |
+Look up self-control roll values and multipliers in your
+converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/disadvantages.md`
 
 **Disadvantage-Driven Characters**: GURPS characters come alive
 through disadvantages. They should reflect the concept, not be
 picked for point value. A Navy SEAL with Duty (Military;
-Extremely Hazardous; 15 or less) [-20] and Sense of Duty
-(Teammates) [-5] tells a story. Greed [-15] on the same
-character doesn't.
+Extremely Hazardous) and Sense of Duty (Teammates) tells a
+story. Greed on the same character doesn't.
 
-**Duty frequency**: 6 or less [-2], 9 or less [-5], 12 or
-less [-10], 15 or less [-15]. Extremely Hazardous doubles
-the base value. Involuntary adds another -5.
+**Duty frequency**: Duty value depends on how often the duty
+comes up (frequency) and how dangerous it is. Extremely
+Hazardous and Involuntary modifiers increase the value further.
+
+Look up specific disadvantage point values in your converted
+GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/disadvantages.md`
 
 **Validation:**
 - Total disadvantages cannot exceed campaign limit
@@ -218,17 +219,13 @@ the base value. Involuntary adds another -5.
 Skills are learned abilities. Effective level = controlling
 attribute + modifier from difficulty and points spent.
 
-**Difficulty Levels and Cost Progression:**
+**Difficulty Levels**: Skills come in Easy, Average, Hard, and
+Very Hard. Harder skills require more points to reach the same
+relative level compared to the controlling attribute.
 
-| Pts Spent | Easy (E) | Average (A) | Hard (H) | Very Hard (VH) |
-|-----------|----------|-------------|----------|----------------|
-| 1 | Attr+0 | Attr-1 | Attr-2 | Attr-3 |
-| 2 | Attr+1 | Attr+0 | Attr-1 | Attr-2 |
-| 4 | Attr+2 | Attr+1 | Attr+0 | Attr-1 |
-| 8 | Attr+3 | Attr+2 | Attr+1 | Attr+0 |
-| 12 | Attr+4 | Attr+3 | Attr+2 | Attr+1 |
-| 16 | Attr+5 | Attr+4 | Attr+3 | Attr+2 |
-| +4 per | +1 | +1 | +1 | +1 |
+Look up the skill difficulty/cost progression table in your
+converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/skills.md`
 
 **Skill Defaults**: Most skills can be attempted untrained at
 attribute-4 to attribute-6. Some have no default (Karate,
@@ -236,9 +233,9 @@ Surgery, etc.).
 
 **Techniques**: Specific applications of a skill bought up from
 a default penalty. Example: Targeted Attack (Guns/Head) defaults
-to Guns-7, can be bought up to Guns-3 max. For martial arts
-techniques, reference `gurps-rules-reference.md` (Martial
-  Arts section).
+to Guns at a penalty, can be bought up to a reduced penalty. For
+martial arts techniques, reference `gurps-rules-reference.md`
+(Martial Arts section).
 
 **Wildcard Skills**: Written as Skill! (e.g., Gun!). Cost 3 pts
 per +1 from attribute. Cinematic campaigns only.
@@ -273,20 +270,12 @@ skills 12-14, related skills 10-12
 Equipment purchased with starting wealth, not character points
 (unless using Signature Gear advantage).
 
-**Starting Wealth by TL:**
+Starting wealth varies by Tech Level. Higher TLs provide more
+starting money; the Wealth advantage multiplies it, while
+Struggling/Poor/Dead Broke reduces it.
 
-| TL | Setting | Starting Wealth |
-|----|---------|----------------|
-| 3 | Medieval | $1,000 |
-| 4 | Renaissance | $2,000 |
-| 5 | Industrial | $5,000 |
-| 6 | WWI-WWII | $10,000 |
-| 7 | Early Modern | $15,000 |
-| 8 | Modern | $20,000 |
-| 9+ | Near Future+ | $30,000+ |
-
-Wealth advantage multiplies starting wealth; Struggling/Poor/
-Dead Broke reduces it.
+Look up starting wealth by TL in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/equipment.md`
 
 For weapons and equipment stats, reference
 `gurps-rules-reference.md` (Equipment section). Canonical

--- a/skills/ttrpg-expert/systems/gurps-4e/mechanics.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/mechanics.md
@@ -1,12 +1,5 @@
 # GURPS 4th Edition — Core Mechanics
 
-> **Copyright Notice:** GURPS is a registered trademark of
-> Steve Jackson Games Incorporated. The mechanical data in
-> this section is derived from GURPS sourcebooks and is
-> included for personal reference only. A future update will
-> replace embedded data with a connector to the user's own
-> licensed GCA data files. See ATTRIBUTION.md for details.
-
 ## Overview
 
 Generic Universal RolePlaying System using 3d6 roll-under.
@@ -20,52 +13,80 @@ For character generation workflows, see
 
 ## Primary Attributes
 
-| Attribute | Default | Cost | Governs |
-|-----------|---------|------|---------|
-| ST | 10 | 10/level | Damage, HP, Basic Lift |
-| DX | 10 | 20/level | Physical skills, Basic Speed |
-| IQ | 10 | 20/level | Mental skills, Will, Perception |
-| HT | 10 | 10/level | FP, Basic Speed, consciousness |
+GURPS characters are built on four primary attributes, each
+defaulting to 10 (human average). Raising or lowering them
+costs character points:
+
+- **ST (Strength)** — Governs melee damage, lifting capacity
+  (Basic Lift), and base Hit Points. Cheaper per level than
+  DX or IQ, making it efficient for physical combatants.
+- **DX (Dexterity)** — Governs physical skills (combat,
+  athletics, stealth) and contributes to Basic Speed. The
+  most expensive physical attribute because it affects so
+  many skills at once.
+- **IQ (Intelligence)** — Governs mental and knowledge skills,
+  and sets the base for Will and Perception. As expensive as
+  DX because it is the controlling attribute for many skills.
+- **HT (Health)** — Governs endurance, Fatigue Points, and
+  contributes to Basic Speed. Also governs consciousness
+  rolls and recovery. Same cost as ST.
+
+For specific point costs per attribute level, this skill reads
+from your converted GCA data at
+`~/.gm-apprentice/data/gurps-4e/`. Run the setup wizard to
+connect your GCA4 data files.
 
 ## Secondary Characteristics
 
-| Characteristic | Base | Cost to Modify |
-|---------------|------|---------------|
-| HP | ST | ±2 pts/level |
-| Will | IQ | ±5 pts/level |
-| Per | IQ | ±5 pts/level |
-| FP | HT | ±3 pts/level |
-| Basic Speed | (HT+DX)/4 | ±5 pts per ±0.25 |
-| Basic Move | Basic Speed (floor) | ±5 pts/level |
-| Dodge | Basic Speed + 3 (floor) | Derived, not bought directly |
-| Basic Lift | ST×ST/5 lbs | Derived from ST |
+Secondary characteristics derive from primary attributes. Each
+can be bought up or down from its base value at a per-level
+cost.
 
-## Damage Table (Key Breakpoints)
+- **HP (Hit Points)** — Defaults to ST. Represents physical
+  toughness and how much damage you can absorb.
+- **Will** — Defaults to IQ. Governs resistance to mental
+  influence, fear, and psychic attacks.
+- **Perception (Per)** — Defaults to IQ. Governs noticing
+  things, spotting ambushes, and sensory rolls.
+- **FP (Fatigue Points)** — Defaults to HT. Represents
+  endurance; spent on extra effort, spellcasting, and
+  sustained exertion.
+- **Basic Speed** — Derived from (HT+DX)/4. Determines turn
+  order in combat and contributes to Dodge.
+- **Basic Move** — Derived from Basic Speed (drop fractions).
+  Yards moved per turn on the ground.
+- **Dodge** — Derived from Basic Speed + 3 (drop fractions
+  first). Primary active defense against any attack.
+- **Basic Lift** — Derived from ST×ST/5 lbs. Determines
+  carrying capacity and encumbrance thresholds.
 
-| ST | Thrust | Swing |
-|----|--------|-------|
-| 8 | 1d-3 | 1d-2 |
-| 10 | 1d-2 | 1d |
-| 11 | 1d-1 | 1d+1 |
-| 12 | 1d-1 | 1d+2 |
-| 13 | 1d | 2d-1 |
-| 14 | 1d | 2d |
-| 16 | 1d+1 | 2d+2 |
-| 18 | 1d+2 | 3d |
-| 20 | 2d-1 | 3d+2 |
+For specific point costs to modify secondary characteristics,
+this skill reads from your converted GCA data at
+`~/.gm-apprentice/data/gurps-4e/`. Run the setup wizard to
+connect your GCA4 data files.
 
 ## Skills
 
-| Difficulty | Attr-3 | Attr-2 | Attr-1 | Attr+0 | Attr+1 | Attr+2 | Each +1 |
-|------------|--------|--------|--------|--------|--------|--------|---------|
-| Easy | — | — | — | 1 | 2 | 4 | +4 |
-| Average | — | — | 1 | 2 | 4 | 8 | +4 |
-| Hard | — | 1 | 2 | 4 | 8 | 12 | +4 |
-| Very Hard | 1 | 2 | 4 | 8 | 12 | 16 | +4 |
+Skills are learned abilities rated by difficulty level: Easy,
+Average, Hard, or Very Hard. The difficulty determines how
+many character points you must invest to reach a given level
+relative to the controlling attribute.
 
-Controlling attribute is typically DX for physical skills,
-IQ for mental/knowledge skills. Some skills use HT, Per,
-or Will. Defaults allow untrained use at a penalty.
+- **Controlling Attribute** — Typically DX for physical skills,
+  IQ for mental/knowledge skills. Some skills use HT, Per,
+  or Will.
+- **Difficulty** — Harder skills require more points to reach
+  the same relative level. A Very Hard skill at attribute+0
+  costs significantly more than an Easy skill at the same
+  relative level.
+- **Defaults** — Most skills can be attempted untrained at a
+  penalty (typically attribute-4 to attribute-6). Some have
+  no default (Karate, Surgery, etc.).
+
+For the skill cost progression table (points spent vs.
+difficulty level), this skill reads from your converted GCA
+data at `~/.gm-apprentice/data/gurps-4e/`. Run the setup
+wizard to connect your GCA4 data files.
 
 ## Roll Mechanics
 
@@ -99,8 +120,15 @@ Point-buy system for traits. Full lists with costs in
 - **Enhancements/Limitations**: Percentage modifiers on
   advantage costs (+/- %, minimum 20% of base)
 
-Self-control rolls for mental disadvantages:
-CR 6 (×2), CR 9 (×1.5), CR 12 (×1), CR 15 (×0.5)
+Mental disadvantages often use self-control rolls (CR) to
+determine how often the character must give in to the
+compulsion. Worse self-control (harder to resist) increases
+the point value of the disadvantage.
+
+For specific self-control roll multipliers and point cost
+tables, this skill reads from your converted GCA data at
+`~/.gm-apprentice/data/gurps-4e/`. Run the setup wizard to
+connect your GCA4 data files.
 
 ## Character Generation
 

--- a/skills/ttrpg-expert/systems/gurps-4e/rules-reference.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/rules-reference.md
@@ -1,20 +1,18 @@
 # GURPS 4e Expanded Rules Reference
 
-> **Copyright Notice:** GURPS is a registered trademark of
-> Steve Jackson Games Incorporated. The mechanical data in
-> this section is derived from GURPS sourcebooks and is
-> included for personal reference only. A future update will
-> replace embedded data with a connector to the user's own
-> licensed GCA data files. See ATTRIBUTION.md for details.
-
 Deep-dive reference for GURPS 4th Edition mechanics beyond the
 summaries in `game-systems.md`. This file covers combat, advantages
 and disadvantages, equipment, powers, magic, and martial arts.
 
 This file is the authoritative GURPS rules reference within
-this skill. All point costs, formulas, and mechanics are based
-on GURPS 4th Edition sourcebooks. Cite source book and page
-number where possible (e.g., "Basic Set — Characters, p.14").
+this skill. All procedural mechanics are based on GURPS 4th
+Edition sourcebooks. Cite source book and page number where
+possible (e.g., "Basic Set — Characters, p.14").
+
+For specific point costs, damage values, and mechanical tables,
+this skill reads from your converted GCA data at
+`~/.gm-apprentice/data/gurps-4e/`. Run the setup wizard to
+connect your GCA4 data files.
 
 ## Table of Contents
 
@@ -78,50 +76,47 @@ without requiring backward movement.
 
 ### Hit Locations
 
-| Location | Penalty | DR Modifier | Wounding Modifier |
-|----------|---------|-------------|-------------------|
-| Torso | +0 | — | ×1 |
-| Skull | -7 | DR 2 (bone) | ×4 |
-| Face | -5 | — | ×4 (no DR 2 bone) |
-| Neck | -5 | — | ×2 (crushing ×1.5) |
-| Eye | -9 | — | ×4, can blind |
-| Groin | -3 | — | ×1 (knockdown at HT-5) |
-| Arm | -2 | — | ×1 (cripple at HP/2) |
-| Leg | -2 | — | ×1 (cripple at HP/2) |
-| Hand | -4 | — | ×1 (cripple at HP/3) |
-| Foot | -4 | — | ×1 (cripple at HP/3) |
-| Vitals | -3 | — | ×3 (imp/pi only) |
+Hit locations impose an attack penalty and modify wounding
+effects on that body part. Key locations include the torso
+(no penalty, standard wounding), skull, face, neck, eyes,
+vitals, limbs, hands, and feet. Some locations have inherent
+DR (e.g., skull bone) and different wounding multipliers for
+different damage types.
+
+Look up the full hit location table (penalties, DR modifiers,
+and wounding multipliers) in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-campaigns/combat-tables.md`
 
 ### Damage Types
 
-| Type | Abbreviation | Notes |
-|------|-------------|-------|
-| Crushing | cr | Blunt trauma; double knockback |
-| Cutting | cut | ×1.5 after DR penetration |
-| Impaling | imp | ×2 after DR penetration |
-| Piercing (small) | pi- | ×0.5 after DR |
-| Piercing | pi | ×1 after DR |
-| Piercing (large) | pi+ | ×1.5 after DR |
-| Piercing (huge) | pi++ | ×2 after DR |
-| Burning | burn | ×1 after DR; can ignite |
-| Corrosion | cor | ×1; also damages DR |
-| Toxic | tox | ×1; internal only |
-| Fatigue | fat | To FP, not HP |
+Damage types determine the wounding multiplier applied after
+armor penetration. The main types are:
+
+- **Crushing (cr)** — Blunt trauma; double knockback
+- **Cutting (cut)** — Slashing; enhanced wounding after DR
+- **Impaling (imp)** — Piercing deep; high wounding multiplier
+- **Piercing (pi-, pi, pi+, pi++)** — Ranging from small to
+  huge, with increasing wounding effectiveness
+- **Burning (burn)** — Fire/energy; can ignite
+- **Corrosion (cor)** — Also damages DR
+- **Toxic (tox)** — Internal only
+- **Fatigue (fat)** — Applies to FP, not HP
+
+Look up specific wounding multipliers for each damage type in
+your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-campaigns/combat-tables.md`
 
 ### Ranged Combat Modifiers
 
-| Factor | Modifier |
-|--------|---------|
-| Range (Speed/Range Table) | -0 to -17+ |
-| Target Size (SM) | Per SM difference |
-| Aim (1 turn) | +weapon Acc |
-| Aim (2 turns) | +Acc +1 |
-| Aim (3+ turns) | +Acc +2 |
-| Braced | Included in Acc for 2-handed |
-| Scope | +1 to +3 (stacks with Acc) |
-| Move and Attack | -4 (max effective 9) |
-| Pop-up attack | -2 |
-| Shooting into melee | -4 per interposing figure |
+Ranged combat applies modifiers for range (via the Speed/Range
+Table), target size (SM), aiming duration, bracing, scope
+bonuses, movement penalties, pop-up attacks, and shooting into
+melee. Aim gives the weapon's Accuracy bonus on the first turn,
+with cumulative +1 per additional turn of aiming (max +2 extra).
+
+Look up the full ranged combat modifier table in your converted
+GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-campaigns/combat-tables.md`
 
 ### Shock and Knockdown
 
@@ -148,65 +143,77 @@ without requiring backward movement.
 
 ### Key Advantages with Rules Notes
 
-**Combat Reflexes** [15]: +1 all active defenses, +6 vs surprise,
-+2 Fright Checks, never freeze. One of the best combat advantages
-in the game. (Characters p.43)
+Advantage names and what they do conceptually. These traits are
+bought with character points — look up specific costs in your
+converted GCA data.
 
-**High Pain Threshold** [10]: Never suffer shock penalties, +3 to
+**Combat Reflexes**: +1 all active defenses, +6 vs surprise,
++2 Fright Checks, never freeze. One of the best combat
+advantages in the game. (Characters p.43)
+
+**High Pain Threshold**: Never suffer shock penalties, +3 to
 resist knockdown/stun, +3 to resist torture. (Characters p.59)
 
-**Danger Sense** [15]: GM rolls Per (or IQ) secretly when danger
+**Danger Sense**: GM rolls Per (or IQ) secretly when danger
 threatens; success = warning. (Characters p.47)
 
-**Fit** [5] / **Very Fit** [15]: Fit = +1 to all HT rolls
-(except resist death). Very Fit = +2 to all HT rolls, recover FP
-at double rate. (Characters p.55)
+**Fit / Very Fit**: Fit = +1 to all HT rolls (except resist
+death). Very Fit = +2 to all HT rolls, recover FP at double
+rate. (Characters p.55)
 
-**Luck** [15] / **Extraordinary Luck** [30] / **Ridiculous Luck**
-[60]: Reroll any one roll (take best) once per hour of play /
-30 min / 10 min. Cinematic campaigns may allow higher levels.
-(Characters p.66)
+**Luck / Extraordinary Luck / Ridiculous Luck**: Reroll any
+one roll (take best) at varying frequencies — once per hour of
+play, every 30 min, or every 10 min. Cinematic campaigns may
+allow higher levels. (Characters p.66)
 
-**Talent** [varies]: +1/level to a group of skills plus reaction
-bonuses from those who value the talent. Cost = 5/10/15 pts per
-level depending on breadth. (Characters p.89)
+**Talent**: +1/level to a group of skills plus reaction bonuses
+from those who value the talent. Cost depends on breadth of the
+skill group. (Characters p.89)
 
-**Trained by a Master** [30]: Halves skill penalties for rapid
+**Trained by a Master**: Halves skill penalties for rapid
 strikes, allows cinematic martial arts techniques. Prerequisite
 for many Martial Arts options. Cinematic. (Characters p.93)
 
-**Weapon Master** [20-45]: +1/die to damage with chosen
-weapon(s), halves penalties for Rapid Strike. Cost varies by
-breadth. (Characters p.99)
+**Weapon Master**: +1/die to damage with chosen weapon(s),
+halves penalties for Rapid Strike. Cost varies by breadth of
+weapons covered. (Characters p.99)
 
-**Magery** [5 + 10/level]: Prerequisite for spells. Level adds
-to spell skill and to IQ for learning spells. Magery 0 [5] =
-can learn spells but no bonus. (Characters p.66)
+**Magery**: Prerequisite for spells. Level adds to spell skill
+and to IQ for learning spells. Magery 0 = can learn spells but
+no bonus. (Characters p.66)
+
+Look up specific advantage point costs in your converted GCA
+data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/advantages.md`
 
 ### Key Disadvantages with Rules Notes
 
-**Duty** [varies]: Frequency × hazard. Base: 6 or less [-2],
-9 or less [-5], 12 or less [-10], 15 or less [-15]. Extremely
-Hazardous = ×2. Involuntary = extra -5. (Characters p.133)
+**Duty**: Value depends on frequency (how often it comes up)
+and hazard level. Extremely Hazardous and Involuntary modifiers
+increase the value. (Characters p.133)
 
-**Enemy** [varies]: Frequency × power. Less powerful than PC
-[-5 base], equal [-10 base], more powerful [-20 base], entire
-government [-30 base]. Frequency multiplier same as Duty.
-(Characters p.135)
+**Enemy**: Value depends on frequency and power relative to the
+PC (less powerful, equal, more powerful, or an entire
+government). (Characters p.135)
 
-**Sense of Duty** [varies]: -2 to small group, -5 to large
-group, -10 to nation, -15 to all living things, -20 to all
-sapient beings. (Characters p.153)
+**Sense of Duty**: Value depends on the size of the group the
+character feels duty toward (small group through all sapient
+beings). (Characters p.153)
 
-**Code of Honor** [varies]: -5 (Professional), -10 (Gentleman's
-or Soldier's), -15 (Chivalric). (Characters p.127)
+**Code of Honor**: Value varies by strictness of the code
+(Professional, Gentleman's/Soldier's, Chivalric).
+(Characters p.127)
 
-**Overconfidence** [-5*]: Self-control roll to avoid rash
-actions. Asterisk = modified by CR. (Characters p.148)
+**Overconfidence**: Self-control roll to avoid rash actions.
+Value modified by self-control number. (Characters p.148)
 
-**Compulsive Behavior** [-5* to -15*]: Various. -5 for minor,
--10 for moderate, -15 for seriously inconvenient. Modified by
-CR. (Characters p.128)
+**Compulsive Behavior**: Various types at different base values
+for minor, moderate, and seriously inconvenient compulsions.
+Modified by self-control roll. (Characters p.128)
+
+Look up specific disadvantage point values in your converted
+GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/disadvantages.md`
 
 ### Disadvantage Limits
 
@@ -224,29 +231,33 @@ limitations decrease it. They're core to the Powers system but
 apply to any advantage.
 
 **Key Enhancements:**
-- Affects Others (+50%/level): Share advantage with others
-- Area Effect (+50%/level): Affects an area (2 yd radius/level)
-- Armor Divisor (+50% for (2), +100% for (3), +150% for (5), +200% for (10))
-- Selective Area (+20%): Exclude targets from area effect
-- Reduced Time (+20%/level): Halve activation time
+- Affects Others: Share advantage with others
+- Area Effect: Affects an area (radius per level)
+- Armor Divisor: Penetrate DR more effectively (multiple tiers)
+- Selective Area: Exclude targets from area effect
+- Reduced Time: Halve activation time per level
 
 **Key Limitations:**
-- Accessibility (-varies): Limited conditions for use
-- Costs Fatigue (-5%/FP): Drains FP to use
-- Limited Use (-varies): Finite uses per day
-- Nuisance Effect (-5%): Annoying side effect
-- Requires (Attribute) Roll (-10%): Must roll to activate
-- Takes Extra Time (-10%/level): Double activation time
-- Unreliable (-varies): Activation roll required
+- Accessibility: Limited conditions for use
+- Costs Fatigue: Drains FP to use
+- Limited Use: Finite uses per day
+- Nuisance Effect: Annoying side effect
+- Requires (Attribute) Roll: Must roll to activate
+- Takes Extra Time: Double activation time per level
+- Unreliable: Activation roll required
 
 **Power Modifiers** (from Powers): These are special limitations
 that tie an advantage to a power source:
-- Divine (-10%): Requires faith and patron deity
-- Magical (-10%): Can be dispelled, detected as magic
-- Psionic (-10%): Subject to anti-psi
-- Spirit (-25%): Requires spirit cooperation
-- Super (-10%): Innate metahuman ability
-- Chi (-10%): Internal energy, requires discipline
+- Divine: Requires faith and patron deity
+- Magical: Can be dispelled, detected as magic
+- Psionic: Subject to anti-psi
+- Spirit: Requires spirit cooperation
+- Super: Innate metahuman ability
+- Chi: Internal energy, requires discipline
+
+Look up specific enhancement and limitation percentage values
+in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/modifiers.md`
 
 **Net modifier rule**: Total limitation percentage cannot reduce
 final cost below 20% of the base cost.
@@ -266,7 +277,7 @@ ST requirement, and special notes.
 - Damage type (cut, cr, imp, etc.)
 
 **Ranged Weapons:**
-- Damage (often listed directly, e.g., 7d pi for 5.56mm)
+- Damage (often listed directly, e.g., dice + type)
 - Accuracy (Acc): Bonus when Aiming
 - Range: Half damage / max range in yards
 - RoF: Shots per turn
@@ -274,44 +285,38 @@ ST requirement, and special notes.
 - Bulk: Handling penalty (more negative = harder to maneuver)
 - Recoil (Rcl): Penalty to subsequent shots in a burst
 
-### Key Modern Firearms (TL8)
+For specific weapon statistics, look up in your converted GCA
+data or reference the source books directly:
+`~/.gm-apprentice/data/gurps-4e/gurps-high-tech/weapons.md`
 
 Source: GURPS High-Tech (TL5-8 weapons) and GURPS
-High-Tech — Weapon Tables. Key weapon categories:
-
-**Pistols**: 2d-3d pi/pi+ damage, Acc 2-3, typical weight 2-3 lbs
-**SMGs**: 2d-3d pi damage, Acc 2-4, RoF 8-15
-**Assault Rifles**: 5d-7d pi damage, Acc 4-5, RoF 10-15
-**Battle Rifles**: 7d pi damage, Acc 5, RoF 10-11
-**Shotguns**: 1d+1 pi per pellet (×9), or slugs 4d+4 pi++
-**Sniper Rifles**: 7d-9d pi damage, Acc 5-6+scope
+High-Tech — Weapon Tables for detailed stats.
 
 ### Armor
 
-**Modern Body Armor** (TL8):
-- Ballistic vest: DR 8/2* (pi/cut vs other)
-- Tactical vest: DR 12/5* with plates
-- Full tactical gear: DR 12-35 depending on plates
+Armor provides Damage Resistance (DR) that subtracts directly
+from incoming damage. DR values vary by material and
+construction, from light leather to heavy plate to modern
+ballistic vests with ceramic plates. Some armor has split DR
+(one value for piercing/cutting, another for other damage
+types, noted with *).
 
-The * notation means the first number applies to piercing and
-cutting attacks; the second applies to all other damage types.
+Look up specific armor DR values in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-high-tech/armor.md`
 
-**Medieval/Fantasy** (Source: GURPS Low-Tech):
-- Leather: DR 1-2
-- Chain mail: DR 4
-- Light plate: DR 6
-- Heavy plate: DR 7-8
-- Shield: DB +1 to +3
+Source: GURPS Low-Tech (TL0-4 armor), GURPS High-Tech (TL5-8
+armor), GURPS Ultra-Tech (TL9+ armor).
 
-### Encumbrance Table
+### Encumbrance
 
-| Level | Weight | Move Penalty | Dodge Penalty |
-|-------|--------|-------------|---------------|
-| None (0) | ≤ BL | None | None |
-| Light (1) | ≤ 2×BL | -1 | -1 |
-| Medium (2) | ≤ 3×BL | -2 | -2 |
-| Heavy (3) | ≤ 6×BL | -3 | -3 |
-| X-Heavy (4) | ≤ 10×BL | -4 | -4 |
+Encumbrance is based on total carried weight relative to Basic
+Lift (BL). There are five levels: None, Light, Medium, Heavy,
+and X-Heavy. Each level above None penalizes both Move and
+Dodge by an increasing amount.
+
+Look up the encumbrance table (weight thresholds and
+Move/Dodge penalties) in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-campaigns/encumbrance.md`
 
 ---
 
@@ -324,7 +329,7 @@ superhuman ability by combining advantages with power modifiers.
 
 A "power" is a thematic group of advantages sharing a power
 source (e.g., all your fire-based abilities share the "Fire
-Power" source with a -10% limitation). This groups them
+Power" source with a limitation). This groups them
 narratively and mechanically.
 
 **Building a Power:**
@@ -333,24 +338,25 @@ narratively and mechanically.
 3. Apply the power source modifier to each advantage
 4. Optionally add a Talent for the power (+1/level to rolls)
 
-**Example — Low-Level Super Soldier (200 pts):**
-- Enhanced ST +5 (Super, -10%) [41]
-- DR 5 (Tough Skin, -40%; Super, -10%) [13]
-- Enhanced Move 1 (Super, -10%) [18]
-- Regeneration (Slow; Super, -10%) [9]
+To build specific power examples with point costs, look up
+advantages and modifiers in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/advantages.md`
 
 ### Power Talents
 
 Power Talents add their level to all rolls made with abilities
-in that power. Cost is 5 pts/level for narrow powers, 10/level
-for broad.
+in that power. Cost depends on whether the power is narrow or
+broad.
 
 ### Anti-Powers
 
 Some advantages specifically counter powers:
-- Neutralize (specific power) [50]: Shut down one power
-- Static (specific power) [30]: Create power-dampening field
-- Resistant to (power) [varies]: Bonus to resist
+- Neutralize (specific power): Shut down one power
+- Static (specific power): Create power-dampening field
+- Resistant to (power): Bonus to resist
+
+Look up anti-power costs in your converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-basic-set-4th-ed-characters/advantages.md`
 
 Source: GURPS Supers covers origin stories, power
 frameworks, and metahuman campaign design in detail.
@@ -365,7 +371,7 @@ system from GURPS Magic.
 ### Default (Spell-Based) Magic
 
 **Prerequisites:**
-- Magery 0 [5] to learn any spells
+- Magery 0 to learn any spells
 - Higher Magery adds to spell skill and IQ for spell learning
 - Most spells require other spells as prerequisites
 
@@ -425,19 +431,19 @@ have:
 
 ### Key Combat Skills
 
-| Skill | Difficulty | Default | Parry | Notes |
-|-------|-----------|---------|-------|-------|
-| Boxing | DX/A | — | Skill/2+3 | +1/die damage, +1 Parry |
-| Brawling | DX/E | — | Skill/2+3 | +1/die damage above skill 2 |
-| Karate | DX/H | — | Skill/2+3 | +1/die damage at DX+1, +2/die at DX+2 |
-| Judo | DX/H | — | Skill/2+3 | Can parry weapons unarmed at -3 |
-| Wrestling | DX/A | — | — | Grappling; +1 per 2 pts of ST |
-| Broadsword | DX/A | Various | Skill/2+3 | Sword & similar |
-| Knife | DX/E | Various | Skill/2+3 | Fast draw common |
-| Shield | DX/E | Various | — | Block = Skill/2+3 |
-| Staff | DX/A | Various | Skill/2+3 | Reach 1-2 |
-| Guns (Pistol) | DX/E | DX-4 | — | Ranged; no parry |
-| Guns (Rifle) | DX/E | DX-4 | — | Ranged; no parry |
+| Skill | Difficulty | Parry | Notes |
+|-------|-----------|-------|-------|
+| Boxing | DX/A | Skill/2+3 | Bonus to damage, +1 Parry |
+| Brawling | DX/E | Skill/2+3 | Bonus to damage at higher skill |
+| Karate | DX/H | Skill/2+3 | Scaling damage bonus at higher skill |
+| Judo | DX/H | Skill/2+3 | Can parry weapons unarmed at -3 |
+| Wrestling | DX/A | — | Grappling; ST bonus |
+| Broadsword | DX/A | Skill/2+3 | Sword & similar |
+| Knife | DX/E | Skill/2+3 | Fast draw common |
+| Shield | DX/E | — | Block = Skill/2+3 |
+| Staff | DX/A | Skill/2+3 | Reach 1-2 |
+| Guns (Pistol) | DX/E | — | Ranged; no parry |
+| Guns (Rifle) | DX/E | — | Ranged; no parry |
 
 ### Key Techniques
 
@@ -445,22 +451,18 @@ Techniques are specializations bought up from a negative default.
 Cost is 1 pt to reduce penalty by 1 (for Average techniques) or
 to reduce by 1 from a Hard technique.
 
-| Technique | Default | Max | Notes |
-|-----------|---------|-----|-------|
-| Arm Lock | Skill+0 | +4 | Grappling follow-up |
-| Back Kick | Skill-4 | Skill-1 | More damage, less accuracy |
-| Choke Hold | Skill-2 | +0 | Fatigue/suffocation |
-| Disarm | Skill-2 | +0 | Quick Contest to disarm |
-| Elbow Strike | Skill-2 | +0 | Close combat |
-| Feint | Skill+0 | — | Not technically a technique; use Quick Contest |
-| Knee Strike | Skill-1 | +0 | Close combat |
-| Targeted Attack | Skill-(location penalty) | Skill-1 to -3 | Reduce hit location penalty |
-| Sweep | Skill-3 | -1 | Knock prone |
-| Rapid Strike | Skill-6 each | Skill-3 each | Two attacks; halved with TBAM/WM |
+Common techniques include: Arm Lock, Back Kick, Choke Hold,
+Disarm, Elbow Strike, Knee Strike, Targeted Attack, Sweep,
+and Rapid Strike. Each has a default relative to the parent
+skill and a maximum level it can be improved to.
+
+Look up specific technique defaults and max values in your
+converted GCA data:
+`~/.gm-apprentice/data/gurps-4e/gurps-martial-arts/techniques.md`
 
 ### Cinematic Combat Options
 
-Require **Trained by a Master** [30] or **Weapon Master** [20-45]:
+Require **Trained by a Master** or **Weapon Master**:
 - Rapid Strike penalties halved (to -3 each)
 - Flying Leap, Power Blow, Pressure Points, Kiai
 - Breaking Blow, Mental Strength, Blind Fighting
@@ -473,7 +475,7 @@ Gutter Fighting, and SAS/SBS Close Combat.
 ### Gun Fu (Cinematic Firearms)
 
 From GURPS Gun Fu. For cinematic gun combat:
-- Dual-Weapon Attack: -4 each hand (halved with Gunslinger)
+- Dual-Weapon Attack: penalty each hand (halved with Gunslinger)
 - Shooting from unusual positions
 - Pistol-whip and weapon transition techniques
 
@@ -484,7 +486,7 @@ Source: GURPS Gun Fu for complete cinematic firearms rules.
 ## 8. Psionic Powers
 
 From GURPS Psionic Powers. Psionics use the Powers framework
-with the Psionic (-10%) power modifier.
+with the Psionic power modifier.
 
 ### Psionic Abilities
 


### PR DESCRIPTION
## Summary

- Build Go binary that parses GCA4 `.gdf` files into clean markdown, with GDF parser, markdown converter, and CLI entrypoint
- Add GitHub Action for cross-compiled releases (macOS arm64/amd64, Linux amd64, Windows amd64)
- Strip copyrighted GURPS numerical data from skill files, replace with pointers to user's converted GCA data at `~/.gm-apprentice/data/gurps-4e/`
- Add setup wizard to SKILL.md that guides first-time GURPS users through connecting their GCA4 data files
- Update documentation with GURPS connector setup instructions

## Test Plan

- [x] All Go tests pass (`go test ./...` — 8 tests: 6 parser, 2 converter)
- [x] Real GCA4 data converts successfully (39 books, 175 markdown files)
- [x] No copyrighted numerical data remains in GURPS skill files
- [x] SKILL.md includes connector setup wizard
- [ ] Tag `v0.1.0` after merge to trigger release workflow
- [ ] Verify GitHub Action produces 4 cross-compiled binaries