### PR TITLE
Add canonical timeline and explicit filing protocol

### DIFF
--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -137,7 +137,7 @@ these fields when reorganising:
   `knownBy`, `nextBeat`, `resolutionCondition`,
   `plantedDetail`, `intendedPayoff`, `ripeness`
 
-**Campaign-tracker.md** may exist at the vault root with
+**campaign-tracker.md** may exist at the vault root with
 consequence logs, foreshadowing logs, world state snapshots,
 and rumour boards. Do not reorganise this file — it is
 updated by the world-evolution procedure.

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -142,6 +142,11 @@ consequence logs, foreshadowing logs, world state snapshots,
 and rumour boards. Do not reorganise this file — it is
 updated by the world-evolution procedure.
 
+**Campaign-timeline.md** may exist at the vault root as an
+append-only session-by-session record of what happened. Do
+not reorganise or edit past entries — the timeline is the
+canonical record of collapsed reality.
+
 ## The Two Layers
 
 ### Narrative Layer (linear)

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -24,6 +24,10 @@ decides what to do.
   tracking (Chekhov Protocol for stale threads, Canon
   Grounding for fact verification). Has per-system topic
   files for rules and stat lookups.
+  The canonical timeline (`campaign-timeline.md`) records
+  what happened each session. When validating entity temporal
+  state, cross-reference: does the entity's `createdSession`
+  match the timeline session that mentions its introduction?
 
 - **campaign-organizer** — Vault structure and entity
   management. When findings involve structural graph issues

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -26,8 +26,11 @@ decides what to do.
   files for rules and stat lookups.
   The canonical timeline (`campaign-timeline.md`) records
   what happened each session. When validating entity temporal
-  state, cross-reference: does the entity's `createdSession`
+  state, cross-reference: for entities with `source: "play"`
+  or `source: "prep"`, does the entity's `createdSession`
   match the timeline session that mentions its introduction?
+  Entities with `source: "backstory"` are exempt — they
+  predate the timeline and may not have an introduction entry.
 
 - **campaign-organizer** — Vault structure and entity
   management. When findings involve structural graph issues

--- a/skills/session-lifecycle/SKILL.md
+++ b/skills/session-lifecycle/SKILL.md
@@ -37,6 +37,9 @@ of a living campaign. This skill manages each stage.
   (npc-generation.md), and continuity checking
   (continuity-engine.md with Chekhov Protocol for stale
   threads and Canon Grounding for fact verification).
+  The world-evolution procedure now produces a timeline entry
+  as part of the filing step. The canonical timeline
+  (`campaign-timeline.md`) records collapsed reality.
 
 - **campaign-organizer** — Vault structure and entity
   management. When wrap-up produces new entities or scenes,

--- a/skills/ttrpg-expert/INDEX.md
+++ b/skills/ttrpg-expert/INDEX.md
@@ -69,6 +69,7 @@ In the table below, `{system}` is one of: `dnd-5e-2024`,
 | **Cipher or coded message** | `handouts-and-props.md` | — |
 | **Random or procedural** content | `random-generation.md` | — |
 | **Post-session update** / world advancement / faction turns / consequence tracking | `world-evolution.md` | For system-specific faction turns: `systems/{system}/session-procedures.md` |
+| **Campaign timeline** / session recap / what happened | `campaign-timeline.md` (in vault root or campaign/) | — |
 | **Session prep** | `session-planner.md` | `gm-session-patterns.md` for frameworks, `scenario-writing.md` for player agency |
 | **PC arc planning or spotlight** | `session-planner.md` | — |
 | **Player agency review** | `session-planner.md` (Step 7) | `scenario-writing.md` for anti-patterns, `continuity-engine.md` for scan |
@@ -189,6 +190,9 @@ guidance as a fallback for unsupported systems.
   faction turns, consequence surfacing, thread management,
   foreshadowing tracking, discovery state updates. Run after
   every session to make the world respond to play.
+- `campaign-timeline.md` — Canonical campaign timeline:
+  append-only, one lean entry per session recording what
+  actually happened. Lives in vault root or campaign/.
 
 #### Content Generation (How to Create Content)
 

--- a/skills/ttrpg-expert/SKILL.md
+++ b/skills/ttrpg-expert/SKILL.md
@@ -216,6 +216,12 @@ changed after that session?"** / **"advance the world"**
   checklist. Present all proposed changes to the GM for
   approval before filing anything.
 
+**"What happened in session [N]?"** / **"campaign recap"** /
+**"timeline"** / **"what's the story so far?"**
+→ Read `campaign-timeline.md` from the campaign directory
+  or vault root. Summarise the requested session(s) or the
+  full campaign arc.
+
 
 ## Three Modes of Operation
 

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -229,14 +229,82 @@ Rumour (world): "A trade ship from the east arrived with
 ### After All Steps
 
 Present all proposals from steps 1-6 together, grouped by
-step. The GM confirms, modifies, or rejects each one. Only
-after GM approval, file the accepted updates to the chosen
-storage location. When filing, set `lastUpdated` and
-`asOfSession` to the current session number on every entity
-that changed (see entity-types.md Universal Fields).
+step. The GM confirms, modifies, or rejects each one.
 
-Suggest: "Updates filed. Would you like to run campaign-qa
-to validate, or proceed to session prep?"
+After GM approval, execute the filing protocol below.
+
+### Filing Protocol
+
+For each approved proposal, file the changes to the storage
+location chosen during the Storage Checkpoint.
+
+**New entities** (NPCs, locations, factions, items, threads
+introduced during play):
+1. Create an entity file using the schema in `entity-types.md`
+2. Set `source: "play"` (or `"prep"` if created during prep)
+3. Set `createdSession`, `lastUpdated`, and `asOfSession` to
+   the current session number
+4. Include all relevant attributes from the approved proposal
+
+**Changed entities** (existing NPCs, factions, items whose
+state changed):
+1. Update the entity file with the changed fields
+2. Set `lastUpdated` and `asOfSession` to the current session
+3. Do not overwrite unchanged fields
+
+**Timeline entry** — append to `campaign-timeline.md`:
+
+```
+## Session [N] — [date]
+
+[One-line summary of what happened — the single sentence
+a GM would use to remind players next session]
+
+**Decisions:** [2-3 PC choices that changed campaign direction]
+**Introduced:** [New entity names — details live on entities]
+**Changed:** [Entity names with brief state change note]
+```
+
+Assemble this from the approved proposals — the summary
+comes from the key events, the decisions from faction turns
+and consequence surfacing, the introduced/changed lists from
+the entity filing above. This is not a separate writing task;
+it is a structured summary of what was just filed.
+
+### Filing Location by Configuration
+
+**Vault mode** (campaign-organizer available):
+- Entity files → hand to campaign-organizer for vault filing
+- `campaign-timeline.md` → vault root
+- `campaign-tracker.md` → vault root
+
+**Simple files mode** (no vault):
+- Use the following directory structure:
+
+```
+campaign/
+  campaign-timeline.md
+  campaign-tracker.md
+  entities/
+    npcs/
+    locations/
+    factions/
+    items/
+    threads/
+    clues/
+```
+
+- One markdown file per entity, named after the entity
+- ttrpg-expert creates this structure on first use if it
+  does not exist
+
+**ttrpg-expert standalone** (only skill installed):
+- Same as simple files mode
+- ttrpg-expert uses `entity-types.md` as its schema guide
+- No dependency on campaign-organizer
+
+After filing, suggest: "Updates filed. Would you like to
+run campaign-qa to validate, or proceed to session prep?"
 
 ---
 

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -254,7 +254,7 @@ state changed):
 
 **Timeline entry** — append to `campaign-timeline.md`:
 
-```
+```markdown
 ## Session [N] — [date]
 
 [One-line summary of what happened — the single sentence
@@ -281,7 +281,7 @@ it is a structured summary of what was just filed.
 **Simple files mode** (no vault):
 - Use the following directory structure:
 
-```
+```text
 campaign/
   campaign-timeline.md
   campaign-tracker.md

--- a/tests/canonical-timeline/benchmark-2026-04-06.md
+++ b/tests/canonical-timeline/benchmark-2026-04-06.md
@@ -1,0 +1,61 @@
+# Canonical Timeline — Benchmark Results
+
+**Date:** 2026-04-06
+**Model:** sonnet (agents), opus (evaluator)
+
+## Metrics
+
+| | Control | Test |
+|---|:---:|:---:|
+| Tokens | 8,731 | 28,584 |
+| Time (s) | 13.9 | 56.0 |
+| Tool uses | 0 | 3 |
+
+## Quality Scores (15 max per question)
+
+| Question | Control | Test | Delta |
+|----------|:-------:|:----:|:-----:|
+| Q1 Timeline entry + entities | 9 | 14 | +5 |
+| Q2 Read-aloud recap | 7 | 13 | +6 |
+| Q3 Fact-check Pell | 10 | 15 | +5 |
+| Q4 Standalone setup | 11 | 14 | +3 |
+| **Total** | **37** | **56** | **+19** |
+
+## Analysis
+
+Strongest overall benchmark so far. Average +4.75 per
+question across all four.
+
+**Q1 (+5):** Test produced a structured timeline entry with
+Decisions/Introduced/Changed fields plus 8 entity updates
+with named schema fields. Control produced a blockquote
+and 4 brief bullet points.
+
+**Q2 (+6):** Largest single-question delta. Control refused
+to produce output ("I can't fill this in without your notes").
+Test produced a complete read-aloud template with fill-in
+brackets for sessions 3-4 and a fully written session 5
+paragraph. Practical help vs learned helplessness.
+
+**Q3 (+5, perfect 15/15):** Test provided a 3-step
+verification protocol: check timeline Introduced/Changed
+fields, check NPC entity createdSession, then raw notes.
+If nothing found: create DRAFT entity with gmNotes flagging
+"Player claims this — verify before AUTHORITATIVE." Control
+suggested "search notes for Pell."
+
+**Q4 (+3):** Test provided the full campaign/ directory
+structure with entity subdirectories and named workflows
+(world-evolution six-step checklist, entity-types.md
+schema). Control suggested flat files (npcs.md, locations.md)
+that would become unwieldy quickly.
+
+## Evaluator Highlights
+
+- Q2: "Delivers a usable template with fill-in brackets —
+  produces useful output even when data is incomplete"
+- Q3: "DRAFT entity with verification flag gives the GM a
+  concrete in-session and post-session workflow" — 15/15
+- Q4: "Full directory tree, named checklists, one-file-per-
+  entity convention — GM can create this and start using it
+  immediately"

--- a/tests/canonical-timeline/test-plan.md
+++ b/tests/canonical-timeline/test-plan.md
@@ -1,0 +1,48 @@
+# Canonical Timeline — Test Plan
+
+## Purpose
+
+Verify that the canonical timeline and filing protocol
+improve the skill's ability to help GMs manage campaign
+history, validate state, and operate standalone.
+
+## Method
+
+- Same model (sonnet) for control and test
+- Control: no file access
+- Test: SKILL.md as entry point, follow routing
+- 4 questions
+- Blind evaluator (opus) with standard 5-dimension rubric
+
+## Questions
+
+**Q1 (Timeline assembly):**
+"Session 5 just ended. Here's what happened: the PCs
+infiltrated the baron's manor, found letters proving his
+alliance with the cult, convinced the butler to defect,
+and escaped through the servant tunnels when guards were
+alerted. They left behind the cult's stolen medallion as
+a calling card. Write the timeline entry and tell me what
+entity updates are needed."
+
+**Q2 (Temporal reconstruction):**
+"I need to remind my players what happened in sessions 3-5.
+I have a campaign timeline. Summarise the arc so far in a
+way I can read aloud at the start of session 6."
+
+**Q3 (Validation query):**
+"A player says their character met the informant Pell at
+the docks in session 3. I don't remember this. How can I
+check whether this actually happened?"
+
+**Q4 (Standalone operation):**
+"I only have the ttrpg-expert skill. No Obsidian, no vault,
+no campaign-organizer. I want to start tracking my campaign
+properly. What structure should I set up and how does it
+work?"
+
+## Scoring Rubric (1-3 per dimension, 15 max)
+
+Standard 5-dimension rubric (factual accuracy, system
+specificity, actionability, mechanical grounding, table-
+ready fiction).

--- a/tests/quick-commands/benchmark-2026-04-06.md
+++ b/tests/quick-commands/benchmark-2026-04-06.md
@@ -1,0 +1,61 @@
+# Quick Commands (Discoverability) — Benchmark Results
+
+**Date:** 2026-04-06
+**Model:** sonnet (agents), opus (evaluator)
+**PR:** #4 (Discoverability + Orchestration)
+
+## Metrics
+
+| | Control | Test |
+|---|:---:|:---:|
+| Tokens | 8,962 | 42,342 |
+| Time (s) | 21.1 | 43.2 |
+| Tool uses | 0 | 5 |
+
+## Quality Scores (15 max per question)
+
+| Question | Control | Test | Delta |
+|----------|:-------:|:----:|:-----:|
+| Q1 Canon check | 9 | 15 | +6 |
+| Q2 Spotlight imbalance | 9 | 15 | +6 |
+| Q3 Character arc | 13 | 15 | +2 |
+| Q4 Failed roll | 13 | 15 | +2 |
+| Q5 Open interaction | 9 | 15 | +6 |
+| **Total** | **53** | **75** | **+22** |
+
+**Perfect score: 75/75.** Five consecutive 15/15 ratings.
+
+## Analysis
+
+The strongest benchmark result across all PRs. The test
+scored perfectly on every question. The evaluator noted:
+
+> "Answer B scores perfectly across all dimensions by naming
+> specific frameworks, providing measurable criteria (15%
+> floor, 15-20 minute timer, three-session threshold),
+> offering multiple categorized options, and delivering
+> table-ready fiction that a GM can use without further
+> interpretation."
+
+The base model scored well on Q3-Q4 (13/15) — it gives
+good general GM advice for arc progression and fail-forward.
+But it scored poorly on Q1, Q2, Q5 (9/15) because these
+require **structured diagnostic frameworks** that the model
+doesn't have in training data:
+- Canon Grounding: "motivation break" as a named category
+- Spotlight Forecast: 15% per-PC floor, three-session
+  corrective threshold, B/C-plot rotation
+- Open Interaction Windows: 15-20 min soft timer, diegetic
+  trigger method, "the open window you forgot to write"
+
+## Key Finding
+
+The Quick Commands' value isn't in routing — it's in giving
+the GM **named, measurable frameworks** to replace vague
+instincts. The base model says "give underserved PCs more
+scenes." The skill says "Delgado is below the 15% floor,
+assign them the B-plot, track rotation explicitly, three
+sessions of imbalance triggers a corrective plan."
+
+Named frameworks with thresholds and categories produce
+dramatically better guidance than general wisdom.

--- a/tests/quick-commands/test-plan.md
+++ b/tests/quick-commands/test-plan.md
@@ -1,0 +1,57 @@
+# Quick Commands (Discoverability) — Test Plan
+
+## Purpose
+
+Verify that the 6 new Quick Commands (PR #4) improve the
+skill's ability to help GMs use buried frameworks —
+Canon Grounding, Chekhov Protocol, Spotlight Forecast,
+Five-Stage Arc Model, Fail Forward, Open Interaction Windows.
+
+## Method
+
+- Same model (sonnet) for control and test
+- Control: no file access
+- Test: SKILL.md as entry point, follow routing
+- 5 questions (one per framework, combining Canon + Chekhov)
+- Blind evaluator (opus) with standard 5-dimension rubric
+
+## Questions
+
+**Q1 (Canon Grounding):**
+"I just prepped a session where the cult leader gives a
+speech to rally followers, but I want to make sure I
+haven't accidentally contradicted anything from earlier
+sessions. The cult leader was described as reclusive in
+session 2, and I have him appearing publicly now in session
+6. How do I check whether this is a contradiction or a
+character development?"
+
+**Q2 (Spotlight Forecast):**
+"I have 4 PCs. Looking back over my notes from the last 3
+sessions: Elena has been in 6 scenes, Marcus in 5, Jun in
+3, and Delgado in 2. What should I do about this imbalance
+before next session?"
+
+**Q3 (Five-Stage Arc Model):**
+"My player's character Kira has been through a lot —
+started as a naive scholar, survived betrayal by a mentor,
+led a desperate defence of the village, and is now
+rebuilding. Where is she in her character arc and what kind
+of scenes should I prep to advance her?"
+
+**Q4 (Fail Forward):**
+"A player just rolled badly on a crucial Lockpicking check
+to open the vault before the guards return. I don't want to
+just say 'you fail and the guards catch you.' What are my
+options?"
+
+**Q5 (Open Interaction Windows):**
+"I designed a tense infiltration scene but the players are
+roleplaying among themselves about what to do — planning,
+arguing, forming alliances. This wasn't in my prep. Should
+I interrupt to move to the planned scene, or let this
+play out?"
+
+## Scoring Rubric (1-3 per dimension, 15 max)
+
+Standard 5-dimension rubric.


### PR DESCRIPTION
## Summary

Adds a canonical campaign timeline (session-by-session record of what happened) and replaces the vague filing section in world-evolution.md with an explicit protocol that works standalone, with simple files, or with a full Obsidian vault.

### What's new

- **Filing Protocol** in world-evolution.md — explicit steps for new entities (create file with schema fields), changed entities (update + timestamp), and timeline entry (lean 5-8 line summary assembled from approved proposals)
- **Simple files directory structure** — `campaign/` with `entities/npcs/`, `entities/factions/`, etc. Works without campaign-organizer or Obsidian. Makes ttrpg-expert fully self-sufficient.
- **Timeline Quick Command** — "What happened in session N?" / "campaign recap" / "timeline"
- **Cross-skill updates** — campaign-organizer knows not to reorganise timeline, campaign-qa can validate entities against it, session-lifecycle knows wrap-up feeds it

### Benchmark

| Question | Control | Test | Delta |
|----------|:-------:|:----:|:-----:|
| Timeline entry + entities | 9 | 14 | +5 |
| Read-aloud recap | 7 | 13 | +6 |
| Fact-check (Pell in session 3?) | 10 | 15 | +5 |
| Standalone setup | 11 | 14 | +3 |
| **Total** | **37** | **56** | **+19** |

Strongest benchmark yet. Perfect 15/15 on fact-checking. The control refused to produce a recap without data; the test produced a usable template with fill-in brackets.