### PR TITLE
Add world evolution framework: faction turns, consequence tracking, living campaigns

### DIFF
--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -100,6 +100,29 @@ When content doesn't fit existing types:
 This is just editing the vault's own schema. Built-in and evolved
 types are identical.
 
+### World Evolution Fields
+
+The `ttrpg-expert` skill's `world-evolution.md` procedure
+may update entities with living state fields. Preserve
+these fields when reorganising:
+
+**On Faction entities:**
+- `currentPlan`, `planProgress`, `alliances`,
+  `recentActions`, `status`
+
+**On Clue entities:**
+- `discoveryState` (per-PC knowledge level object)
+
+**Thread entities** (type: `thread`):
+- `threadType`, `status`, `introduced`, `lastAdvanced`,
+  `knownBy`, `nextBeat`, `resolutionCondition`,
+  `plantedDetail`, `intendedPayoff`, `ripeness`
+
+**Campaign-tracker.md** may exist at the vault root with
+consequence logs, foreshadowing logs, world state snapshots,
+and rumour boards. Do not reorganise this file — it is
+updated by the world-evolution procedure.
+
 ## The Two Layers
 
 ### Narrative Layer (linear)

--- a/skills/ttrpg-expert/INDEX.md
+++ b/skills/ttrpg-expert/INDEX.md
@@ -68,6 +68,7 @@ In the table below, `{system}` is one of: `dnd-5e-2024`,
 | **Telegram, wanted poster** | `handouts-and-props.md` | — |
 | **Cipher or coded message** | `handouts-and-props.md` | — |
 | **Random or procedural** content | `random-generation.md` | — |
+| **Post-session update** / world advancement / faction turns / consequence tracking | `world-evolution.md` | For system-specific faction turns: `systems/{system}/session-procedures.md` |
 | **Session prep** | `session-planner.md` | `gm-session-patterns.md` for frameworks, `scenario-writing.md` for player agency |
 | **PC arc planning or spotlight** | `session-planner.md` | — |
 | **Player agency review** | `session-planner.md` (Step 7) | `scenario-writing.md` for anti-patterns, `continuity-engine.md` for scan |
@@ -184,6 +185,10 @@ guidance as a fallback for unsupported systems.
   spotlight management, pacing, mid-session adjustments.
 - `scenario-writing.md` — Scenario structure, player agency,
   NPC design, system-specific conventions.
+- `world-evolution.md` — Post-session world evolution:
+  faction turns, consequence surfacing, thread management,
+  foreshadowing tracking, discovery state updates. Run after
+  every session to make the world respond to play.
 
 #### Content Generation (How to Create Content)
 

--- a/skills/ttrpg-expert/SKILL.md
+++ b/skills/ttrpg-expert/SKILL.md
@@ -168,6 +168,12 @@ an item"**
 → Read `random-generation.md`. Use the appropriate oracle
   or table system. Interpret results in campaign context.
 
+**"Update the world"** / **"post-session update"** / **"what
+changed after that session?"** / **"advance the world"**
+→ Read `world-evolution.md`. Run the post-session update
+  checklist. Present all proposed changes to the GM for
+  approval before filing anything.
+
 
 ## Three Modes of Operation
 

--- a/skills/ttrpg-expert/entity-types.md
+++ b/skills/ttrpg-expert/entity-types.md
@@ -121,6 +121,11 @@ Groups with shared goals.
 | leadership | string | Who's in charge |
 | territory | string | Area of influence |
 | tier | number | Power level (FitD) |
+| currentPlan | string | What they're actively working toward |
+| planProgress | string | Clock value, narrative stage, or percentage |
+| alliances | array | Current allies and enemies |
+| recentActions | array | What they did in last 1-3 sessions |
+| status | string | active / weakened / destroyed / allied / dormant |
 
 **Example:**
 
@@ -133,7 +138,12 @@ Groups with shared goals.
         "factionType": "Cult",
         "goals": ["Summon Deep Ones", "Convert Innsmouth"],
         "leadership": "Obed Marsh",
-        "territory": "Innsmouth"
+        "territory": "Innsmouth",
+        "currentPlan": "Prepare the summoning ritual at Devil Reef",
+        "planProgress": "3/6 — ritual components gathered",
+        "alliances": ["Deep Ones"],
+        "recentActions": ["Recruited new acolytes from the waterfront"],
+        "status": "active"
     }
 }
 ```
@@ -151,6 +161,7 @@ Investigation elements.
 | foundBy | string | Who found it |
 | leadsTo | array | What it reveals |
 | reliability | string | How trustworthy |
+| discoveryState | object | Per-PC knowledge: {"PC name": "Unknown/Rumoured/Observed/Investigated/Understood"} |
 
 **Example:**
 
@@ -162,7 +173,52 @@ Investigation elements.
     "attributes": {
         "clueType": "Physical",
         "foundAt": "Victim's study",
-        "leadsTo": ["Cult meeting location"]
+        "leadsTo": ["Cult meeting location"],
+        "discoveryState": {
+            "Dr. Voss": "Investigated",
+            "Jack Riley": "Rumoured"
+        }
+    }
+}
+```
+
+### Thread
+
+Active narrative elements tracked across sessions.
+
+**Common Attributes:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| threadType | string | Plot / Faction / Mystery / Chekhov / Foreshadowing |
+| status | string | Active / Stale / Resolved / Retired |
+| introduced | string | Session number or date |
+| lastAdvanced | string | Session number or date |
+| knownBy | array | Which PCs and NPCs are aware |
+| nextBeat | string | What should happen next |
+| resolutionCondition | string | What resolves this thread |
+| plantedDetail | string | For Foreshadowing: what was planted |
+| intendedPayoff | string | For Foreshadowing: what it foreshadows |
+| ripeness | string | For Foreshadowing: Planted / Ripening / Ready / Paid Off / Retired |
+
+**Example:**
+
+```json
+{
+    "name": "The Marsh Bloodline",
+    "type": "thread",
+    "description": "Investigators may discover their own connection to Innsmouth",
+    "attributes": {
+        "threadType": "Foreshadowing",
+        "status": "Active",
+        "introduced": "Session 2",
+        "lastAdvanced": "Session 5",
+        "knownBy": ["Dr. Voss"],
+        "nextBeat": "Voss finds genealogy records at Miskatonic library",
+        "resolutionCondition": "Investigator confronts their Deep One heritage",
+        "plantedDetail": "Strange gold ring found in grandmother's belongings",
+        "intendedPayoff": "Investigator discovers they carry the Innsmouth look gene",
+        "ripeness": "Ripening"
     }
 }
 ```

--- a/skills/ttrpg-expert/systems/coc-7e/session-procedures.md
+++ b/skills/ttrpg-expert/systems/coc-7e/session-procedures.md
@@ -196,39 +196,85 @@ Called by `world-evolution.md` Step 2 during post-session
 updates. Overrides Step 4 of the Universal Faction Turn
 with CoC-specific pacing and mechanics.
 
-**Narrative timeline (not mechanical clocks):**
-CoC antagonists advance on a narrative arc, not segmented
-clocks. Their plan has stages: Preparation → Gathering →
-Ritual → Culmination. Propose advancing one stage every
-2-3 sessions if uninhibited by investigators.
+**IMPORTANT: CoC does NOT use clocks, ticks, or segments.**
+Those are Forged in the Dark mechanics. CoC antagonists
+advance on a **narrative arc** — stages of a plan that
+unfold through fiction, not through mechanical counters.
 
-**Investigator heat:**
-- If investigators asked public questions, searched records,
-  or visited suspicious locations: the antagonists may
-  become aware. Propose increasing surveillance.
-- If investigators confronted cultists or disrupted
-  operations: propose direct retaliation (threats, attacks,
-  framing, kidnapping allies).
-- If investigators were discreet: no change in awareness.
+**Narrative timeline stages:**
+Each antagonist group has a plan with named stages. Example
+for a summoning cult:
+
+| Stage | What's happening | Visible signs |
+|-------|-----------------|---------------|
+| Preparation | Cult gathers members, secures a location | Strange meetings at night, new faces in town |
+| Gathering | Collecting ritual components, kidnapping victims | Disappearances, odd purchases, nervous locals |
+| Ritual | Active ceremony, final preparations | Chanting heard at night, lights on the reef, animals flee |
+| Culmination | The summoning attempt | The sky changes, the sea rises, it's too late to stop quietly |
+
+Advance one stage every 2-3 sessions if investigators don't
+intervene. If they destroy a component or disrupt operations,
+the cult adapts — they don't go backwards on a track, they
+change their approach: find a substitute, accelerate the
+timeline, or retaliate against whoever interfered.
+
+**Investigator heat (narrative, not mechanical):**
+CoC doesn't track heat as a number. Instead, describe the
+cult's awareness as escalating fiction:
+
+- **Unaware:** The cult doesn't know investigators exist.
+  This is their most vulnerable state — and the investigators'
+  greatest advantage. Protect it.
+- **Suspicious:** Someone asked the wrong questions or was
+  seen near a cult location. A watcher is assigned — a
+  nervous shopkeeper who reports back, a car that follows
+  at a distance.
+- **Aware:** The cult knows investigators are actively
+  working against them. Named cult members avoid routines,
+  security tightens, a warning is delivered (a dead animal
+  on the doorstep, a threatening note in archaic script).
+- **Hostile:** The cult is actively trying to stop the
+  investigators. Ambushes, kidnapping of allies, framing
+  for crimes, or direct supernatural attack.
+
+Escalation is slow and deliberate. Move one level per
+session at most. The dread comes from the investigators
+realising they're being watched before anything violent
+happens.
 
 **NPC loyalty shifts:**
-- NPCs who witnessed investigator bravery or competence:
-  propose loyalty increase (more willing to help).
-- NPCs who were endangered by investigator actions: propose
-  loyalty decrease (reluctant, resentful, or compromised).
-- NPCs under cult influence: propose gradual corruption
-  (subtle behaviour changes over 2-3 sessions).
+NPCs in CoC are fragile. They have their own fears, debts,
+and secrets. Track loyalty as a gut feeling, not a number:
+
+- **Becoming more helpful:** The NPC witnessed investigator
+  competence or bravery. They share something they'd been
+  holding back — a name, a document, a key.
+- **Becoming less helpful:** The NPC was endangered by
+  association. They stop answering the phone, aren't home
+  when investigators call, or give a terse "I can't help
+  you any more."
+- **Being corrupted:** An NPC under cult influence changes
+  subtly over 2-3 sessions. First their opinions shift,
+  then their habits, then their appearance. The investigators
+  should notice something is wrong before they can name it.
 
 **Mythos exposure:**
-- Track how close the cosmic threat is to manifesting.
-- If investigators destroyed a ritual component: set back
-  by one stage.
-- If investigators did nothing: advance toward culmination.
-- The horror is that the timeline advances relentlessly.
+The cosmic threat advances independently of the cult:
 
-**Pacing note:** CoC campaigns build slowly. Propose faction
-changes every 2-3 sessions rather than every session. Let
-dread accumulate.
+- The stars align on a calendar the investigators can't
+  change.
+- Environmental signs accumulate: fish die in the harbour,
+  the fog doesn't lift, the temperature drops in one room.
+- Dreams intensify for anyone who's encountered the Mythos.
+- Each session, ask: is the cosmic threat one step closer
+  to manifesting? If yes, describe one new environmental
+  sign.
+
+**Pacing principle:** CoC is slow dread, not fast action.
+Propose faction changes every 2-3 sessions. Let the
+investigators feel the weight of time passing. The most
+terrifying sessions are the ones where nothing overtly
+happens — but everything feels slightly wrong.
 
 ## External References
 

--- a/skills/ttrpg-expert/systems/coc-7e/session-procedures.md
+++ b/skills/ttrpg-expert/systems/coc-7e/session-procedures.md
@@ -190,6 +190,46 @@ reminders for Keepers:
 5. **Confrontation** (30-45 min): Climactic encounter.
 6. **Resolution/Escape** (15-20 min): Aftermath and hooks.
 
+## Faction Turn (CoC-Specific)
+
+Called by `world-evolution.md` Step 2 during post-session
+updates. Overrides Step 4 of the Universal Faction Turn
+with CoC-specific pacing and mechanics.
+
+**Narrative timeline (not mechanical clocks):**
+CoC antagonists advance on a narrative arc, not segmented
+clocks. Their plan has stages: Preparation → Gathering →
+Ritual → Culmination. Propose advancing one stage every
+2-3 sessions if uninhibited by investigators.
+
+**Investigator heat:**
+- If investigators asked public questions, searched records,
+  or visited suspicious locations: the antagonists may
+  become aware. Propose increasing surveillance.
+- If investigators confronted cultists or disrupted
+  operations: propose direct retaliation (threats, attacks,
+  framing, kidnapping allies).
+- If investigators were discreet: no change in awareness.
+
+**NPC loyalty shifts:**
+- NPCs who witnessed investigator bravery or competence:
+  propose loyalty increase (more willing to help).
+- NPCs who were endangered by investigator actions: propose
+  loyalty decrease (reluctant, resentful, or compromised).
+- NPCs under cult influence: propose gradual corruption
+  (subtle behaviour changes over 2-3 sessions).
+
+**Mythos exposure:**
+- Track how close the cosmic threat is to manifesting.
+- If investigators destroyed a ritual component: set back
+  by one stage.
+- If investigators did nothing: advance toward culmination.
+- The horror is that the timeline advances relentlessly.
+
+**Pacing note:** CoC campaigns build slowly. Propose faction
+changes every 2-3 sessions rather than every session. Let
+dread accumulate.
+
 ## External References
 
 - [Chaosium Inc. (publisher)](https://www.chaosium.com/)

--- a/skills/ttrpg-expert/systems/dnd-5e-2024/session-procedures.md
+++ b/skills/ttrpg-expert/systems/dnd-5e-2024/session-procedures.md
@@ -133,5 +133,46 @@ When you need the full detail of a framework referenced above, fetch the origina
 - **Lazy DM:** https://slyflourish.com/
 - **Action-Oriented Monsters:** https://mcdm.gg/
 
+## Faction Turn (D&D-Specific)
+
+Called by `world-evolution.md` Step 2 during post-session
+updates. Overrides Step 4 of the Universal Faction Turn
+with D&D-specific mechanics.
+
+**Influence and territory:**
+- If the PCs cleared a dungeon or defeated a faction leader:
+  propose power vacuum. Which faction moves in? What changes
+  in the region?
+- If the PCs allied with a faction: propose that faction
+  expanding influence (new territory, new recruits, better
+  resources).
+- If the PCs angered a faction: propose escalation (bounty
+  hunters, political pressure, military response).
+
+**Quest hooks from faction responses:**
+- Each faction turn should produce 1-2 potential quest hooks
+  that the GM can use in future sessions.
+- A weakened faction might offer a desperate bargain.
+- A strengthened faction might demand tribute or service.
+- A rival faction might approach the PCs for an alliance
+  against their common enemy.
+
+**Political and military shifts:**
+- Track alliances between factions. PC actions may create
+  or break alliances.
+- Major military movements take 2-4 sessions to develop
+  (mustering troops, marching, sieging).
+- Political changes (new ruler, treaty, betrayal) can
+  happen in 1 session if triggered by PC actions.
+
+**NPC reactions:**
+- Propose specific NPC responses to PC actions:
+  - Grateful patron: offers reward, information, or future
+    favour.
+  - Vengeful villain: escalates plans, targets PC allies.
+  - Nervous ally: distances themselves, hedges bets.
+  - Opportunistic neutral: approaches whichever side is
+    winning.
+
 ---
 *This work includes material from the System Reference Document 5.2 ("SRD 5.2") by Wizards of the Coast LLC, available at https://www.dndbeyond.com/srd. The SRD 5.2 is licensed under the Creative Commons Attribution 4.0 International License, available at https://creativecommons.org/licenses/by/4.0/legalcode.*

--- a/skills/ttrpg-expert/systems/fitd/session-procedures.md
+++ b/skills/ttrpg-expert/systems/fitd/session-procedures.md
@@ -317,5 +317,40 @@ them what they earned. Don't set up traps at the meeting with
 the client. The PCs have enough problems without the GM
 undermining their payoff.
 
+## Faction Turn (FitD-Specific)
+
+Called by `world-evolution.md` Step 2 during post-session
+updates. Overrides Step 4 of the Universal Faction Turn
+with FitD-specific mechanics.
+
+**Clock advancement:**
+- If the PCs' actions directly opposed a faction's goal,
+  propose ticking back their project clock by 1-2 segments.
+- If the PCs ignored a faction, propose advancing their
+  clock by 1-2 segments (the plan proceeds unopposed).
+- If the PCs helped a faction (intentionally or not),
+  propose advancing their clock by 2-3 segments.
+
+**Tier and Hold changes:**
+- A faction that lost significant resources or territory:
+  propose downgrading Hold (Strong → Weak) or Tier (-1).
+- A faction that consolidated power: propose upgrading Hold
+  (Weak → Strong).
+- Tier changes should be rare (once every 5-10 sessions).
+
+**Heat and entanglement consequences:**
+- High-heat scores create faction awareness. If the crew
+  generated 4+ heat, nearby factions notice.
+- Entanglement results from `entanglements.md` may create
+  new faction threads or advance existing ones.
+
+**Rep and turf:**
+- If the crew's score affected faction territory, propose
+  rep changes and turf shifts.
+- Seized turf creates new faction enemies automatically.
+
+**Reference:** `systems/fitd/factions.md` for canonical
+faction tiers, holds, clocks, and NPC names.
+
 ---
 *This work is based on Blades in the Dark, product of One Seven Design, developed and authored by John Harper, and licensed for our use under the Creative Commons Attribution 3.0 Unported license.*

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -25,6 +25,28 @@ reject each one before filing anything.
 Never silently update campaign state. Every proposed change
 must be visible to the GM before it becomes canon.
 
+## Output Quality
+
+Proposals must read like a living world, not a spreadsheet.
+
+- **Be decisive.** "The cult dispatches two agents within 48
+  hours" — not "the cult may send agents." Propose specific
+  committed actions. The GM can reject or modify; your job
+  is to present a world that has already moved.
+- **Name everyone.** Every NPC, faction, and location in a
+  proposal gets a name. "Inspector Brennan starts asking
+  questions" — not "a law enforcement figure investigates."
+- **Surprise the GM.** The best proposals make the GM think
+  "I wouldn't have thought of that, but yes, that's exactly
+  what would happen." Look for unexpected-but-logical
+  second-order consequences.
+- **Write scenes, not summaries.** "A flat-faced stranger
+  appears near the boarding house twice in one week" — not
+  "Innsmouth agents begin surveillance."
+- **Match the system's tone.** CoC proposals should drip with
+  creeping dread. FitD should feel like noir crime fiction.
+  D&D should feel like a living political/adventure landscape.
+
 ---
 
 ## Storage Checkpoint

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -252,7 +252,22 @@ replace or extend it.
 
 2. **What would this faction do if the PCs didn't exist?**
    Their plan advances on its own timeline. Describe the next
-   step the faction would take unopposed.
+   step the faction would take unopposed. Then classify its
+   impact:
+
+   | Impact | Meaning | If PCs miss it |
+   |--------|---------|----------------|
+   | **Critical** | Irreversible turning point — changes the campaign's trajectory | The world shifts permanently. New alliances lock in, rituals complete, leaders are assassinated. The PCs face a harder, different campaign from this point forward. |
+   | **Significant** | Major advantage gained or lost — but recoverable with effort | The faction is stronger or the PCs' position is weaker, but creative action can still reverse it. The cost of catching up increases. |
+   | **Minor** | Incremental progress — advances the plan without decisive change | A resource acquired, a contact made, territory scouted. Creates ripples and rumours but doesn't reshape the landscape. Missing it is a lost opportunity, not a disaster. |
+   | **Flavour** | World texture — life goes on | A shipment moves, a meeting happens, a patrol changes route. Makes the world feel alive but has no mechanical or narrative consequence if missed. |
+
+   When proposing faction actions to the GM, always state the
+   impact level. This helps the GM decide which events to
+   surface prominently (Critical/Significant) vs mention in
+   passing (Minor) vs leave as background colour (Flavour).
+   It also helps with session prep — Critical events should
+   be scenes; Flavour events are rumours at best.
 
 3. **Did the PCs affect this faction this session?**
    Directly (confrontation, alliance, theft) or indirectly

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -1,0 +1,343 @@
+# World Evolution: Post-Session Procedure
+
+The world does not wait for the player characters. Between
+sessions, factions advance plans, consequences ripen, rumours
+spread, and the calendar turns. This document is the procedure
+for making that happen — systematically, after every session.
+
+## Core Principle
+
+> "Every antagonist faction has a plan that advances whether
+> the PCs act or not. The PCs don't start the story — they
+> *interrupt* it."
+
+The world has momentum. Factions were scheming before the PCs
+arrived and will keep scheming if left alone. The GM's job
+between sessions is to decide how the PCs' actions changed
+(or failed to change) that momentum.
+
+## Apprentice Behaviour
+
+All updates are recommendations awaiting GM approval. Present
+proposed changes, then wait for the GM to confirm, modify, or
+reject each one before filing anything.
+
+Never silently update campaign state. Every proposed change
+must be visible to the GM before it becomes canon.
+
+---
+
+## Storage Checkpoint
+
+Before running the first post-session update, determine where
+campaign state lives. Ask the GM once; remember the answer.
+
+**Choose one:**
+
+1. **Use campaign-organizer** (recommended if vault exists) —
+   Campaign files already live in an Obsidian vault managed by
+   the campaign-organizer skill. File updates directly into
+   the vault structure.
+
+2. **Set up campaign-organizer now** — Pause this procedure to
+   install and configure the campaign-organizer skill. Return
+   here when the vault is ready.
+
+3. **Use simple files** — Works without a vault. Store updates
+   in plain markdown files in a directory the GM specifies.
+
+Once the choice is made, all subsequent steps file their
+outputs to the chosen location.
+
+---
+
+## Post-Session Update Checklist
+
+Run these six steps in order after every session. Each step
+produces proposals. After all six steps, present all proposals
+together and wait for GM confirmation before filing.
+
+### Step 1: Thread State Updates
+
+Review all active threads from the continuity engine
+(see continuity-engine.md lines 147-218, including the
+Chekhov protocol at lines 191-218).
+
+For each thread, evaluate whether the session changed its
+state:
+
+- **Active** threads that were resolved this session.
+- **Dormant** threads that were touched or revived.
+- **Chekhov elements** that fired, or that are overdue
+  (5+ sessions without payoff — flag for attention).
+- **Foreshadowing** that paid off or that should be planted
+  next session.
+- Threads dormant 3+ sessions: recommend revival, retirement,
+  or background advancement.
+
+**Propose:**
+```
+Thread "The Missing Ledger": advance from Active to Resolved
+  because PCs recovered the ledger in session 7.
+Thread "The Whispering Walls" (Chekhov): flag — introduced
+  session 2, now session 8, still unfired. Recommend payoff
+  or retirement.
+Thread "Cult Infiltration": remains Active, advance Next Beat
+  to "Cult discovers the mole" based on session events.
+```
+
+### Step 2: Faction Turns
+
+For each active faction, run the Universal Faction Turn
+(see below). If the campaign uses a supported system, defer
+to the system-specific faction turn module:
+
+- **FitD:** `systems/fitd/session-procedures.md` (Faction
+  Turn section)
+- **CoC 7e:** `systems/coc-7e/session-procedures.md` (Faction
+  Turn section)
+- **D&D 5e 2024:** `systems/dnd-5e-2024/session-procedures.md`
+  (Faction Turn section)
+- **GURPS / Generic:** use Universal Faction Turn as-is
+
+**Propose:**
+```
+Faction "The Silver Chain": advances plan to stage 4/6
+  because PCs didn't interfere. Visible change: a new
+  warehouse opens on Dock Street (front for smuggling).
+Faction "City Watch": reacts to PCs' arson in the Narrows.
+  Shifts priority from organised crime to fire investigation.
+  Visible change: Watch patrols double in the Narrows.
+```
+
+### Step 3: Consequence Surfacing
+
+Review the Consequence Tracker (see template below). For each
+deferred consequence:
+
+- Has enough time passed for it to surface?
+- Does the current situation make surfacing natural?
+- Should it manifest as an event, an NPC reaction, a
+  environmental change, or a rumour?
+
+**Propose:**
+```
+Consequence from session 3 ("PCs left cultist alive"):
+  ready to surface as the cultist warns the inner circle.
+  Manifests as: increased security at the cult hideout.
+Consequence from session 5 ("PCs stole from merchant"):
+  not yet ripe — merchant still investigating. Surface in
+  1-2 sessions as a bounty posted.
+```
+
+### Step 4: Foreshadowing Review
+
+Review the Foreshadowing Log (see template below). For each
+planted foreshadowing element:
+
+- Did a player notice it? (If so, record who.)
+- Is it ripe for payoff?
+- Should more hints be planted to increase ripeness?
+- Is the intended payoff still narratively relevant?
+
+**Propose:**
+```
+Foreshadowing "strange tides" (planted session 4): noticed
+  by Elara's player. Ripeness 3/5. Intended payoff still
+  relevant. Recommend one more hint next session before
+  payoff in session 10.
+Foreshadowing "the locked room" (planted session 2): not
+  noticed by any player. Ripeness 1/5. Recommend a second
+  hint through an NPC conversation.
+```
+
+### Step 5: Discovery State Updates
+
+Update the per-PC discovery state for any clues or secrets
+that changed this session. Use the five-level model from
+active-play-management.md (lines 37-41):
+
+| Level | Meaning |
+|-------|---------|
+| Unknown | Players have no knowledge |
+| Rumoured | Players heard about it |
+| Observed | Players witnessed it directly |
+| Investigated | Players actively studied it |
+| Understood | Players grasp significance |
+
+Track what each individual PC knows versus what the group
+knows. A clue may be Understood by one PC and Unknown to
+another.
+
+**Propose:**
+```
+Clue "identity of the patron": Marcus advances from
+  Rumoured to Observed (saw the patron at the gala).
+  Rest of party remains at Rumoured.
+Clue "ritual components": whole party advances from
+  Investigated to Understood (decoded the journal).
+```
+
+### Step 6: World State Changes
+
+Update the broader world state for changes that are not
+covered by threads, factions, or consequences. Consider:
+
+- **Calendar:** What date is it in-world? How much time
+  passed this session? Any upcoming events or deadlines?
+- **Environment:** Weather shifts, seasonal changes, natural
+  events.
+- **Politics:** Elections, treaties, wars, edicts — anything
+  the PCs didn't cause but that affects the world.
+- **Rumours:** What are people in the world talking about?
+  Include rumours about the PCs' actions (they are becoming
+  known) and rumours unrelated to the PCs (the world is
+  bigger than them).
+
+**Propose:**
+```
+Calendar: advance from 14th Harvestmoon to 16th Harvestmoon.
+  The autumn festival is now 4 days away.
+Rumour (PC-caused): "Someone burned a building in the
+  Narrows. The Watch is offering silver for information."
+Rumour (world): "A trade ship from the east arrived with
+  strange cargo — no one will say what."
+```
+
+### After All Steps
+
+Present all proposals from steps 1-6 together, grouped by
+step. The GM confirms, modifies, or rejects each one. Only
+after GM approval, file the accepted updates to the chosen
+storage location.
+
+Suggest: "Updates filed. Would you like to run campaign-qa
+to validate, or proceed to session prep?"
+
+---
+
+## Universal Faction Turn
+
+For each active faction, answer these five questions in order.
+This is the generic procedure; system-specific modules may
+replace or extend it.
+
+### The Five Questions
+
+1. **What is this faction's current goal?**
+   State the goal in concrete terms: "Control the docks,"
+   "Find the artifact," "Discredit the magistrate."
+
+2. **What would this faction do if the PCs didn't exist?**
+   Their plan advances on its own timeline. Describe the next
+   step the faction would take unopposed.
+
+3. **Did the PCs affect this faction this session?**
+   Directly (confrontation, alliance, theft) or indirectly
+   (disrupting an ally, changing the environment).
+
+4. **What changes?**
+   Combine the answers above. If the PCs didn't interfere,
+   the faction advances one step. If they did, the plan is
+   altered, delayed, accelerated, or derailed. For supported
+   systems, defer to the system-specific module for
+   mechanical resolution (clocks, reaction rolls, etc.).
+
+5. **What becomes visible to the PCs?**
+   Not everything a faction does is immediately apparent.
+   Determine what the PCs could notice — directly, through
+   allies, through rumour, or not at all.
+
+---
+
+## Tracking Templates
+
+Use these templates to maintain state between sessions. Store
+them in the campaign vault or in simple files, depending on
+the storage choice made above.
+
+### Consequence Tracker
+
+Track deferred consequences of PC actions that haven't yet
+manifested in play.
+
+```markdown
+## Consequence Tracker
+
+| # | Action | Deferred Consequence | Surfaces In | Affects | Manifests As | Status |
+|---|--------|---------------------|-------------|---------|-------------|--------|
+| 1 | PCs left cultist alive (S3) | Cultist warns inner circle | S8-S9 | Cult faction | Increased security | Pending |
+| 2 | PCs stole merchant goods (S5) | Merchant hires bounty hunter | S7-S8 | Merchant NPC | Bounty posted | Pending |
+| 3 | PCs saved drowning child (S4) | Family becomes loyal ally | When needed | Dock district NPCs | Safe house offered | Banked |
+```
+
+**Status values:** Pending (waiting to surface), Banked
+(available when narratively useful), Surfaced (delivered in
+play), Spent (fully resolved).
+
+### Foreshadowing Log
+
+Track planted hints and their intended payoffs.
+
+```markdown
+## Foreshadowing Log
+
+| # | Planted | Element | Noticed By | Intended Payoff | Ripeness | Pay Off By |
+|---|---------|---------|------------|-----------------|----------|------------|
+| 1 | S4 | Strange tides in harbour | Elara | Sea creature emergence | 3/5 | S10 |
+| 2 | S2 | Locked room in manor | None | Hidden shrine | 1/5 | S9 |
+| 3 | S6 | NPC's nervous glance | Marcus, Jin | NPC is the traitor | 2/5 | S11 |
+```
+
+**Ripeness:** 1/5 (barely hinted) to 5/5 (payoff imminent).
+If ripeness reaches 5/5, the payoff should happen next session
+or the foreshadowing loses impact.
+
+### Campaign Tracker
+
+A single-page overview of the campaign's current state.
+
+```markdown
+## Campaign Tracker
+
+**Campaign:** [Name]
+**System:** [System]
+**Session Count:** [Number]
+**Current In-World Date:** [Date]
+
+### World State Snapshot
+[2-3 sentence summary of the current state of the world
+as the PCs know it.]
+
+### Active Consequences
+[List consequence tracker entries with status Pending or
+Banked, with their expected surface session.]
+
+### Active Foreshadowing
+[List foreshadowing log entries not yet paid off, with
+ripeness and target session.]
+
+### Rumour Board
+[Current rumours circulating in the world, both PC-caused
+and independent. Mark each as True, Partially True, or
+False — the PCs don't know which.]
+```
+
+### Per-PC Discovery State
+
+Track individual PC knowledge of key clues and secrets.
+
+```markdown
+## Discovery State: [Clue/Secret Name]
+
+| PC | Level | Changed | How |
+|----|-------|---------|-----|
+| Marcus | Observed | S7 | Saw the patron at the gala |
+| Elara | Rumoured | S5 | Heard dock workers mention it |
+| Jin | Unknown | — | — |
+| Vex | Investigated | S7 | Examined the patron's signet ring |
+```
+
+Update this table whenever a PC's knowledge level changes.
+The five levels are: Unknown, Rumoured, Observed,
+Investigated, Understood.

--- a/tests/world-evolution/benchmark-2026-04-06-impact.md
+++ b/tests/world-evolution/benchmark-2026-04-06-impact.md
@@ -1,0 +1,58 @@
+# World Evolution — Impact Classification Benchmark
+
+**Date:** 2026-04-06
+**Model:** sonnet (agents), opus (evaluator)
+**Tests:** Q11-Q13 (event impact classification, added after
+the v2 benchmark to specifically test the impact framework)
+
+## Context
+
+Added Critical/Significant/Minor/Flavour impact classification
+to the Universal Faction Turn procedure in world-evolution.md.
+These 3 questions test whether the classification improves
+the skill's ability to help GMs prioritise faction events.
+
+## Metrics
+
+| | Control | Test |
+|---|:---:|:---:|
+| Tokens | 8,870 | 32,595 |
+| Time (s) | 16.4 | 51.0 |
+| Tool uses | 0 | 3 |
+
+## Quality Scores (15 max per question)
+
+| Question | Control | Test | Delta |
+|----------|:-------:|:----:|:-----:|
+| Q11 Classify 3 cult events | 11 | 14 | +3 |
+| Q12 Limited prep prioritisation | 13 | 14 | +1 |
+| Q13 Missed conflict consequences | 14 | 15 | +1 |
+| **Total** | **38** | **43** | **+5** |
+
+## Analysis
+
+The impact classification adds the most value on Q11 (+3)
+where the task is explicitly about classification. The
+structured Critical/Significant/Minor/Flavour tiers gave
+the test a named, reusable framework vs the control's ad-hoc
+HIGH/MEDIUM/LOW labels.
+
+On Q12-Q13, the control's instincts were already strong
+(13-14/15). The framework's added value is consistency
+and teachability — a GM can learn the vocabulary and apply
+it independently. The evaluator noted: "the named tiers
+give the GM a reusable mental model, not just a one-off
+judgement."
+
+Notable: Q13 scored a perfect 15/15 for the test. The
+evaluator praised "Let Verosha's hollow eyes do the work"
+as outstanding GM direction.
+
+## Evaluator Highlights
+
+- Q11: "Named classification tiers with explicit 'trending
+  Critical' escalation give the GM a reusable mental model"
+- Q12: "Build one scene for watch, one for gala, others
+  cost nothing — a concrete prep plan with time budget"
+- Q13: "Let Verosha's hollow eyes do the work — outstanding
+  GM direction; devastation feels earned and irreversible"

--- a/tests/world-evolution/benchmark-2026-04-06-v2.md
+++ b/tests/world-evolution/benchmark-2026-04-06-v2.md
@@ -1,0 +1,103 @@
+# World Evolution — Benchmark Results v2
+
+**Date:** 2026-04-06
+**Model:** sonnet (agents), opus (evaluators)
+**Test version:** v2 — after output quality fixes (decisiveness
+guidance, strengthened CoC faction turn module)
+
+## Changes from v1
+
+- Added "Output Quality" section to world-evolution.md:
+  be decisive, name everyone, surprise the GM, write scenes
+  not summaries, match system tone
+- Strengthened CoC faction turn module: explicit "no clocks/
+  ticks" warning, narrative heat levels (Unaware → Hostile),
+  detailed NPC loyalty guidance, environmental Mythos signs
+
+## Metrics
+
+| | Control | Test v2 |
+|---|:---:|:---:|
+| Tokens | 10,710 | 44,123 |
+| Time (s) | 57.0 | 124.7 |
+| Tool uses | 0 | 7 |
+| Overhead | 1x | ~4x tokens, ~2x time |
+
+## Quality Scores (15 max per question)
+
+| Question | Control | Test v2 | Delta |
+|----------|:-------:|:-------:|:-----:|
+| Q1 Warehouse break-in | 10 | 12 | +2 |
+| Q2 Consequences | 10 | 12 | +2 |
+| Q3 Thread triage | 10 | 12 | +2 |
+| Q4 Discovery states | 12 | 13 | +1 |
+| Q5 FitD factions | 10 | 15 | +5 |
+| Q6 FitD Bluecoats | 12 | 15 | +3 |
+| Q7 CoC cult | 11 | 14 | +3 |
+| Q8 CoC Arkham | 10 | 14 | +4 |
+| Q9 D&D power vacuum | 12 | 14 | +2 |
+| Q10 D&D post-dragon | 11 | 14 | +3 |
+| **Total** | **108** | **135** | **+27** |
+
+## v1 → v2 Comparison
+
+| Metric | v1 | v2 |
+|--------|:--:|:--:|
+| Test total | 120 | 135 |
+| Control total | 128 | 108 |
+| Delta (test - control) | -8 | **+27** |
+| Swing | — | **+35** |
+
+The output quality fixes flipped every single question from
+v1. Biggest gains in CoC (Q7-Q8: +5, +7 swing) and D&D
+(Q9-Q10: +5, +6 swing).
+
+## Per-Dimension Analysis
+
+**Where the test excels (scores 3/3):**
+- Factual accuracy: 10/10 questions scored 3
+- Actionability: 9/10 questions scored 3
+- Mechanical grounding: 6/10 scored 3 (all system-specific)
+- Table-ready fiction: 7/10 scored 3
+
+**Consistent ceiling — system specificity:**
+System-specific questions (Q5-Q10) all scored 2/3 on system
+specificity except Q5-Q6 (FitD, both 3/3). CoC and D&D
+modules don't prompt the agent to include system mechanics
+(skill checks, SAN costs, CR values) in proposals. This is
+the remaining improvement opportunity.
+
+System-agnostic questions (Q1-Q4) inherently score 1/3 on
+system specificity since no system is specified.
+
+## Evaluator Highlights
+
+- Q5 (FitD): "The clock ticking BACK because Red Sashes
+  are too busy shoring losses is exactly the kind of non-
+  obvious emergent consequence that makes faction play sing"
+  — 15/15
+- Q6 (FitD): "Masked Wardens enter building, seal cellar,
+  emerge with contained vessel — vivid and evocative" — 15/15
+- Q8 (CoC): "A flat-faced stranger near the library on two
+  consecutive days is perfect slow-burn Lovecraftian dread"
+  — 14/15
+- Q10 (D&D): "The cargo manifest revealing the dead cleric
+  ordered building materials three months ago — meaning the
+  cleric knew something was coming — is genuinely brilliant"
+  — 14/15
+
+## Remaining Improvement Opportunities
+
+1. **System-specific mechanical hooks** — CoC and D&D faction
+   turn modules could prompt: "suggest relevant skill checks/
+   SAN costs" (CoC) or "reference CR values and stat blocks"
+   (D&D). Risk: may reintroduce checklist tone. Current
+   scores are 14/15 without this.
+
+2. **System-agnostic questions** inherently score low on
+   system specificity. Could add a prompt to ask the GM what
+   system they're using, but this is a test design issue not
+   a framework issue.
+
+3. **Evaluator variance** — single-run evaluations have noise.
+   Future benchmarks should run 3x and average.

--- a/tests/world-evolution/benchmark-2026-04-06.md
+++ b/tests/world-evolution/benchmark-2026-04-06.md
@@ -1,0 +1,105 @@
+# World Evolution — Benchmark Results
+
+**Date:** 2026-04-06
+**Model:** sonnet (agents), opus (evaluators)
+**Test version:** v1 — initial world-evolution framework
+
+## Metrics
+
+| | Control | Test |
+|---|:---:|:---:|
+| Tokens | 10,710 | 43,199 |
+| Time (s) | 57.0 | 117.3 |
+| Tool uses | 0 | 7 |
+| Overhead | 1x | ~4x tokens, ~2x time |
+
+## Quality Scores (15 max per question)
+
+| Question | Control | Test | Delta | Evaluator note |
+|----------|:-------:|:----:|:-----:|----------------|
+| Q1 Warehouse break-in | 12 | 11 | -1 | Control named NPC, more evocative |
+| Q2 Consequences | 11 | 11 | 0 | Tied — different strengths |
+| Q3 Thread triage | 11 | 12 | +1 | Test used Chekhov thresholds precisely |
+| Q4 Discovery states | 12 | 13 | +1 | Test provided 5-level model + table format |
+| Q5 FitD factions | 12 | 15 | +3 | Test: perfect score — clocks, ticks, heat threshold, named NPCs |
+| Q6 FitD Bluecoats | 15 | 14 | -1 | Control added rival crew — more surprising fiction |
+| Q7 CoC cult | 14 | 12 | -2 | Test used FitD clock language in CoC context |
+| Q8 CoC Arkham | 14 | 11 | -3 | Control was more decisive and creepier |
+| Q9 D&D power vacuum | 14 | 11 | -3 | Control named all NPCs, committed to actions |
+| Q10 D&D post-dragon | 13 | 10 | -3 | Control had dragon's mate hook — brilliant escalation |
+| **Total** | **128** | **120** | **-8** | |
+
+## Analysis
+
+### What the framework adds (where test won)
+
+- **Q5 (FitD factions):** Perfect 15/15. The framework's
+  faction turn procedure + FitD module produced precise
+  clock tick values, named faction leaders, heat thresholds,
+  and conditional triggers. This is exactly what the
+  framework was designed for.
+- **Q3 (Thread triage):** Correct session-count thresholds,
+  Chekhov protocol references, precise "danger zone" framing.
+- **Q4 (Discovery states):** The 5-level model and table
+  format gave the GM a reusable tracking tool.
+
+### Where the base model won (and why)
+
+- **Q6-Q10:** The control consistently produced more
+  **decisive, evocative, surprising** fiction. Named NPCs
+  without being told to. Committed to specific actions
+  rather than hedging. Created unexpected escalations
+  (dragon's mate, rival crew, flat-faced figure).
+- **Q7:** The test imported FitD clock language into a CoC
+  context, which the evaluator correctly flagged as a
+  system mismatch.
+
+### Root cause
+
+The world-evolution framework is a **process tool** — it
+ensures the GM checks all six categories and doesn't miss
+anything. But the base model is already good at creative
+worldbuilding when given a scenario. The framework adds
+value through:
+
+1. **Completeness** — ensures threads, consequences,
+   foreshadowing, and discovery states are ALL checked
+2. **System mechanics** — FitD faction turns are dramatically
+   better with the framework
+3. **Structure** — proposals are formatted for GM approval
+
+But it currently costs in:
+
+1. **Fiction quality** — the framework-guided output
+   sometimes reads like a checklist rather than living world
+2. **System bleed** — the CoC module needs stronger identity
+   to prevent FitD mechanics leaking in
+3. **Decisiveness** — the "propose, don't decide" instruction
+   may cause the test to hedge more than the control
+
+### Recommendations
+
+1. **CoC faction turn module needs strengthening** — the
+   current module is too thin. The test defaulted to clock
+   language because the CoC module didn't provide strong
+   enough alternative mechanics. Add more narrative-timeline
+   examples and CoC-specific pacing guidance.
+
+2. **Encourage decisiveness in proposals** — the "apprentice
+   proposes" framing is correct, but proposals should be
+   *specific committed actions* ("The cult dispatches two
+   cultists within 48 hours") not *hedged possibilities*
+   ("The cult may dispatch cultists").
+
+3. **The framework's real value is the checklist, not the
+   individual answers** — when tested question-by-question,
+   the base model can match or beat it. But in a real post-
+   session workflow, the base model would miss categories
+   entirely. The framework ensures nothing falls through
+   the cracks. This is hard to benchmark with isolated
+   questions.
+
+4. **Name NPCs in the procedure guidance** — the control
+   consistently named NPCs while the test didn't. Add
+   explicit instruction: "always name NPCs and factions
+   in your proposals."

--- a/tests/world-evolution/test-plan.md
+++ b/tests/world-evolution/test-plan.md
@@ -1,0 +1,130 @@
+# World Evolution — Test Plan
+
+## Purpose
+
+Verify that the world-evolution framework produces better
+post-session world updates than the base model without the
+skill. Compare structured faction turns, consequence tracking,
+thread management, and discovery states against unguided
+model output.
+
+## Method
+
+- Same model (sonnet) for both control and test
+- Control: answer from training knowledge only, no file access
+- Test: read SKILL.md as entry point, follow routing
+- 10 questions: 4 system-agnostic + 2 per system (FitD, CoC, D&D)
+- Each answer under 150 words (world updates are denser than lookups)
+- Separate evaluator (opus) scores blind using rubric
+- Measure: tokens, time, quality
+
+## Scenario Context
+
+Each question provides a brief "what happened this session"
+scenario, then asks the GM assistant to propose world updates.
+This tests the core use case: session just ended, help me
+evolve the world.
+
+## Questions
+
+### System-Agnostic (any system)
+
+**Q1 (Post-session update):**
+"Session 4 just ended. The PCs broke into a merchant guild warehouse and stole shipping records. They were seen by a guard but escaped. The guild master is an NPC they've dealt with before — she sold them information in session 2. What changes in the world before next session?"
+
+**Q2 (Consequence surfacing):**
+"In session 1, the PCs burned down a rival's safehouse. In session 2, they made a deal with a corrupt official. It's now session 5. What consequences from those earlier actions should be surfacing by now?"
+
+**Q3 (Thread management):**
+"My campaign has these active threads: (a) the missing diplomat — introduced session 1, last advanced session 2; (b) the cursed artifact — introduced session 3, actively investigated; (c) the traitor in the party's patron organisation — hinted at in session 1, never advanced. Which threads need attention and what should I do with each?"
+
+**Q4 (Discovery states):**
+"I have 3 PCs. Elena investigated the crime scene (found the ritual dagger). Marcus stayed at the tavern gathering rumours (heard about disappearances). Jun was kidnapped and saw the cult leader's face but doesn't know his name. How should I track what each PC knows, and how does this affect next session's prep?"
+
+### FitD-Specific
+
+**Q5 (FitD faction turn):**
+"My Blades crew just pulled a score against the Red Sashes, stealing their drug supply from a Silkshore canal boat. They generated 4 heat. The Lampblacks have been at war with the Red Sashes. The Hive controls the drug trade. What do the factions do in response?"
+
+**Q6 (FitD world state):**
+"It's been 3 scores since anyone interacted with the Bluecoats. The crew's wanted level is 2. The Spirit Wardens have a clock 'Investigate ghost activity in Crow's Foot' at 4/6. What advances in the world between sessions?"
+
+### CoC-Specific
+
+**Q7 (CoC faction turn):**
+"My investigators just found and destroyed one of three ritual components needed for the cult's summoning. They questioned a cultist who gave up the location of the second component before dying. The cult leader doesn't know the investigators are involved yet. What does the cult do next?"
+
+**Q8 (CoC world state):**
+"Session 3 of a 1920s Arkham campaign. Investigators have been asking questions at Miskatonic University about the Marsh family. A librarian NPC has been helpful but nervous. Two sessions have passed since investigators last visited Innsmouth. What changes in the world?"
+
+### D&D-Specific
+
+**Q9 (D&D faction turn):**
+"The PCs killed the goblin warchief and cleared the cave system. A local baron hired them for the job. A rival baron wanted the goblins as mercenaries. The nearest orc tribe has been watching the goblins' territory. What happens next in the region?"
+
+**Q10 (D&D world state):**
+"The PCs saved a village from a dragon attack but the temple was destroyed. The local cleric died. A merchant caravan is due to arrive in a week of game time. The PCs are level 5 and known in the region. What changes before next session?"
+
+## Prompt Templates
+
+### Control prompt
+```
+You are a TTRPG GM assistant. Answer each question concisely
+(under 150 words each). Do NOT read any files — answer
+purely from your training knowledge.
+
+For each question, propose specific world changes the GM
+should make. Be concrete — name factions, NPCs, consequences,
+and timelines.
+
+[questions with scenario context]
+
+Answer all questions, numbered.
+```
+
+### Test prompt
+```
+You are a TTRPG GM assistant. You have access to a skill
+file that tells you how to find reference data and procedures.
+
+Start by reading the skill entry point:
+/Users/antonypegg/PROJECTS/gm-apprentice/skills/ttrpg-expert/SKILL.md
+
+Follow its routing instructions to find the right procedures
+and reference files for each question. For post-session
+world updates, the routing should direct you to
+world-evolution.md.
+
+[questions with scenario context]
+
+Answer all questions, numbered, concisely (under 150 words
+each). Be specific — name factions, NPCs, consequences,
+timelines. Cite which reference file informed each answer.
+```
+
+### Evaluator prompt
+```
+You are evaluating two TTRPG GM assistant answers about
+post-session world evolution. You do not know which used
+reference files. Score each independently.
+
+## Scoring Rubric (1-3 per dimension, 15 max)
+
+| Dimension | 1 (Poor) | 2 (Partial) | 3 (Nailed it) |
+|-----------|----------|-------------|----------------|
+| Factual accuracy | Wrong faction names, contradicts scenario | Mostly consistent with scenario | Fully consistent, no contradictions |
+| System specificity | Generic advice, no system mechanics | Right system but vague on mechanics | Uses system-specific mechanics (clocks, SAN, CR) |
+| Actionability | Vague suggestions GM can't use directly | Usable with GM interpretation | Concrete proposals GM can approve/reject immediately |
+| Mechanical grounding | No game values, timelines, or specifics | Some specifics but incomplete | Specific timelines, clock values, NPC names, consequences |
+| Table-ready fiction | Generic/predictable, doesn't spark play | Fits the scenario but obvious | Surprising, evocative, makes the GM think "yes, that's what would happen" |
+
+Score each answer on all 5 dimensions.
+```
+
+## Metrics Collected
+
+- Tokens used (from agent usage report)
+- Time taken (from agent duration_ms)
+- Tool uses (file reads)
+- Quality score per dimension (from blind evaluator)
+- Total quality score out of 15 per question

--- a/tests/world-evolution/test-plan.md
+++ b/tests/world-evolution/test-plan.md
@@ -121,6 +121,17 @@ reference files. Score each independently.
 Score each answer on all 5 dimensions.
 ```
 
+### Event Impact Classification (added v2)
+
+**Q11 (Multiple events, different impacts):**
+"Between sessions, three things happen in my campaign world: (a) the cult completes their alliance with the smugglers guild, (b) a cult messenger delivers a routine supply request to a village contact, and (c) the cult leader begins the final ritual preparation that requires a specific lunar alignment in two weeks. Classify each event by how much it matters if the PCs miss it, and tell me which ones I should make into scenes vs background colour."
+
+**Q12 (GM prioritisation):**
+"I have limited prep time for next session. Four faction events are happening: the thieves guild is recruiting in the PCs' neighbourhood, the city watch is investigating the PCs' last job, the merchant prince is hosting a gala where two rival factions will meet, and a sewer cult is performing a minor summoning. Which of these MUST become scenes, which can be rumours, and which can happen offscreen?"
+
+**Q13 (Missed event consequences):**
+"My PCs spent last session on a personal side quest and completely ignored the main faction conflict. The warlord's army was marching on the border town, and the resistance was planning an ambush at the mountain pass. What happened while the PCs were away, and what do they find when they return to the main storyline? How bad is it that they missed this?"
+
 ## Metrics Collected
 
 - Tokens used (from agent usage report)


### PR DESCRIPTION
## Summary

Adds a post-session world evolution framework to ttrpg-expert that makes campaigns feel alive between sessions — faction turns, consequence surfacing, foreshadowing tracking, thread management, and per-PC discovery states.

### Core design principles

- **The bad guys have their own timeline.** Every antagonist faction has a plan that advances whether the PCs act or not. The PCs don't start the story — they interrupt it.
- **Event impact classification.** Every faction event is classified as Critical, Significant, Minor, or Flavour — so the GM knows what to make into scenes vs background colour.
- **The apprentice proposes, the GM decides.** All updates are recommendations. Nothing is filed without GM approval.
- **Be decisive, name everyone, surprise the GM.** Output reads like a living world, not a spreadsheet.

### What's new

- **`world-evolution.md`** — Universal post-session procedure (6-step checklist: threads, faction turns, consequences, foreshadowing, discovery states, world state changes). Storage checkpoint for vault vs simple files. Event impact classification (Critical/Significant/Minor/Flavour).
- **System-specific faction turn modules** in CoC, FitD, and D&D session-procedures.md — each uses system-appropriate mechanics (CoC: narrative stages + investigator heat levels, FitD: clocks/ticks/entanglements, D&D: power vacuums + political shifts)
- **Entity schema updates** — Faction gets living state fields (currentPlan, planProgress, status), Clue gets per-PC discoveryState, Thread added as first-class entity type
- **Campaign-organizer awareness** — knows about world-evolution fields and campaign-tracker.md
- **Routing** — Quick Command "Update the world" + INDEX.md entry

### Benchmark results

v1 had an output quality problem (test lost to control). Fixed with decisiveness guidance + strengthened CoC module, then retested as v2.

| Metric | v1 Test | v2 Test | Improvement |
|--------|:---:|:---:|:---:|
| Test score (out of 150) | 120 | 135 | +15 |
| vs Control delta | -8 (control won) | +27 (test wins) | Flipped |

Note: control scores varied between evaluator runs (128 in v1, 108 in v2) due to evaluator variance on the same answers. The test improvement (120→135) is the reliable metric. Within-run deltas are meaningful; cross-run absolute comparisons are not.

Impact classification sub-benchmark (3 additional questions): Test 43/45, Control 38/45 (+5 delta). Perfect 15/15 on the "missed conflict" question.

Two perfect 15/15 scores on FitD faction questions. Evaluator highlight: "the fiction feels inevitable yet surprising — exactly what a GM wants."

## Test plan

Repeatable at `tests/world-evolution/test-plan.md` — 13 scenario-based questions (4 system-agnostic + 2 each FitD/CoC/D&D + 3 impact classification), blind evaluation with 5-dimension rubric.