### PR TITLE
Improve discoverability and skill orchestration

### DIFF
--- a/docs/campaign-lifecycle.md
+++ b/docs/campaign-lifecycle.md
@@ -1,0 +1,88 @@
+# Campaign Lifecycle
+
+How the four gm-apprentice skills work together across the
+life of a TTRPG campaign.
+
+## The Four Skills
+
+| Skill | Role |
+|-------|------|
+| **ttrpg-expert** | Content generation, rules reference, session planning, GM frameworks |
+| **campaign-organizer** | Vault structure, entity filing, graph relationships, Obsidian integration |
+| **session-lifecycle** | Prep → Play → Wrap-up cycle, entity creation from play notes |
+| **campaign-qa** | Validation, contradiction detection, integrity checking |
+
+## Campaign Flow
+
+### Starting a Campaign
+
+1. **Scaffold the vault** — `/gm-apprentice:campaign-organizer`
+   Create the campaign folder structure, world overview,
+   initial factions, and key locations.
+
+2. **Session 0 / Table prep** — `/gm-apprentice:ttrpg-expert`
+   Help players create characters, teach the system, establish
+   safety tools, build party cohesion. File new PCs with
+   campaign-organizer.
+
+### Each Session Cycle
+
+3. **Session prep** — `/gm-apprentice:ttrpg-expert`
+   Use session-planner.md for the full 7-step workflow:
+   PC Roster Review → Arc Check → Touchpoints → Scenes →
+   Connection Audit → Spotlight Forecast → Canon Grounding.
+   Generate NPCs, encounters, handouts as needed.
+
+4. **Pre-session validation** — `/gm-apprentice:campaign-qa`
+   Run a continuity check to catch contradictions before
+   they reach the table.
+
+5. **Active play** — Both skills available:
+   - `/gm-apprentice:ttrpg-expert` for quick rules lookups,
+     stat blocks, improv NPCs, fail-forward guidance
+   - `/gm-apprentice:session-lifecycle` (Play mode) for
+     table dynamics and note-taking
+
+6. **Post-session wrap-up** — `/gm-apprentice:session-lifecycle`
+   Process play notes, capture what actually happened,
+   identify new entities (NPCs, locations, items) created
+   during play.
+
+7. **File new entities** — `/gm-apprentice:campaign-organizer`
+   Organise newly created NPCs, locations, items, and
+   factions into the vault with proper linking.
+
+8. **Post-session validation** — `/gm-apprentice:campaign-qa`
+   Check for contradictions introduced by improvisation.
+   Verify thread states and flag stale plot hooks.
+
+### Between Sessions
+
+9. **Advance the world** — `/gm-apprentice:ttrpg-expert`
+   Update faction states, advance clocks, surface
+   consequences from player actions. Prep the next session
+   starting from step 3.
+
+## Common Handoff Patterns
+
+**"I just created an NPC"**
+→ ttrpg-expert generated it → campaign-organizer files it
+
+**"Session prep is done"**
+→ ttrpg-expert planned it → campaign-qa validates →
+  session-lifecycle enters Prep mode
+
+**"Session just ended"**
+→ session-lifecycle wraps up → campaign-organizer files
+  new entities → campaign-qa checks for contradictions
+
+**"I need to check continuity"**
+→ For a full audit: campaign-qa
+→ For a quick thread/canon check: ttrpg-expert
+  (continuity-engine.md)
+
+**"I need content for my campaign"**
+→ ttrpg-expert generates → campaign-organizer files
+
+**"I want to review my whole campaign"**
+→ campaign-qa runs a full audit across all categories

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -17,16 +17,21 @@ flag it rather than inventing content.
 
 ## Companion Skills
 
-- **ttrpg-expert** — Content creation (NPCs, scenes, stat blocks,
-  handouts). Also has authoritative schema definitions: read its
-  `entity-types.md`, `relationship-patterns.md`, and
-  `canon-management.md` for canonical type definitions.
-- **session-lifecycle** — Prep → Play → Wrap-up cycle. Suggest
-  after organizing session-related content.
-- **campaign-qa** — Canon/timeline/graph validation. Suggest after
-  major Organize or Weave passes.
-- **narrative-tracker** — Foreshadowing, discovery state, plot
-  threads. Suggest after session wrap-up processing.
+- **ttrpg-expert** — Content creation (NPCs, scenes, stat
+  blocks, handouts). Has authoritative schema definitions:
+  read its `entity-types.md`, `relationship-patterns.md`,
+  and `canon-management.md` for canonical type definitions.
+  Also has per-system topic files (creatures, spells,
+  factions, equipment) for quick reference and system-
+  specific routing via Quick Commands.
+
+- **session-lifecycle** — Prep → Play → Wrap-up cycle.
+  Suggest after organizing session-related content.
+
+- **campaign-qa** — Canon/timeline/graph validation. Suggest
+  after major Organize or Weave passes. For thread and
+  foreshadowing tracking, ttrpg-expert's continuity-engine.md
+  handles the narrative state.
 
 ## Environment Detection
 

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -15,22 +15,25 @@ decides what to do.
 
 ## Companion Skills
 
-- **ttrpg-expert** — Content creation and deep continuity
-  analysis. When a QA finding requires new content (rewriting
-  an NPC profile, generating a missing clue), hand off to
-  ttrpg-expert. Its `continuity-engine.md` defines the
-  detection categories this skill operationalises.
-- **campaign-organizer** — Vault structure and entity management.
-  When findings involve structural graph issues (orphans,
-  missing relationships), campaign-organizer's Validate mode
-  handles the repair. This skill detects; campaign-organizer
-  restructures.
-- **session-lifecycle** — Session prep and wrap-up. Suggest a
-  QA pass after wrap-up produces changes, or before prep to
-  catch stale data.
-- **narrative-tracker** — Thread and foreshadowing tracking.
-  The clue redundancy check overlaps with narrative-tracker's
-  domain; hand off thread-level findings there.
+- **ttrpg-expert** — Content creation and continuity
+  analysis. When a QA finding requires new content
+  (rewriting an NPC profile, generating a missing clue),
+  hand off to ttrpg-expert. Its `continuity-engine.md`
+  defines the detection categories this skill
+  operationalises. It also handles thread and foreshadowing
+  tracking (Chekhov Protocol for stale threads, Canon
+  Grounding for fact verification). Has per-system topic
+  files for rules and stat lookups.
+
+- **campaign-organizer** — Vault structure and entity
+  management. When findings involve structural graph issues
+  (orphans, missing relationships), campaign-organizer's
+  Validate mode handles the repair. This skill detects;
+  campaign-organizer restructures.
+
+- **session-lifecycle** — Session prep and wrap-up. Suggest
+  a QA pass after wrap-up produces changes, or before prep
+  to catch stale data.
 
 ## Vault Integration
 

--- a/skills/campaign-qa/references/report-template.md
+++ b/skills/campaign-qa/references/report-template.md
@@ -70,7 +70,7 @@ appropriate:]
 
 - If new content is needed: suggest ttrpg-expert
 - If vault structure needs work: suggest campaign-organizer
-- If threads need tracking: suggest narrative-tracker
+- If threads need tracking: suggest ttrpg-expert (continuity-engine.md)
 - If session prep should incorporate fixes: suggest
   session-lifecycle
 

--- a/skills/session-lifecycle/SKILL.md
+++ b/skills/session-lifecycle/SKILL.md
@@ -28,18 +28,25 @@ of a living campaign. This skill manages each stage.
 
 ## Companion Skills
 
-- **ttrpg-expert** — Content generation (scenes, NPCs, stat
-  blocks). When prep reveals a gap that needs new content, hand
-  off to ttrpg-expert. Its session-planner.md has the full PC
-  Roster Review and Arc Stage workflows for deep prep.
-- **campaign-organizer** — Vault structure and entity management.
-  When wrap-up produces new entities or scenes, hand off to
-  campaign-organizer for filing and linking. Its Dissect mode
-  extracts entities from large documents.
-- **campaign-qa** — Validation. After wrap-up or reconciliation
-  produces changes, suggest a QA pass to catch contradictions.
-- **narrative-tracker** — Thread and foreshadowing tracking. After
-  wrap-up, suggest a narrative pass to update thread states.
+- **ttrpg-expert** — Content generation and rules reference.
+  When prep reveals a gap that needs new content (scenes,
+  NPCs, stat blocks), hand off to ttrpg-expert. It has
+  per-system topic files for quick lookups (creatures,
+  spells, factions, equipment) and frameworks for session
+  planning (session-planner.md), NPC generation
+  (npc-generation.md), and continuity checking
+  (continuity-engine.md with Chekhov Protocol for stale
+  threads and Canon Grounding for fact verification).
+
+- **campaign-organizer** — Vault structure and entity
+  management. When wrap-up produces new entities or scenes,
+  hand off to campaign-organizer for filing and linking.
+  Its Dissect mode extracts entities from large documents.
+
+- **campaign-qa** — Validation. After wrap-up or
+  reconciliation produces changes, suggest a QA pass to
+  catch contradictions. For thread and foreshadowing state,
+  ttrpg-expert's continuity-engine.md handles tracking.
 
 ## Vault Integration
 

--- a/skills/ttrpg-expert/SKILL.md
+++ b/skills/ttrpg-expert/SKILL.md
@@ -194,6 +194,27 @@ Many requests combine modes. "Generate an NPC and check they
 don't conflict with existing characters" uses Generation
 then Continuity.
 
+## Companion Skills
+
+- **campaign-organizer** — Vault structure and entity filing.
+  After generating NPCs, locations, factions, or items,
+  suggest filing them in the vault with campaign-organizer.
+  After character creation, suggest organizing PC files.
+  Campaign-organizer handles structure; this skill handles
+  content.
+
+- **session-lifecycle** — Prep → Play → Wrap-up cycle.
+  After session planning is complete, suggest transitioning
+  to session-lifecycle Prep mode for the full session cycle.
+  After a session ends, suggest session-lifecycle Wrap-up
+  for processing play notes and capturing new entities.
+
+- **campaign-qa** — Validation and contradiction detection.
+  After session prep (especially after Canon Grounding in
+  Step 7), suggest a campaign-qa validation pass. After
+  major content generation, suggest a QA check to catch
+  contradictions before they reach the table.
+
 ## Knowledge Base
 
 **Routing priority:**

--- a/skills/ttrpg-expert/SKILL.md
+++ b/skills/ttrpg-expert/SKILL.md
@@ -168,6 +168,48 @@ an item"**
 → Read `random-generation.md`. Use the appropriate oracle
   or table system. Interpret results in campaign context.
 
+**"Check my facts"** / **"verify canon"** / **"am I
+contradicting anything?"** / **"ground this in canon"**
+→ Read `session-planner.md` (Step 7: Player Agency Audit &
+  Canon Grounding). Verify all facts trace to source files.
+  Flag any content that can't be grounded in established
+  canon.
+
+**"Check for stale threads"** / **"unresolved plot threads"**
+/ **"what loose ends do I have?"** / **"forgotten plot hooks"**
+→ Read `continuity-engine.md` (Chekhov Protocol section).
+  Identify threads that have been open longer than 3-5
+  sessions without advancement. Suggest: resolve, advance,
+  or deliberately retire each stale thread.
+
+**"Who hasn't had spotlight?"** / **"check PC balance"** /
+**"am I neglecting a player?"** / **"spotlight check"**
+→ Read `session-planner.md` (Step 6: Spotlight Forecast).
+  Review the last 2-3 sessions for per-PC touchpoint
+  distribution. Flag any PC with fewer touchpoints than
+  average and suggest scenes that feature them.
+
+**"Where is my PC in their arc?"** / **"character arc stage"**
+/ **"what's next for this character?"** / **"arc progression"**
+→ Read `session-planner.md` (Five-Stage Arc Model section).
+  Identify which stage the PC is in (Establishment, Testing,
+  Climax, Consequences, Resolution) and suggest what kind
+  of scenes advance them to the next stage.
+
+**"How do I handle a failed roll?"** / **"fail forward"** /
+**"the player failed, now what?"** / **"consequence ideas"**
+→ Read `active-play-management.md` (Fail Forward section).
+  Apply the appropriate pattern: Succeed at Cost, Partial
+  Info, Delayed Consequence, Resource Drain, Complication,
+  or Worse Position. Choose based on the fiction and pacing.
+
+**"Add sandbox time to my scene"** / **"give players room
+to explore"** / **"open interaction"** / **"sandbox phase"**
+→ Read `scene-encounter-patterns.md` (Open Interaction
+  Windows section). Insert a freeform phase into the current
+  scene where PCs can explore, interact, and pursue their
+  own goals before the next structured beat.
+
 
 ## Three Modes of Operation
 


### PR DESCRIPTION
## Summary

- Surface 6 buried GM frameworks as Quick Commands in ttrpg-expert (Canon Grounding, Chekhov Protocol, Spotlight Forecast, Arc Model, Fail Forward, Open Interaction Windows)
- Add Companion Skills section to ttrpg-expert (was the only skill missing one)
- Update companion skill sections in session-lifecycle, campaign-organizer, and campaign-qa to replace non-existent narrative-tracker references with ttrpg-expert continuity-engine.md
- Add Phase 5 topic file details to all companion skill cross-references
- Create `docs/campaign-lifecycle.md` — human-readable reference showing how the four skills work together across a campaign

## Context

Benchmark testing and audit (Phase 5) identified two usability gaps:
- **Discoverability**: Powerful frameworks (Canon Grounding, Chekhov Protocol, Spotlight Forecast) existed but were buried in files — GMs didn't know they were available
- **Orchestration**: ttrpg-expert never suggested handing off to companion skills, and all four skills referenced a narrative-tracker skill that was never built

## Test plan

- Verify no `narrative-tracker` references remain: `grep -rn "narrative-tracker" skills/`
- Verify all 4 skills have Companion Skills sections
- Verify campaign-lifecycle.md exists and covers the full campaign flow