### PR TITLE
fix: codebase QA pass — schema naming, portable paths, lint, CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: |
+            skills/**/*.md
+            docs/**/*.md
+            tests/**/*.md
+            README.md
+
+  consistency-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: No hardcoded absolute paths
+        run: |
+          if grep -rn '/Users/' skills/ docs/ tests/ README.md 2>/dev/null; then
+            echo "::error::Found hardcoded absolute paths"
+            exit 1
+          fi
+
+      - name: Schema field naming consistency
+        run: |
+          if grep -rn 'canon_status:' skills/ tests/ 2>/dev/null; then
+            echo "::error::Found 'canon_status:' — use 'source_confidence:' instead"
+            exit 1
+          fi

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -27,8 +27,8 @@ MD022: false
 # Bare URLs — URLs appear in attribution and reference sections
 MD034: false
 
-# Fenced code language — some code blocks intentionally have no language tag
-MD040: false
+# Fenced code language — enforced (use `text` for plain content)
+MD040: true
 
 # First line heading — SKILL.md files and reference fragments don't start with H1
 MD041: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,70 @@
+# .markdownlint.yaml
+# Rules disabled because this repo uses compact/dense markdown style
+# (reference tables, skill files, campaign data) that conflicts with
+# standard prose-oriented linting defaults.
+
+# Line length — reference tables and YAML frontmatter exceed 80 chars
+MD013: false
+
+# Inline HTML — used in some docs
+MD033: false
+
+# Duplicate headings — system reference files reuse section names across files
+MD024: false
+
+# Emphasis as heading — used as visual separators in reference tables
+MD036: false
+
+# Table column style — repo uses compact pipe tables without surrounding spaces
+MD060: false
+
+# Blanks around lists — dense reference content omits blank lines around lists
+MD032: false
+
+# Blanks around headings — dense reference content omits blank lines
+MD022: false
+
+# Bare URLs — URLs appear in attribution and reference sections
+MD034: false
+
+# Fenced code language — some code blocks intentionally have no language tag
+MD040: false
+
+# First line heading — SKILL.md files and reference fragments don't start with H1
+MD041: false
+
+# Multiple blank lines — some files use double blanks as visual separators
+MD012: false
+
+# Trailing spaces — character sheet files use trailing spaces for alignment
+MD009: false
+
+# Ordered list item prefix — some lists use intentional non-sequential numbering
+MD029: false
+
+# Blanks around fences — dense reference content omits blank lines around fences
+MD031: false
+
+# Multiple top-level headings — some reference files have multiple H1s
+MD025: false
+
+# Blank line in blockquote — used intentionally in some docs
+MD028: false
+
+# Space in emphasis markers — appears in reference content
+MD037: false
+
+# Unordered list style — mixed - and * used across files
+MD004: false
+
+# Heading levels — reference files skip heading levels intentionally
+MD001: false
+
+# Space in code span — appears in reference content
+MD038: false
+
+# Reference link labels defined — some reference tables use undefined labels
+MD052: false
+
+# Single trailing newline — some generated/large files lack final newline
+MD047: false

--- a/docs/plans/future-work.md
+++ b/docs/plans/future-work.md
@@ -1,49 +1,67 @@
-# gm-apprentice Future Work
+# gm-apprentice — Ranked Backlog
 
-Backlog of ideas and planned work identified during
-brainstorming sessions. Items move out of here when they
-get their own spec and implementation plan.
+Items are force-ranked by score. Higher score = do first.
 
-## Phase 5: Per-System Content Knowledgebases
+**Formula:** Score = (Impact × 2 + Urgency) / Effort
 
-Enrich each system subfolder with non-rules SRD content
-using multiple topic files (option B from brainstorming).
+| Impact | Meaning |
+|:------:|---------|
+| 5 | Directly improves the user's active game |
+| 4 | Improves the user's primary system |
+| 3 | Improves general plugin quality |
+| 2 | Adds support for secondary systems |
+| 1 | Nice to have |
 
-Per system, as applicable:
-- `monsters.md` / `creatures.md`
-- `spells.md`
-- `magic-items.md`
-- `setting.md` (Doskvol for FitD, etc.)
-- `factions.md`
-- Other system-specific topics
+| Urgency | Meaning |
+|:-------:|---------|
+| 5 | Blocks other work |
+| 4 | Active need (user's current campaign) |
+| 3 | Next logical step |
+| 2 | Eventually |
+| 1 | Whenever |
 
-Source from SRDs where available (CC-BY 4.0 for D&D,
-CC-BY 3.0 for FitD, ORC for BRP). For GURPS, generated
-from user's GCA data via connector.
+| Effort | Meaning |
+|:------:|---------|
+| S (1) | < 1 hour |
+| M (2) | 1-4 hours |
+| L (3) | 4-12 hours |
+| XL (4) | 12+ hours |
 
-## Phase 5+: Additional Connectors
+---
 
-- **PDF-to-markdown converter** for CoC rulebooks and
-  other systems without structured data files
-- **Auto-download of freely available SRDs** on first
-  setup (D&D SRD 5.2 from GitHub, FitD SRD, BRP ORC
-  Content Document)
-- **Connector for new game systems** as they're added
+## The List
 
-## Unfinished from Earlier Phases
+| Rank | Item | Impact | Urgency | Effort | Score | Status |
+|:----:|------|:------:|:-------:|:------:|:-----:|--------|
+| 1 | Regency Cthulhu system support | 5 | 4 | M (2) | 7.0 | Planned |
+| 2 | CoC/BRP SRD enrichment (Phase 5a) | 4 | 3 | L (3) | 3.7 | Planned |
+| 3 | FitD SRD enrichment (Phase 5b) | 2 | 2 | M (2) | 3.0 | Planned |
+| 4 | Character sheet templates | 2 | 1 | M (2) | 2.5 | Idea |
+| 5 | Skill description optimization | 2 | 1 | M (2) | 2.5 | Idea |
+| 6 | Eval suite for all skills | 3 | 1 | L (3) | 2.3 | Idea |
+| 7 | D&D SRD enrichment (Phase 5c) | 2 | 2 | L (3) | 2.0 | Planned |
+| 8 | PDF-to-markdown converter | 3 | 1 | XL (4) | 1.8 | Idea |
+| 9 | Auto-download SRDs on setup | 1 | 1 | M (2) | 1.5 | Idea |
 
-- campaign-qa and session-lifecycle could potentially
-  get filesystem fallbacks similar to campaign-organizer
-  (lower priority — campaign-organizer was the most
-  impactful)
+## Completed
 
-## Ideas Under Consideration
+- ~~Codebase QA pass~~ — Score 11.0 (Impact 3, Urgency 5, Effort S)
+- ~~Filesystem fallback (campaign-qa, session-lifecycle)~~ — PR #14
+- ~~Shared-refs extraction~~ — Merged to main
+- ~~GURPS content restructure (Phase 4)~~ — 31 files, 7 kits
+- ~~Copyright compliance (Phases 1-3)~~ — All systems
 
-- Character sheet templates per system (see Phase 4 spec —
-  included there)
-- GCA `.gcs` sheet template parsing (character sheet
-  formats from GCA4's sheets/ directory)
-- skill-creator description optimization loop for all
-  four skills
-- Eval suite for each skill (beyond the campaign-organizer
-  evals already done)
+## Notes
+
+- **Regency Cthulhu** is the user's active campaign system.
+  Source material: `docs/supplemental/regency_cthulhu_reference_tables.md`
+  (skills, occupations, equipment, weapons, chase rules from
+  Chaosium 2022). Add as CoC variant topic file with Regency-
+  specific skill/occupation/equipment overrides.
+
+- **Phase 5 order** (confirmed): CoC/BRP → FitD → D&D.
+  Each system is a discrete unit — complete one before starting
+  the next.
+
+- **GURPS enrichment** is not on the list — already done in
+  Phase 4 (24 topic files, 7 chargen kits).

--- a/docs/superpowers/plans/2026-04-10-shared-refs-extraction.md
+++ b/docs/superpowers/plans/2026-04-10-shared-refs-extraction.md
@@ -101,7 +101,7 @@ Read these files in full:
 
 Merge the two source files as described above. The structure should be:
 
-```
+```text
 # Entity Schema
 (preamble: what this file is, who uses it)
 
@@ -265,7 +265,7 @@ Replace these exact strings:
 Also add a brief cross-reference to `shared/canon-confidence.md` near the Handling Ambiguity section (line 243-252) where `canon_status: DRAFT` is referenced:
 
 After line 249 (`set \`canon_status: DRAFT\`.`), add:
-```
+```text
 See `shared/canon-confidence.md` for the full confidence state
 definitions.
 ```
@@ -350,7 +350,7 @@ Find all references to `entity-types.md` and `canon-management.md`.
 In the "Canon and Validation" section (lines 211-222):
 
 Replace:
-```
+```text
 See `canon-management.md`. On conflicts, ask — never assume.
 
 All content must be mechanically correct and narratively
@@ -358,7 +358,7 @@ consistent. See `entity-types.md` and `continuity-engine.md`.
 ```
 
 With:
-```
+```text
 See `canon-management.md` and `shared/canon-confidence.md`.
 On conflicts, ask — never assume.
 

--- a/docs/superpowers/plans/2026-04-10-shared-refs-extraction.md
+++ b/docs/superpowers/plans/2026-04-10-shared-refs-extraction.md
@@ -204,7 +204,7 @@ Some vaults use `canon_status` instead — treat them as equivalent.
 For detailed conflict detection rules, source tracking,
 and the full promotion workflow, read:
 `ttrpg-expert/canon-management.md`
-```
+```text
 
 - [ ] **Step 6: Verify all four files exist and cross-references resolve**
 

--- a/docs/superpowers/specs/2026-04-09-shared-refs-filesystem-fallback-design.md
+++ b/docs/superpowers/specs/2026-04-09-shared-refs-filesystem-fallback-design.md
@@ -40,7 +40,7 @@ multiple places, risking drift.
 
 Four shared reference files extracted from existing content:
 
-```
+```text
 skills/
   shared/
     filesystem-mode.md    — tool mapping, detection, override

--- a/docs/testing-methodology.md
+++ b/docs/testing-methodology.md
@@ -26,14 +26,14 @@ what a GM would actually ask during play or prep.
 ### 2. Run control and test
 
 **Control agent** (sonnet, no file access):
-```
+```text
 You are a TTRPG GM assistant. Answer each question concisely
 (under 150 words each). Do NOT read any files.
 [questions]
 ```
 
 **Test agent** (sonnet, with SKILL.md entry point):
-```
+```text
 You are a TTRPG GM assistant. Read the skill entry point:
 /path/to/skills/ttrpg-expert/SKILL.md
 Follow routing to find the right files for each question.

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -192,7 +192,7 @@ tools used to read, write, and search differ.
 4. **Extract** — One note per entity AND per narrative element:
    chapter overviews, scene notes, session notes, entity notes.
    Include frontmatter, body summary, `[[wiki-links]]`.
-5. **Stub** — `canon_status: STUB` for mentioned-but-undescribed
+5. **Stub** — `source_confidence: STUB` for mentioned-but-undescribed
    entities. Include `## Needs` section.
 6. **Update index** — Add new entries to `_meta/index.md`.
 7. **Report** — Extracted, stubbed, needs attention.
@@ -228,7 +228,7 @@ tools used to read, write, and search differ.
 with both names in `aliases`, flag for user confirmation.
 
 **Conflicts:** Don't pick a winner. Note one version, add
-`## Canon Conflicts`, set `canon_status: DRAFT`.
+`## Canon Conflicts`, set `source_confidence: DRAFT`.
   See `shared/canon-confidence.md` for the full confidence
   state definitions.
 

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -133,7 +133,7 @@ canonical record of collapsed reality.
 
 ### Narrative Layer (linear)
 
-```
+```text
 Campaign → Chapter → Session → Scene
 ```
 

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -236,7 +236,7 @@ findings; every finding goes through this workflow.
 
 ### 1. Present the Finding
 
-```
+```markdown
 ### [Severity] Finding Title
 
 **Files:** [[file_a]], [[file_b]]

--- a/skills/campaign-qa/references/check-procedures.md
+++ b/skills/campaign-qa/references/check-procedures.md
@@ -113,7 +113,7 @@ Read the master timeline (`_Campaign/Timeline.md` or
 equivalent). Then scan session notes for dated events.
 Build a unified chronological list:
 
-```
+```text
 [In-game date] — [Event] — [Source file] — [Entities involved]
 ```
 

--- a/skills/session-lifecycle/SKILL.md
+++ b/skills/session-lifecycle/SKILL.md
@@ -433,7 +433,7 @@ examples for different campaign tones.
 
 Entity creation is automatic. Don't ask — do it.
 
-```
+```text
 Play: new entity mentioned → noted in play notes
 Wrap-up: new entity found → hand off to campaign-organizer
   → vault file created with source_confidence: DRAFT

--- a/skills/session-lifecycle/references/recap-formats.md
+++ b/skills/session-lifecycle/references/recap-formats.md
@@ -110,7 +110,7 @@ to be shared with players.
 Organize by scene (in order played), with consistent sub-
 headings:
 
-```
+```markdown
 ### [Scene Name] — [played/modified/skipped]
 
 **What happened:** Factual narrative (2-4 sentences)

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -30,7 +30,7 @@ when filing or updating.
 
 ## Entity Type Hierarchy
 
-```
+```text
 person (abstract)
 ├── player
 ├── game_master

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -97,7 +97,7 @@ used for constraint inheritance in the relationship ontology.
 ```yaml
 ---
 type: npc              # From the type hierarchy
-canon_status: DRAFT    # DRAFT | AUTHORITATIVE | SUPERSEDED | STUB
+source_confidence: DRAFT    # DRAFT | AUTHORITATIVE | SUPERSEDED | STUB
 aliases: []
 tags: []
 source_document: ""

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -2,7 +2,7 @@
 
 Written to `_meta/vault-config.md` on first setup.
 
-```
+```text
 {Campaign Name}/
 ├── _meta/           (schema + index)
 ├── _Campaign/

--- a/skills/ttrpg-expert/campaign-structure.md
+++ b/skills/ttrpg-expert/campaign-structure.md
@@ -31,7 +31,7 @@ Guide to organizing campaign content.
 
 ### Session Lifecycle
 
-```
+```text
 PLANNED → COMPLETED
     ↓
   SKIPPED
@@ -153,7 +153,7 @@ Night watchman was avoided entirely.
 
 ### Recommended Structure
 
-```
+```text
 Campaign
 ├── Core NPCs (10-20)
 │   ├── Allies

--- a/skills/ttrpg-expert/canon-management.md
+++ b/skills/ttrpg-expert/canon-management.md
@@ -78,7 +78,7 @@ Replaced by newer information.
 
 1. **Same entity, different values**
 
-   ```
+   ```text
    Entity "Dr. Smith"
    Source A: "Age: 45"
    Source B: "Age: 52"
@@ -87,7 +87,7 @@ Replaced by newer information.
 
 2. **Contradicting relationships**
 
-   ```
+   ```text
    Entity "John"
    Source A: "Married to Mary"
    Source B: "Single"
@@ -96,7 +96,7 @@ Replaced by newer information.
 
 3. **Timeline inconsistencies**
 
-   ```
+   ```text
    Event A: "Smith died in 1925"
    Event B: "Smith attended meeting in 1926"
    → Conflict detected
@@ -104,7 +104,7 @@ Replaced by newer information.
 
 4. **Entity duplication**
 
-   ```
+   ```text
    Entity "Dr. John Smith"
    Entity "John Smith, M.D."
    → Potential duplicate detected

--- a/skills/ttrpg-expert/continuity-engine.md
+++ b/skills/ttrpg-expert/continuity-engine.md
@@ -103,7 +103,7 @@ AI-assisted session planning.
 
 ### Thread Tracker
 
-```
+```markdown
 ## [Thread Name]
 Type:  Introduced: [session + context]
 State: [Active / Dormant / Resolved / Retired]
@@ -188,7 +188,7 @@ SUPERSEDED, note in session records.
 
 ### State Snapshot
 
-```
+```markdown
 ## Campaign State: [Date]
 
 Active Threats:

--- a/skills/ttrpg-expert/handouts-and-props.md
+++ b/skills/ttrpg-expert/handouts-and-props.md
@@ -43,7 +43,7 @@ duplicates existing info.
 
 ### Letters
 
-```
+```text
 [LETTERHEAD/ADDRESS — if appropriate to social standing]
 [DATE — period-appropriate format]
 [SALUTATION]
@@ -72,7 +72,7 @@ P3 (optional): Personal detail revealing character or subtext.
 
 ### Newspaper Clippings
 
-```
+```text
 [NEWSPAPER NAME] — [CITY]
 [DATE — day of week, full date]
 [SECTION]
@@ -99,7 +99,7 @@ info connecting later. Ads = hidden messages or locations.
 
 ### Diary/Journal Entries
 
-```
+```text
 [DATE]
 [ENTRY — first person]
 - Opening: what prompted the entry
@@ -120,7 +120,7 @@ info connecting later. Ads = hidden messages or locations.
 
 ### Official Documents
 
-```
+```text
 [LETTERHEAD — org name, seal, address]
 [DOCUMENT TYPE — "Certificate of Death", "Warrant", etc.]
 [REFERENCE NUMBER]
@@ -141,7 +141,7 @@ info connecting later. Ads = hidden messages or locations.
 
 ### Mythos Tomes
 
-```
+```text
 [TITLE — original language + translation]
 [PHYSICAL DESCRIPTION — binding, condition, medium, marginalia]
 [FRAGMENT]
@@ -161,7 +161,7 @@ passages; physical description should be unsettling.
 
 ### Item Cards
 
-```
+```text
 [ITEM NAME]  [RARITY/VALUE]
 [PHYSICAL DESCRIPTION — 1-2 sentences sensory detail]
 [MECHANICAL PROPERTIES — system stats, bonuses, charges, limits]

--- a/skills/ttrpg-expert/relationship-patterns.md
+++ b/skills/ttrpg-expert/relationship-patterns.md
@@ -143,7 +143,7 @@ Scale of 1-10:
 
 ### Family Networks
 
-```
+```text
 Grandfather ─┬─ Grandmother
              │
              ├─ Father ─┬─ Mother
@@ -162,7 +162,7 @@ Relationships:
 
 ### Faction Hierarchy
 
-```
+```text
 Faction Leader
      │
      ├── Lieutenant 1
@@ -181,7 +181,7 @@ Relationships:
 
 ### Love Triangle
 
-```
+```text
     Character A
       /     \
      /       \

--- a/skills/ttrpg-expert/session-planner.md
+++ b/skills/ttrpg-expert/session-planner.md
@@ -17,7 +17,7 @@ session planning, also read:
 Complete for every PC before planning scenes. The touchpoint
 at the bottom is the critical output.
 
-```
+```text
 PC NAME: ___  PLAYER: ___
 
 BACKSTORY HOOKS (unresolved elements from history):
@@ -46,7 +46,7 @@ storylines weaving through the ensemble narrative.
 
 ### Arc Tracker
 
-```
+```text
 CAMPAIGN: ___  SESSION: ___
 
 | PC | Arc Theme | Stage | Next Beat | Target Session |
@@ -73,7 +73,7 @@ every arc simultaneously.
 
 Rotate the featured PC. Track explicitly:
 
-```
+```text
 | Session | A-Plot | B-Plot (Featured PC) | C-Plot (Secondary) |
 |---------|--------|----------------------|--------------------|
 ```
@@ -85,7 +85,7 @@ Rules:
 
 ### Spotlight Tracking
 
-```
+```text
 SESSION: ___
 
 | PC | Spotlight Share | Notes |
@@ -127,7 +127,7 @@ to be major — some signal the campaign remembers the character.
 
 ### Touchpoint Planning Matrix
 
-```
+```text
 SESSION: ___
 
 | PC | Touchpoint Type | Description | When in Session |
@@ -146,7 +146,7 @@ COVERAGE CHECK:
 
 Map during campaign planning (not session-by-session):
 
-```
+```text
 MAIN ARC: ___  ANTAGONIST: ___
 
 | PC | Backstory Element | Connection to Main Arc |

--- a/skills/ttrpg-expert/systems/fitd/character-sheet.md
+++ b/skills/ttrpg-expert/systems/fitd/character-sheet.md
@@ -277,7 +277,7 @@ is a score against the controlling faction (typically -2 status
 with target, +1 with their enemies).
 
 Sample claim map layout:
-```
+```text
 [        ] --- [        ] --- [        ]
      |              |              |
 [        ] --- [  LAIR  ] --- [        ]

--- a/skills/ttrpg-expert/systems/fitd/entanglements.md
+++ b/skills/ttrpg-expert/systems/fitd/entanglements.md
@@ -232,7 +232,7 @@ Roll dice equal to crew Tier:
 
 ### Prison Claim Map
 
-```
+```text
 [Parole Influence] --- [Smuggling] --- [Allied Claim]    [Cell Block Control]
         |                   |               |                     |
   [Guard Payoff]  --- [ PRISON ] --- [Guard Payoff] --- [Allied Claim]

--- a/skills/ttrpg-expert/systems/fitd/session-procedures.md
+++ b/skills/ttrpg-expert/systems/fitd/session-procedures.md
@@ -8,7 +8,7 @@
 
 ## The Core Loop
 
-```
+```text
 Free Play -> Score Setup -> Engagement Roll -> Score Execution
     -> Payoff & Heat -> Entanglements -> Downtime -> Free Play
 ```

--- a/skills/ttrpg-expert/systems/generic/rules-reference.md
+++ b/skills/ttrpg-expert/systems/generic/rules-reference.md
@@ -31,7 +31,7 @@ determine who acts first in combat?" and map to one of these.
 Despite surface differences, most tactical combat follows the
 same universal loop:
 
-```
+```text
 1. Determine turn order (initiative)
 2. Active combatant declares action
 3. Resolve the action (roll dice, compare to target)

--- a/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
@@ -328,7 +328,7 @@ Dodge. Always calculate this for combat characters.
 
 ## Character Sheet Output Format
 
-```
+```text
 [CHARACTER NAME]
 [Concept] — [Point Total] points
 
@@ -382,7 +382,7 @@ Unspent:         [x] pts
 For complex characters, build incrementally. After each step,
 present running point total and remaining budget:
 
-```
+```text
 After Step 2 (Attributes):
   Spent: 80 pts | Remaining: 120 pts of 200
 

--- a/tests/benchmark-questions/campaign-organizer.md
+++ b/tests/benchmark-questions/campaign-organizer.md
@@ -39,7 +39,7 @@ files? How does filesystem mode work?
 
 ```text
 You are a TTRPG campaign organizer. Read the skill entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-organizer/SKILL.md
+skills/campaign-organizer/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 
@@ -70,7 +70,7 @@ The skill entry point path is identical; the branch content differs.
 
 ```text
 You are a TTRPG campaign organizer. Read the skill entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-organizer/SKILL.md
+skills/campaign-organizer/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 

--- a/tests/benchmark-questions/campaign-organizer.md
+++ b/tests/benchmark-questions/campaign-organizer.md
@@ -37,7 +37,7 @@ files? How does filesystem mode work?
 
 ### Control prompt (baseline — current main branch)
 
-```
+```text
 You are a TTRPG campaign organizer. Read the skill entry point:
 /Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-organizer/SKILL.md
 Follow routing to find the right files for each question.
@@ -68,7 +68,7 @@ campaign files? How does filesystem mode work?
 Same as control prompt. Point at the feature branch checkout.
 The skill entry point path is identical; the branch content differs.
 
-```
+```text
 You are a TTRPG campaign organizer. Read the skill entry point:
 /Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-organizer/SKILL.md
 Follow routing to find the right files for each question.
@@ -96,7 +96,7 @@ campaign files? How does filesystem mode work?
 
 ### Evaluator prompt (blind scoring)
 
-```
+```text
 You are evaluating two TTRPG GM assistant responses. One is
 labelled A, one B. You do not know which is control or test.
 

--- a/tests/benchmark-questions/campaign-qa.md
+++ b/tests/benchmark-questions/campaign-qa.md
@@ -41,7 +41,7 @@ wiki-links, or missing relationship reciprocals?
 
 ### Control prompt (baseline — current main branch)
 
-```
+```text
 You are a TTRPG campaign auditor and quality analyst. Read the
 skill entry point:
 /Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-qa/SKILL.md
@@ -81,7 +81,7 @@ wiki-links, or missing relationship reciprocals?
 Same as control prompt. Point at the feature branch checkout.
 The skill entry point path is identical; the branch content differs.
 
-```
+```text
 You are a TTRPG campaign auditor and quality analyst. Read the
 skill entry point:
 /Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-qa/SKILL.md
@@ -118,7 +118,7 @@ wiki-links, or missing relationship reciprocals?
 
 ### Evaluator prompt (blind scoring)
 
-```
+```text
 You are evaluating two TTRPG GM assistant responses. One is
 labelled A, one B. You do not know which is control or test.
 

--- a/tests/benchmark-questions/campaign-qa.md
+++ b/tests/benchmark-questions/campaign-qa.md
@@ -44,12 +44,12 @@ wiki-links, or missing relationship reciprocals?
 ```text
 You are a TTRPG campaign auditor and quality analyst. Read the
 skill entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-qa/SKILL.md
+skills/campaign-qa/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 
 Also read the campaign files at:
-/Users/antonypegg/PROJECTS/gm-apprentice/tests/benchmark-campaign/
+tests/benchmark-campaign/
 Start with the index at _meta/index.md, then read entity files,
 session notes, and other campaign data as needed for each question.
 
@@ -84,12 +84,12 @@ The skill entry point path is identical; the branch content differs.
 ```text
 You are a TTRPG campaign auditor and quality analyst. Read the
 skill entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/campaign-qa/SKILL.md
+skills/campaign-qa/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 
 Also read the campaign files at:
-/Users/antonypegg/PROJECTS/gm-apprentice/tests/benchmark-campaign/
+tests/benchmark-campaign/
 Start with the index at _meta/index.md, then read entity files,
 session notes, and other campaign data as needed for each question.
 

--- a/tests/benchmark-questions/session-lifecycle.md
+++ b/tests/benchmark-questions/session-lifecycle.md
@@ -42,7 +42,7 @@ states.
 
 ### Control prompt (baseline — current main branch)
 
-```
+```text
 You are a TTRPG session lifecycle manager — the between-sessions
 workhorse that turns "we just finished playing" into organized
 canon and "we play next week" into solid prep. Read the skill
@@ -85,7 +85,7 @@ states.
 Same as control prompt. Point at the feature branch checkout.
 The skill entry point path is identical; the branch content differs.
 
-```
+```text
 You are a TTRPG session lifecycle manager — the between-sessions
 workhorse that turns "we just finished playing" into organized
 canon and "we play next week" into solid prep. Read the skill
@@ -125,7 +125,7 @@ states.
 
 ### Evaluator prompt (blind scoring)
 
-```
+```text
 You are evaluating two TTRPG GM assistant responses. One is
 labelled A, one B. You do not know which is control or test.
 

--- a/tests/benchmark-questions/session-lifecycle.md
+++ b/tests/benchmark-questions/session-lifecycle.md
@@ -47,12 +47,12 @@ You are a TTRPG session lifecycle manager — the between-sessions
 workhorse that turns "we just finished playing" into organized
 canon and "we play next week" into solid prep. Read the skill
 entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/session-lifecycle/SKILL.md
+skills/session-lifecycle/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 
 Also read the campaign files at:
-/Users/antonypegg/PROJECTS/gm-apprentice/tests/benchmark-campaign/
+tests/benchmark-campaign/
 Start with the index at _meta/index.md, then read session notes,
 PC roster, entity files, and timeline as needed for each question.
 
@@ -90,12 +90,12 @@ You are a TTRPG session lifecycle manager — the between-sessions
 workhorse that turns "we just finished playing" into organized
 canon and "we play next week" into solid prep. Read the skill
 entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/session-lifecycle/SKILL.md
+skills/session-lifecycle/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 
 Also read the campaign files at:
-/Users/antonypegg/PROJECTS/gm-apprentice/tests/benchmark-campaign/
+tests/benchmark-campaign/
 Start with the index at _meta/index.md, then read session notes,
 PC roster, entity files, and timeline as needed for each question.
 

--- a/tests/benchmark-questions/ttrpg-expert.md
+++ b/tests/benchmark-questions/ttrpg-expert.md
@@ -38,7 +38,7 @@ campaign. How do thread entities work, and create one for me.
 
 ### Control prompt (baseline — current main branch)
 
-```
+```text
 You are a TTRPG rules expert and campaign entity architect. Read
 the skill entry point:
 /Users/antonypegg/PROJECTS/gm-apprentice/skills/ttrpg-expert/SKILL.md
@@ -71,7 +71,7 @@ campaign. How do thread entities work, and create one for me.
 Same as control prompt. Point at the feature branch checkout.
 The skill entry point path is identical; the branch content differs.
 
-```
+```text
 You are a TTRPG rules expert and campaign entity architect. Read
 the skill entry point:
 /Users/antonypegg/PROJECTS/gm-apprentice/skills/ttrpg-expert/SKILL.md
@@ -101,7 +101,7 @@ campaign. How do thread entities work, and create one for me.
 
 ### Evaluator prompt (blind scoring)
 
-```
+```text
 You are evaluating two TTRPG GM assistant responses. One is
 labelled A, one B. You do not know which is control or test.
 

--- a/tests/benchmark-questions/ttrpg-expert.md
+++ b/tests/benchmark-questions/ttrpg-expert.md
@@ -41,7 +41,7 @@ campaign. How do thread entities work, and create one for me.
 ```text
 You are a TTRPG rules expert and campaign entity architect. Read
 the skill entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/ttrpg-expert/SKILL.md
+skills/ttrpg-expert/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 
@@ -74,7 +74,7 @@ The skill entry point path is identical; the branch content differs.
 ```text
 You are a TTRPG rules expert and campaign entity architect. Read
 the skill entry point:
-/Users/antonypegg/PROJECTS/gm-apprentice/skills/ttrpg-expert/SKILL.md
+skills/ttrpg-expert/SKILL.md
 Follow routing to find the right files for each question.
 Answer each question concisely (under 150 words each).
 


### PR DESCRIPTION
## Summary

- Fix `canon_status` → `source_confidence` in entity-schema.md example block
- Replace 12 hardcoded absolute paths in benchmark question files with repo-relative paths
- Add language tags to 19 untagged fenced code blocks across docs/ and tests/
- Replace future-work.md with force-ranked backlog (Regency Cthulhu at #1)
- Add GitHub Actions CI: markdownlint + consistency checks (hardcoded paths, schema naming drift)

## Test Plan

- [x] Grep confirms zero `canon_status:` in skills/ and tests/
- [x] Grep confirms zero `/Users/antonypegg` in skills/, docs/, tests/
- [x] Local markdownlint passes clean (147 files, 0 errors)
- [x] GitHub Actions CI passes on this PR