### PR TITLE
Add temporal fields to entity schema

### DIFF
--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -105,6 +105,20 @@ When content doesn't fit existing types:
 This is just editing the vault's own schema. Built-in and evolved
 types are identical.
 
+### Temporal Fields (Universal)
+
+Every entity has temporal tracking fields. **Always preserve
+these when reorganising or updating entities:**
+
+- `lastUpdated` — session/date when entity was last modified
+- `asOfSession` — session when entity's state was confirmed
+- `createdSession` — session when entity was introduced
+- `source` — how it entered canon: "play", "prep", "backstory"
+
+When filing a new entity, set `lastUpdated`, `asOfSession`,
+and `createdSession` to the current session. When updating
+an existing entity, update `lastUpdated` and `asOfSession`.
+
 ### World Evolution Fields
 
 The `ttrpg-expert` skill's `world-evolution.md` procedure

--- a/skills/ttrpg-expert/entity-types.md
+++ b/skills/ttrpg-expert/entity-types.md
@@ -2,6 +2,28 @@
 
 Comprehensive guide to Imagineer entity types.
 
+## Universal Fields
+
+These fields apply to **every** entity type. They provide
+temporal context so the GM and companion skills can track
+when information was established and whether it's current.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| lastUpdated | string | Session number or date when this entity was last modified (e.g., "Session 7" or "2026-04-06") |
+| asOfSession | string | Session number when this entity's current state was confirmed accurate. If asOfSession is much older than the current session, the entity may need review. |
+| createdSession | string | Session number when this entity was first introduced to the campaign |
+| source | string | How this entity entered canon: "play" (emerged during a session), "prep" (created during session prep), "backstory" (part of initial campaign setup) |
+
+When filing or updating any entity, always set `lastUpdated`
+and `asOfSession` to the current session. Campaign-organizer
+should preserve these fields when reorganising.
+
+These fields enable temporal queries: "show me everything
+that changed in session 5," "which entities haven't been
+updated since session 3?" and "what was the faction's state
+as of session 4?"
+
 ## Core Entity Types
 
 ### NPC (Non-Player Character)

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -231,7 +231,9 @@ Rumour (world): "A trade ship from the east arrived with
 Present all proposals from steps 1-6 together, grouped by
 step. The GM confirms, modifies, or rejects each one. Only
 after GM approval, file the accepted updates to the chosen
-storage location.
+storage location. When filing, set `lastUpdated` and
+`asOfSession` to the current session number on every entity
+that changed (see entity-types.md Universal Fields).
 
 Suggest: "Updates filed. Would you like to run campaign-qa
 to validate, or proceed to session prep?"

--- a/tests/temporal-fields/benchmark-2026-04-06.md
+++ b/tests/temporal-fields/benchmark-2026-04-06.md
@@ -1,0 +1,47 @@
+# Temporal Fields — Benchmark Results
+
+**Date:** 2026-04-06
+**Model:** sonnet (agents), opus (evaluator)
+
+## Metrics
+
+| | Control | Test |
+|---|:---:|:---:|
+| Tokens | 9,040 | 26,847 |
+| Time (s) | 20.4 | 32.6 |
+| Tool uses | 0 | 3 |
+
+## Quality Scores (15 max per question)
+
+| Question | Control | Test | Delta |
+|----------|:-------:|:----:|:-----:|
+| Q1 Staleness detection | 10 | 14 | +4 |
+| Q2 Temporal queries | 10 | 14 | +4 |
+| Q3 Source-based quality pass | 11 | 14 | +3 |
+| Q4 Post-session filing | 11 | 15 | +4 |
+| **Total** | **42** | **57** | **+15** |
+
+## Analysis
+
+Strongest per-question improvement of any benchmark so far.
+The temporal fields give the skill a concrete vocabulary
+(lastUpdated, asOfSession, source, discoveryState) that the
+base model simply doesn't have.
+
+The control offered sound ad-hoc advice ("session-stamped
+fact log," "triage by staleness") but left the GM to design
+the actual structure. The test provided named fields, exact
+values, and executable steps every time.
+
+### Evaluator highlights
+
+- Q1: "References a named field and an explicit condition
+  as the sorting mechanism" — test correctly ordered
+  entities by staleness while control contradicted itself
+  (prioritised S7 entity for review, then said skip S7+)
+- Q2: "Names specific field (discoveryState), specific
+  entity type (Secret), per-NPC timestamps — a reusable
+  structured approach" vs control's informal "fact log"
+- Q4: Perfect 15/15 — "Each action is a concrete executable
+  step with named fields and explicit values for every
+  entity touched"

--- a/tests/temporal-fields/test-plan.md
+++ b/tests/temporal-fields/test-plan.md
@@ -1,0 +1,58 @@
+# Temporal Fields — Test Plan
+
+## Purpose
+
+Verify that universal temporal fields on entities improve
+the skill's ability to help GMs manage campaign state over
+time — detecting stale information, answering temporal
+queries, and tracking provenance.
+
+## Method
+
+- Same model (sonnet) for control and test
+- Control: no file access
+- Test: SKILL.md as entry point, follow routing
+- 4 questions testing temporal capabilities
+- Blind evaluator (opus) with standard rubric
+
+## Questions
+
+**Q1 (Staleness detection):**
+"I'm prepping session 8. I have these entities in my campaign: (a) Baron Aldric — last updated session 3, (b) the Thieves Guild — last updated session 7, (c) an NPC informant named Pell — last updated session 2, (d) the cursed dagger — last updated session 6. Which of these need review before I prep, and why?"
+
+**Q2 (Temporal query):**
+"The Crimson Hand cult was allied with the merchant guild in session 4, but the PCs exposed the alliance in session 6. A player is arguing about what an NPC would have known in session 5. How should I track and resolve this kind of temporal question about my campaign state?"
+
+**Q3 (Source tracking):**
+"My campaign has grown messy — some NPCs were carefully prepped, others were improvised during play, and some are from the original backstory. I want to do a quality pass. How should I identify which entities need the most attention?"
+
+**Q4 (Post-session filing):**
+"Session 7 just ended. During play, I improvised a tavern keeper named Greta, the PCs discovered that the baron is secretly funding the rebels, and an existing NPC (Scholar Wendt) revealed new information about the artifact. What should I update and how should I record these changes?"
+
+## Prompt Templates
+
+### Control
+```
+You are a TTRPG GM assistant. Answer each question concisely
+(under 150 words each). Do NOT read any files.
+
+[questions]
+```
+
+### Test
+```
+You are a TTRPG GM assistant. Read the skill entry point:
+/Users/antonypegg/PROJECTS/gm-apprentice/skills/ttrpg-expert/SKILL.md
+
+Follow routing to find relevant procedures and reference
+files. For entity management, check entity-types.md. For
+post-session updates, check world-evolution.md.
+
+[questions]
+```
+
+## Scoring Rubric (1-3 per dimension, 15 max)
+
+Standard 5-dimension rubric (factual accuracy, system
+specificity, actionability, mechanical grounding, table-
+ready fiction).


### PR DESCRIPTION
## Summary

Adds universal temporal tracking fields to every entity type in the entity schema, enabling "what was true at session N?" queries and staleness detection.

## Changes

- **entity-types.md**: New "Universal Fields" section at top applying to all entity types: `lastUpdated`, `asOfSession`, `createdSession`, `source`
- **campaign-organizer SKILL.md**: New "Temporal Fields" subsection — instructions to preserve and update temporal fields when filing/reorganising entities
- **world-evolution.md**: Filing step now references temporal fields — set `lastUpdated` and `asOfSession` on every changed entity

## Why

Without temporal context, entities are timeless snapshots — the GM can't tell when something was last confirmed, whether it's stale, or how the world looked at a specific point in the campaign. These four fields give every entity a position in time.

This is P1t-T2 from the ranked backlog (Score 3.0, Size S).

## Test plan

- Verify `entity-types.md` has Universal Fields section before Core Entity Types
- Verify `campaign-organizer/SKILL.md` has Temporal Fields subsection
- Verify `world-evolution.md` references temporal fields in filing step