### PR TITLE
Upstream displayTitle + template overhaul from canticle patches

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
-- ~~Publish tool: displayTitle + template overhaul~~ — displayTitle on all page objects, data-driven `display_meta` PC meta row, Team/Fallen landing split with SVG status icons
+- ~~Publish tool: displayTitle + template overhaul~~ — displayTitle on all page objects, data-driven `display_meta` PC meta row, Team/Fallen landing split with SVG status icons (PR #25)
 - ~~CoC/BRP SRD enrichment (Phase 5a)~~ — already covered by v3 terminology fixes, 18 content files, Regency variant overlay
 - ~~Publish tool: Event dedicated template~~ — dedicated event template, vault template, session-lifecycle event decomposition (PR #20)
 - ~~Publish tool: Landing page dashboard~~ — hero, session recap, PC roster, key NPCs, explore grid

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Items are force-ranked by score. Higher score = do first.
 
 | Rank | Item | Impact | Urgency | Effort | Score | Status | Notes |
 |:----:|------|:------:|:-------:|:------:|:-----:|--------|-------|
-| 1 | Publish tool: displayTitle + template overhaul | 5 | 5 | S (1) | 15.0 | Patched | Upstream the node_modules patches: (1) scanner.js `displayTitle` replacing underscores with spaces, (2) all templates use `displayTitle` for rendering while keeping `title` for link resolution, (3) PC template replaces GURPS `point_total` with `age`/`nationality` fields, (4) landing page splits roster into active ("The Team") and dead/retired ("The Fallen"). Currently patched in canticle-of-the-end site repo — `npm install` will overwrite. |
+| 1 | ~~Publish tool: displayTitle + template overhaul~~ | 5 | 5 | S (1) | 15.0 | Done | |
 | 2 | ~~Publish tool: Landing page dashboard (recap, PC roster, key NPCs)~~ | 5 | 4 | M (2) | 7.0 | Done | |
 | 3 | Skill roles audit: clarify inter-skill relationships | 4 | 4 | M (2) | 6.0 | Idea | Review all 6 skill descriptions, routing, companion skill refs to ensure clear advisor/doer boundaries |
 | 4 | Pulp Cthulhu variant support | 4 | 4 | M (2) | 6.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality |
@@ -63,6 +63,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
+- ~~Publish tool: displayTitle + template overhaul~~ — displayTitle on all page objects, data-driven `display_meta` PC meta row, Team/Fallen landing split with SVG status icons
 - ~~CoC/BRP SRD enrichment (Phase 5a)~~ — already covered by v3 terminology fixes, 18 content files, Regency variant overlay
 - ~~Publish tool: Event dedicated template~~ — dedicated event template, vault template, session-lifecycle event decomposition (PR #20)
 - ~~Publish tool: Landing page dashboard~~ — hero, session recap, PC roster, key NPCs, explore grid

--- a/skills/publish-site/references/schema-reference.md
+++ b/skills/publish-site/references/schema-reference.md
@@ -25,8 +25,8 @@ These entity types have purpose-built page layouts.
 | `status` | Optional | active, retired, dead, npc |
 | `key_traits` | Optional | List of defining traits (shown on PC card and landing page) |
 | `player_name` | Optional | Real-world player name |
-| `point_total` | Optional | Character point total (defaults to 200) |
 | `portrait` | Optional | Path relative to vault root (e.g. `_attachments/characters/slug.jpg`) |
+| `display_meta` | Optional | Ordered list of frontmatter field names to show in the meta row (defaults to `[occupation, age, nationality]`) |
 
 The PC template renders all body content as collapsible accordion
 sections using the H2 headings as panel titles. Use H2 headings

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -334,7 +334,9 @@ during Dissect mode.
 (alive/dead/missing/unknown), `portrait` (optional)
 
 **PC:** `player_name`, `occupation`, `age`, `gender`, `nationality`,
-`status` (alive/dead/missing/unknown), `key_traits`, `portrait` (optional)
+`status` (alive/dead/missing/unknown), `key_traits`, `portrait` (optional),
+`display_meta` (optional array: ordered field names for published site meta row;
+defaults to `[occupation, age, nationality]` when omitted)
 
 **Location:** `location_type`, `parent_location` (wiki-link),
 `atmosphere`, `portrait` (optional)

--- a/skills/ttrpg-expert/systems/coc-7e/character-generation.md
+++ b/skills/ttrpg-expert/systems/coc-7e/character-generation.md
@@ -11,11 +11,14 @@ investigator from scratch.
 
 When creating a PC entity file, set `display_meta` to control
 which fields appear in the character's header on a published
-campaign site. CoC default:
+campaign site. Recommended for CoC:
 
 ```yaml
 display_meta: [occupation, age, nationality]
 ```
+
+If `display_meta` is omitted, the publish tool falls back to
+`[occupation, age, nationality]` (which matches this recommendation).
 
 ## Investigator Creation Workflow
 

--- a/skills/ttrpg-expert/systems/coc-7e/character-generation.md
+++ b/skills/ttrpg-expert/systems/coc-7e/character-generation.md
@@ -7,6 +7,16 @@
 Step-by-step guide for building a Call of Cthulhu 7th Edition
 investigator from scratch.
 
+## Published Site Defaults
+
+When creating a PC entity file, set `display_meta` to control
+which fields appear in the character's header on a published
+campaign site. CoC default:
+
+```yaml
+display_meta: [occupation, age, nationality]
+```
+
 ## Investigator Creation Workflow
 
 1. **Roll Characteristics** -- generate eight stats.

--- a/skills/ttrpg-expert/systems/dnd-5e-2024/character-generation.md
+++ b/skills/ttrpg-expert/systems/dnd-5e-2024/character-generation.md
@@ -6,11 +6,14 @@ Step-by-step creation from the SRD 5.2 (2024 revision).
 
 When creating a PC entity file, set `display_meta` to control
 which fields appear in the character's header on a published
-campaign site. D&D 5e default:
+campaign site. Recommended for D&D 5e:
 
 ```yaml
 display_meta: [class, level, race]
 ```
+
+If `display_meta` is omitted, the publish tool falls back to
+`[occupation, age, nationality]`.
 
 ## Creation Workflow
 

--- a/skills/ttrpg-expert/systems/dnd-5e-2024/character-generation.md
+++ b/skills/ttrpg-expert/systems/dnd-5e-2024/character-generation.md
@@ -2,6 +2,16 @@
 
 Step-by-step creation from the SRD 5.2 (2024 revision).
 
+## Published Site Defaults
+
+When creating a PC entity file, set `display_meta` to control
+which fields appear in the character's header on a published
+campaign site. D&D 5e default:
+
+```yaml
+display_meta: [class, level, race]
+```
+
 ## Creation Workflow
 
 1. **Choose a Class** -- pick from 12 core classes

--- a/skills/ttrpg-expert/systems/fitd/character-generation.md
+++ b/skills/ttrpg-expert/systems/fitd/character-generation.md
@@ -4,11 +4,14 @@
 
 When creating a PC entity file, set `display_meta` to control
 which fields appear in the character's header on a published
-campaign site. FitD default:
+campaign site. Recommended for FitD:
 
 ```yaml
 display_meta: [playbook, crew]
 ```
+
+If `display_meta` is omitted, the publish tool falls back to
+`[occupation, age, nationality]`.
 
 ## Character Creation (8 Steps)
 

--- a/skills/ttrpg-expert/systems/fitd/character-generation.md
+++ b/skills/ttrpg-expert/systems/fitd/character-generation.md
@@ -1,5 +1,15 @@
 # Forged in the Dark -- Character & Crew Generation
 
+## Published Site Defaults
+
+When creating a PC entity file, set `display_meta` to control
+which fields appear in the character's header on a published
+campaign site. FitD default:
+
+```yaml
+display_meta: [playbook, crew]
+```
+
 ## Character Creation (8 Steps)
 
 ### Step 1: Choose a Playbook

--- a/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
@@ -12,6 +12,16 @@ Comprehensive character creation assistant for GURPS 4th Edition.
 Supports any genre, power level, and campaign style. Works for
 both players building PCs and GMs drafting NPCs.
 
+## Published Site Defaults
+
+When creating a PC entity file, set `display_meta` to control
+which fields appear in the character's header on a published
+campaign site. GURPS default:
+
+```yaml
+display_meta: [point_total, age, TL]
+```
+
 ## Campaign Context Awareness
 
 The character generation workflow is context-sensitive. If the

--- a/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
@@ -16,11 +16,14 @@ both players building PCs and GMs drafting NPCs.
 
 When creating a PC entity file, set `display_meta` to control
 which fields appear in the character's header on a published
-campaign site. GURPS default:
+campaign site. Recommended for GURPS:
 
 ```yaml
 display_meta: [point_total, age, TL]
 ```
+
+If `display_meta` is omitted, the publish tool falls back to
+`[occupation, age, nationality]`.
 
 ## Campaign Context Awareness
 

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -601,6 +601,12 @@ td .stat {
 .status-alive { background: #d4edda; color: #155724; }
 .status-kia { background: #f8d7da; color: #721c24; }
 .status-mia { background: #fff3cd; color: #856404; }
+.fallen-icon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.3em;
+  opacity: 0.7;
+}
 .pc-traits {
   font-size: 0.8rem;
   color: var(--text-muted);

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -601,6 +601,7 @@ td .stat {
 .status-alive { background: #d4edda; color: #155724; }
 .status-kia { background: #f8d7da; color: #721c24; }
 .status-mia { background: #fff3cd; color: #856404; }
+.status-retired { background: #e2e3e5; color: #383d41; }
 .fallen-icon {
   display: inline-block;
   vertical-align: middle;

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -137,7 +137,7 @@ function renderRelationships(frontmatter, linkMap, currentOutputPath) {
   const items = valid.map(r => {
     const targetName = String(r.target).replace(/\[\[|\]\]/g, '');
     const targetPath = linkMap[targetName];
-    const escapedName = escapeHtml(targetName);
+    const escapedName = escapeHtml(targetName.replace(/_/g, ' '));
     const link = targetPath
       ? `<a href="${relativePath(currentDir, targetPath)}" class="entity-link">${escapedName}</a>`
       : escapedName;

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -57,6 +57,7 @@ function scanVault(config) {
         if (!outputDir && dirRel !== '') continue; // skip unmapped directories
 
         const baseName = path.basename(entry.name, '.md');
+        const displayTitle = baseName.replace(/_/g, ' ');
         const slug = slugify(baseName);
         const outputPath = outputDir
           ? outputDir + '/' + slug + '.html'
@@ -65,6 +66,7 @@ function scanVault(config) {
         pages.push({
           sourcePath: fullPath,
           title: baseName,
+          displayTitle,
           slug,
           outputPath,
           outputDir: outputDir || '',

--- a/tools/publish/lib/templates/creature.js
+++ b/tools/publish/lib/templates/creature.js
@@ -43,13 +43,13 @@ function creatureTemplate(page, processedContent, navFor, config, imageMap) {
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${badgeHtml}\n${statBlock}\n${abilities}\n${weaknesses}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/event.js
+++ b/tools/publish/lib/templates/event.js
@@ -54,7 +54,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
   ${metaHtml}
 </div>`;
 
@@ -90,7 +90,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
   const content = `${headerCard}\n${badgeHtml}\n${outcomeHtml}\n${participantsHtml}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/faction.js
+++ b/tools/publish/lib/templates/faction.js
@@ -63,7 +63,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
     const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
     const memberLinks = members.map(m => {
       const href = relativePath(currentDir, m.outputPath);
-      return `<li><a href="${href}">${escapeHtml(m.title)}</a></li>`;
+      return `<li><a href="${href}">${escapeHtml(m.displayTitle)}</a></li>`;
     }).join('\n');
     membersHtml = `<div class="members"><h3>Members</h3><ul>${memberLinks}</ul></div>`;
   }
@@ -71,13 +71,13 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${badgeHtml}\n${leadershipHtml}\n${territoryHtml}\n${goals}\n${membersHtml}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -14,7 +14,7 @@ function indexTemplate(outputDir, title, pages, navFor, config) {
           : relativePath(currentDir, p.outputPath);
         return `
 <div class="roster-card">
-  <h3><a href="${href}">${escapeHtml(p.title)}</a>${stubBadge(fm)}</h3>
+  <h3><a href="${href}">${escapeHtml(p.displayTitle)}</a>${stubBadge(fm)}</h3>
   ${subtitle ? `<div class="role">${escapeHtml(subtitle)}</div>` : ''}
 </div>`;
       }).join('\n')}</div>`

--- a/tools/publish/lib/templates/item.js
+++ b/tools/publish/lib/templates/item.js
@@ -59,13 +59,13 @@ function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap)
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${badgeHtml}\n${statBlock}\n${holderHtml}\n${originHtml}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -14,6 +14,7 @@ function statusClass(status) {
   const s = String(status).toLowerCase();
   if (s === 'dead' || s === 'deceased') return 'status-kia';
   if (s === 'missing' || s === 'unknown') return 'status-mia';
+  if (s === 'retired') return 'status-retired';
   return 'status-alive';
 }
 
@@ -22,8 +23,23 @@ function statusLabel(status) {
   const s = String(status).toLowerCase();
   if (s === 'dead' || s === 'deceased') return 'KIA';
   if (s === 'missing' || s === 'unknown') return 'MIA';
+  if (s === 'retired') return 'Retired';
   return 'Active';
 }
+
+const FALLEN_STATUSES = new Set(['dead', 'deceased', 'retired', 'unknown', 'missing']);
+
+const SVG_SKULL = '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="9" r="7"/><rect x="9" y="16" width="6" height="4" rx="1"/><circle cx="9.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><circle cx="14.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><path d="M9 12 h1.5 L12 11 l1.5 1 H15" stroke="var(--bg, #fff)" stroke-width="0.8" fill="none"/></svg>';
+const SVG_SUNSET = '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="16" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M4 16 Q8 8 12 10 Q16 8 20 16" fill="currentColor" opacity="0.6"/><line x1="12" y1="4" x2="12" y2="10" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="5" x2="10" y2="9" stroke="currentColor" stroke-width="1"/><line x1="16" y1="5" x2="14" y2="9" stroke="currentColor" stroke-width="1"/></svg>';
+const SVG_QUESTION = '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" fill="currentColor">?</text></svg>';
+
+const FALLEN_ICONS = {
+  dead: SVG_SKULL,
+  deceased: SVG_SKULL,
+  retired: SVG_SUNSET,
+  unknown: SVG_QUESTION,
+  missing: SVG_QUESTION,
+};
 
 function landingTemplate(pages, navFor, config, publishConfig) {
   const outputPath = 'index.html';
@@ -81,19 +97,9 @@ function landingTemplate(pages, navFor, config, publishConfig) {
   }
 
   // --- The Team / The Fallen ---
-  const FALLEN_STATUSES = new Set(['dead', 'deceased', 'retired', 'unknown', 'missing']);
-
   const allPCs = getPCs(pages);
   const activePCs = allPCs.filter(pc => !FALLEN_STATUSES.has(String(pc.frontmatter.status || '').toLowerCase()));
   const fallenPCs = allPCs.filter(pc => FALLEN_STATUSES.has(String(pc.frontmatter.status || '').toLowerCase()));
-
-  const FALLEN_ICONS = {
-    dead: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="9" r="7"/><rect x="9" y="16" width="6" height="4" rx="1"/><circle cx="9.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><circle cx="14.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><path d="M9 12 h1.5 L12 11 l1.5 1 H15" stroke="var(--bg, #fff)" stroke-width="0.8" fill="none"/></svg>',
-    deceased: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="9" r="7"/><rect x="9" y="16" width="6" height="4" rx="1"/><circle cx="9.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><circle cx="14.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><path d="M9 12 h1.5 L12 11 l1.5 1 H15" stroke="var(--bg, #fff)" stroke-width="0.8" fill="none"/></svg>',
-    retired: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="16" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M4 16 Q8 8 12 10 Q16 8 20 16" fill="currentColor" opacity="0.6"/><line x1="12" y1="4" x2="12" y2="10" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="5" x2="10" y2="9" stroke="currentColor" stroke-width="1"/><line x1="16" y1="5" x2="14" y2="9" stroke="currentColor" stroke-width="1"/></svg>',
-    unknown: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" fill="currentColor">?</text></svg>',
-    missing: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" fill="currentColor">?</text></svg>',
-  };
 
   function renderPCCards(pcs, showFallenIcon) {
     return pcs.map(pc => {

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -80,11 +80,23 @@ function landingTemplate(pages, navFor, config, publishConfig) {
 </div>`;
   }
 
-  // --- The Team ---
-  const pcs = getPCs(pages);
-  let rosterHtml = '';
-  if (pcs.length > 0) {
-    const pcCards = pcs.map(pc => {
+  // --- The Team / The Fallen ---
+  const FALLEN_STATUSES = new Set(['dead', 'deceased', 'retired', 'unknown']);
+
+  const allPCs = getPCs(pages);
+  const activePCs = allPCs.filter(pc => !FALLEN_STATUSES.has(String(pc.frontmatter.status || '').toLowerCase()));
+  const fallenPCs = allPCs.filter(pc => FALLEN_STATUSES.has(String(pc.frontmatter.status || '').toLowerCase()));
+
+  const FALLEN_ICONS = {
+    dead: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="9" r="7"/><rect x="9" y="16" width="6" height="4" rx="1"/><circle cx="9.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><circle cx="14.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><path d="M9 12 h1.5 L12 11 l1.5 1 H15" stroke="var(--bg, #fff)" stroke-width="0.8" fill="none"/></svg>',
+    deceased: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="9" r="7"/><rect x="9" y="16" width="6" height="4" rx="1"/><circle cx="9.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><circle cx="14.5" cy="8" r="1.5" fill="var(--bg, #fff)"/><path d="M9 12 h1.5 L12 11 l1.5 1 H15" stroke="var(--bg, #fff)" stroke-width="0.8" fill="none"/></svg>',
+    retired: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="16" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M4 16 Q8 8 12 10 Q16 8 20 16" fill="currentColor" opacity="0.6"/><line x1="12" y1="4" x2="12" y2="10" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="5" x2="10" y2="9" stroke="currentColor" stroke-width="1"/><line x1="16" y1="5" x2="14" y2="9" stroke="currentColor" stroke-width="1"/></svg>',
+    unknown: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" fill="currentColor">?</text></svg>',
+    missing: '<svg class="fallen-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" fill="currentColor">?</text></svg>',
+  };
+
+  function renderPCCards(pcs, showFallenIcon) {
+    return pcs.map(pc => {
       const fm = pc.frontmatter;
       const initials = getInitials(pc.displayTitle);
       const attachPrefix = (config.attachmentsDir || '_attachments') + '/';
@@ -98,20 +110,34 @@ function landingTemplate(pages, navFor, config, publishConfig) {
         ? fm.key_traits.join(' \u00b7 ')
         : (fm.occupation || '');
       const link = pc.outputPath || '#';
+      const fallenIcon = showFallenIcon ? (FALLEN_ICONS[String(fm.status || '').toLowerCase()] || '') : '';
       return `
 <div class="pc-card">
   ${portrait}
-  <h3><a href="${escapeHtml(link)}">${escapeHtml(pc.displayTitle)}</a></h3>
+  <h3>${fallenIcon}<a href="${escapeHtml(link)}">${escapeHtml(pc.displayTitle)}</a></h3>
   ${badge}
   <div class="pc-traits">${escapeHtml(traits)}</div>
 </div>`;
     }).join('\n');
+  }
 
-    rosterHtml = `
+  let rosterHtml = '';
+  if (activePCs.length > 0) {
+    rosterHtml += `
 <div class="dashboard-section">
   <h2>The Team</h2>
   <div class="pc-roster">
-    ${pcCards}
+    ${renderPCCards(activePCs, false)}
+  </div>
+</div>`;
+  }
+
+  if (fallenPCs.length > 0) {
+    rosterHtml += `
+<div class="dashboard-section">
+  <h2>The Fallen</h2>
+  <div class="pc-roster">
+    ${renderPCCards(fallenPCs, true)}
   </div>
 </div>`;
   }

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -81,7 +81,7 @@ function landingTemplate(pages, navFor, config, publishConfig) {
   }
 
   // --- The Team / The Fallen ---
-  const FALLEN_STATUSES = new Set(['dead', 'deceased', 'retired', 'unknown']);
+  const FALLEN_STATUSES = new Set(['dead', 'deceased', 'retired', 'unknown', 'missing']);
 
   const allPCs = getPCs(pages);
   const activePCs = allPCs.filter(pc => !FALLEN_STATUSES.has(String(pc.frontmatter.status || '').toLowerCase()));

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -86,12 +86,12 @@ function landingTemplate(pages, navFor, config, publishConfig) {
   if (pcs.length > 0) {
     const pcCards = pcs.map(pc => {
       const fm = pc.frontmatter;
-      const initials = getInitials(pc.title);
+      const initials = getInitials(pc.displayTitle);
       const attachPrefix = (config.attachmentsDir || '_attachments') + '/';
       const portraitStr = fm.portrait ? String(fm.portrait) : '';
       const portraitRel = portraitStr.startsWith(attachPrefix) ? portraitStr.slice(attachPrefix.length) : portraitStr;
       const portrait = fm.portrait
-        ? `<div class="pc-portrait"><img src="images/${escapeHtml(portraitRel)}" alt="${escapeHtml(pc.title)}"></div>`
+        ? `<div class="pc-portrait"><img src="images/${escapeHtml(portraitRel)}" alt="${escapeHtml(pc.displayTitle)}"></div>`
         : `<div class="pc-portrait">${escapeHtml(initials)}</div>`;
       const badge = `<span class="status-badge ${statusClass(fm.status)}">${statusLabel(fm.status)}</span>`;
       const traits = fm.key_traits
@@ -101,7 +101,7 @@ function landingTemplate(pages, navFor, config, publishConfig) {
       return `
 <div class="pc-card">
   ${portrait}
-  <h3><a href="${escapeHtml(link)}">${escapeHtml(pc.title)}</a></h3>
+  <h3><a href="${escapeHtml(link)}">${escapeHtml(pc.displayTitle)}</a></h3>
   ${badge}
   <div class="pc-traits">${escapeHtml(traits)}</div>
 </div>`;
@@ -122,14 +122,14 @@ function landingTemplate(pages, navFor, config, publishConfig) {
   if (scoredNPCs.length > 0) {
     const npcCards = scoredNPCs.map(({ page, role }) => {
       const fm = page.frontmatter;
-      const initials = getInitials(page.title);
+      const initials = getInitials(page.displayTitle);
       const roleText = fm.occupation ? `${role} \u00b7 ${fm.occupation}` : role;
       const link = page.outputPath || '#';
       return `
 <div class="npc-card">
   <div class="npc-icon">${escapeHtml(initials)}</div>
   <div class="npc-info">
-    <h4><a href="${escapeHtml(link)}">${escapeHtml(page.title)}</a></h4>
+    <h4><a href="${escapeHtml(link)}">${escapeHtml(page.displayTitle)}</a></h4>
     <span class="npc-role">${escapeHtml(roleText)}</span>
   </div>
 </div>`;

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -15,19 +15,19 @@ function locationTemplate(page, processedContent, navFor, config, imageMap) {
     : '';
 
   const breadcrumb = fm.parent_location
-    ? `<div class="breadcrumb">${escapeHtml(fm.parent_location.replace(/\[\[|\]\]/g, ''))} <span class="sep">&rsaquo;</span> ${escapeHtml(page.title)}</div>`
+    ? `<div class="breadcrumb">${escapeHtml(fm.parent_location.replace(/\[\[|\]\]/g, '').replace(/_/g, ' '))} <span class="sep">&rsaquo;</span> ${escapeHtml(page.displayTitle)}</div>`
     : '';
 
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${breadcrumb}\n${badgeHtml}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/nav.js
+++ b/tools/publish/lib/templates/nav.js
@@ -25,7 +25,7 @@ function generateNav(pages) {
       for (const p of [...dirPages].sort((a, b) => a.title.localeCompare(b.title))) {
         const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));
         const href = relativePath(currentDir, p.outputPath);
-        html += `<li><a href="${escapeHtml(href)}">${escapeHtml(p.title)}</a></li>\n`;
+        html += `<li><a href="${escapeHtml(href)}">${escapeHtml(p.displayTitle)}</a></li>\n`;
       }
       html += `</ul>\n`;
     }

--- a/tools/publish/lib/templates/nav.js
+++ b/tools/publish/lib/templates/nav.js
@@ -22,7 +22,7 @@ function generateNav(pages) {
       }
       if (dirPages.length === 0) continue;
       html += `<h2>${escapeHtml(label)}</h2>\n<ul>\n`;
-      for (const p of [...dirPages].sort((a, b) => a.title.localeCompare(b.title))) {
+      for (const p of [...dirPages].sort((a, b) => a.displayTitle.localeCompare(b.displayTitle))) {
         const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));
         const href = relativePath(currentDir, p.outputPath);
         html += `<li><a href="${escapeHtml(href)}">${escapeHtml(p.displayTitle)}</a></li>\n`;

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -8,7 +8,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap) {
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
   <div class="meta">
     ${fm.occupation ? `<span><span class="label">Role</span> ${escapeHtml(fm.occupation)}</span>` : ''}
     ${fm.nationality ? `<span><span class="label">Nationality</span> ${escapeHtml(fm.nationality)}</span>` : ''}
@@ -21,7 +21,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap) {
   const content = `${headerCard}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -1,21 +1,37 @@
 const { escapeHtml } = require('../processor');
 const { baseShell, cssPath, rootPath, portraitImg } = require('./base');
 
+const DEFAULT_META_FIELDS = ['occupation', 'age', 'nationality'];
+
+function formatLabel(fieldName) {
+  return fieldName
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function renderMetaSpans(fm) {
+  const fields = Array.isArray(fm.display_meta) ? fm.display_meta : DEFAULT_META_FIELDS;
+  return fields
+    .filter(field => fm[field] != null && fm[field] !== '')
+    .map(field => `<span><span class="label">${escapeHtml(formatLabel(field))}</span> ${escapeHtml(String(fm[field]))}</span>`)
+    .join('\n    ');
+}
+
 function pcTemplate(page, processedContent, sections, navFor, config, imageMap) {
   const fm = page.frontmatter;
   const traits = fm.key_traits
     ? escapeHtml(Array.isArray(fm.key_traits) ? fm.key_traits.join(', ') : String(fm.key_traits))
     : '';
   const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const metaSpans = renderMetaSpans(fm);
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.title)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}</h1>
   <p class="concept">${traits}</p>
   <div class="meta">
     <span><span class="label">Player</span> ${escapeHtml(fm.player_name || '')}</span>
-    <span><span class="label">Points</span> ${escapeHtml(String(fm.point_total || 200))}/200</span>
-    <span><span class="label">Background</span> ${escapeHtml(fm.occupation || '')}</span>
+    ${metaSpans}
     <span><span class="label">Status</span> ${escapeHtml(fm.status || 'active')}</span>
   </div>
 </div>`;
@@ -35,7 +51,7 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap) 
   const content = `${headerCard}\n${sectionNav}\n${accordions}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -6,10 +6,10 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap) {
   const badges = metadataBadgesFor(fm);
   const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
 
-  const content = `<h1 class="page-title">${escapeHtml(page.title)}${stubBadge(fm)}</h1>\n${portrait}\n${badges}\n${processedContent.html}\n${processedContent.relationships}`;
+  const content = `<h1 class="page-title">${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>\n${portrait}\n${badges}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
-    title: page.title,
+    title: page.displayTitle,
     siteTitle: config.siteTitle,
     cssHref: cssPath(page.outputPath),
     navHtml: navFor(page.outputPath),

--- a/tools/publish/test/fixtures/minimal/Characters/PCs/Meta_PC.md
+++ b/tools/publish/test/fixtures/minimal/Characters/PCs/Meta_PC.md
@@ -1,0 +1,20 @@
+---
+type: pc
+player_name: Meta Tester
+status: active
+occupation: Scholar
+age: 28
+nationality: French
+point_total: 150
+TL: 6
+display_meta:
+  - point_total
+  - age
+  - TL
+key_traits:
+  - Curious
+---
+
+# Meta_PC
+
+A character testing display_meta rendering.

--- a/tools/publish/test/fixtures/minimal/Characters/PCs/Underscored_Name.md
+++ b/tools/publish/test/fixtures/minimal/Characters/PCs/Underscored_Name.md
@@ -1,0 +1,9 @@
+---
+type: pc
+player_name: Tester
+status: active
+---
+
+# Underscored_Name
+
+Test fixture for underscore replacement.

--- a/tools/publish/test/fixtures/with-dashboard/Characters/PCs/Dead_PC.md
+++ b/tools/publish/test/fixtures/with-dashboard/Characters/PCs/Dead_PC.md
@@ -1,0 +1,13 @@
+---
+type: pc
+player_name: Player Three
+status: dead
+occupation: Field Medic
+key_traits:
+  - Selfless
+  - Stubborn
+---
+
+# Dead_PC
+
+A field medic who gave everything.

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -62,6 +62,15 @@ describe('build integration', () => {
       assert.ok(html.includes('Test Player'));
     });
 
+    it('PC page renders display_meta fields', () => {
+      const pcPath = path.join(outputDir, 'docs', 'characters', 'pcs', 'meta-pc.html');
+      assert.ok(fs.existsSync(pcPath));
+      const html = fs.readFileSync(pcPath, 'utf-8');
+      assert.ok(html.includes('Point Total'), 'Should render point_total label');
+      assert.ok(html.includes('150'), 'Should render point_total value');
+      assert.ok(html.includes('Meta PC'), 'Should render displayTitle without underscores');
+    });
+
     it('creates NPC page', () => {
       const npcPath = path.join(outputDir, 'docs', 'characters', 'npcs', 'test-npc.html');
       assert.ok(fs.existsSync(npcPath));

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -857,10 +857,11 @@ describe('build integration', () => {
 
     it('active PCs appear in The Team, not The Fallen', () => {
       const html = fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
-      // Find The Team section and verify Guy LeFleur is in it
-      const teamMatch = html.match(/The Team[\s\S]*?<\/div>\s*<\/div>/);
-      const teamHtml = teamMatch ? teamMatch[0] : '';
-      assert.ok(teamHtml.includes('Guy LeFleur'), 'Active PC should be in The Team');
+      const fallenIdx = html.indexOf('The Fallen');
+      assert.ok(fallenIdx !== -1, 'The Fallen section should exist');
+      const fallenHtml = html.slice(fallenIdx);
+      assert.ok(!fallenHtml.includes('Guy LeFleur'), 'Active PC should not be in The Fallen');
+      assert.ok(html.includes('Guy LeFleur'), 'Active PC should appear on the page');
     });
   });
 

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -828,6 +828,31 @@ describe('build integration', () => {
       const exploreGridHtml = exploreGridMatch ? exploreGridMatch[1] : '';
       assert.ok(!exploreGridHtml.includes('>Player Characters<'));
     });
+
+    it('landing page shows The Fallen section for dead PCs', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
+      assert.ok(html.includes('The Fallen'));
+    });
+
+    it('fallen section contains dead PC with displayTitle (no underscores)', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
+      assert.ok(html.includes('Dead PC'), 'Should show displayTitle without underscores');
+      assert.ok(!html.includes('>Dead_PC<'), 'Should not show raw filename with underscores');
+    });
+
+    it('fallen cards include SVG status icons', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
+      assert.ok(html.includes('fallen-icon'), 'Should include fallen icon element');
+      assert.ok(html.includes('<svg'), 'Should include inline SVG');
+    });
+
+    it('active PCs appear in The Team, not The Fallen', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
+      // Find The Team section and verify Guy LeFleur is in it
+      const teamMatch = html.match(/The Team[\s\S]*?<\/div>\s*<\/div>/);
+      const teamHtml = teamMatch ? teamMatch[0] : '';
+      assert.ok(teamHtml.includes('Guy LeFleur'), 'Active PC should be in The Team');
+    });
   });
 
   describe('auto-exclude fixture', () => {

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { escapeHtml, relativePath, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, filterFields } = require('../../lib/processor');
+const { escapeHtml, relativePath, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, filterFields, renderRelationships } = require('../../lib/processor');
 
 describe('escapeHtml', () => {
   it('escapes angle brackets', () => {
@@ -168,5 +168,19 @@ describe('filterFields', () => {
     const fm = { type: 'npc', secrets: 'Still here' };
     const result = filterFields(fm, []);
     assert.deepStrictEqual(result, { type: 'npc', secrets: 'Still here' });
+  });
+});
+
+describe('renderRelationships', () => {
+  it('replaces underscores with spaces in target display text', () => {
+    const frontmatter = {
+      relationships: [
+        { target: '[[Captain_James_Harker]]', type: 'allied_with' },
+      ],
+    };
+    const linkMap = {};
+    const result = renderRelationships(frontmatter, linkMap, 'characters/pcs/test.html');
+    assert.ok(result.includes('Captain James Harker'), 'Should display underscores as spaces');
+    assert.ok(!result.includes('Captain_James_Harker'), 'Should not contain raw underscored name');
   });
 });

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -1,6 +1,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { slugify, mapFolder, buildLinkMap } = require('../../lib/scanner');
+const path = require('path');
+const { slugify, mapFolder, buildLinkMap, scanVault } = require('../../lib/scanner');
 
 describe('slugify', () => {
   it('converts to lowercase', () => {
@@ -81,5 +82,32 @@ describe('buildLinkMap', () => {
     ];
     const map = buildLinkMap(pages);
     assert.strictEqual(map['Old Name'], 'new.html');
+  });
+});
+
+describe('scanVault displayTitle', () => {
+  const fixturesDir = path.join(__dirname, '..', 'fixtures', 'minimal');
+  const config = {
+    vaultPath: fixturesDir,
+    excludeDirs: ['_meta', '_Templates'],
+    folderMap: {
+      '_Campaign': 'campaign',
+      'Characters/PCs': 'characters/pcs',
+      'Characters/NPCs': 'characters/npcs',
+      'Locations': 'locations',
+    },
+  };
+
+  it('sets displayTitle with underscores replaced by spaces', () => {
+    const pages = scanVault(config);
+    const pc = pages.find(p => p.title === 'Test PC');
+    assert.ok(pc, 'Test PC page should exist');
+    assert.strictEqual(pc.displayTitle, 'Test PC');
+  });
+
+  it('preserves title as raw filename for link resolution', () => {
+    const pages = scanVault(config);
+    const pc = pages.find(p => p.title === 'Test PC');
+    assert.strictEqual(pc.title, 'Test PC');
   });
 });

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -100,14 +100,14 @@ describe('scanVault displayTitle', () => {
 
   it('sets displayTitle with underscores replaced by spaces', () => {
     const pages = scanVault(config);
-    const pc = pages.find(p => p.title === 'Test PC');
-    assert.ok(pc, 'Test PC page should exist');
-    assert.strictEqual(pc.displayTitle, 'Test PC');
+    const pc = pages.find(p => p.title === 'Underscored_Name');
+    assert.ok(pc, 'Underscored_Name page should exist');
+    assert.strictEqual(pc.displayTitle, 'Underscored Name');
   });
 
   it('preserves title as raw filename for link resolution', () => {
     const pages = scanVault(config);
-    const pc = pages.find(p => p.title === 'Test PC');
-    assert.strictEqual(pc.title, 'Test PC');
+    const pc = pages.find(p => p.title === 'Underscored_Name');
+    assert.strictEqual(pc.title, 'Underscored_Name');
   });
 });

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -108,6 +108,7 @@ describe('scanVault displayTitle', () => {
   it('preserves title as raw filename for link resolution', () => {
     const pages = scanVault(config);
     const pc = pages.find(p => p.title === 'Underscored_Name');
+    assert.ok(pc, 'Underscored_Name page should exist');
     assert.strictEqual(pc.title, 'Underscored_Name');
   });
 });

--- a/tools/publish/test/unit/templates.test.js
+++ b/tools/publish/test/unit/templates.test.js
@@ -117,3 +117,37 @@ describe('parseParticipant', () => {
     assert.strictEqual(result.isLink, true);
   });
 });
+
+describe('displayTitle usage', () => {
+  const { npcTemplate } = require('../../lib/templates/npc');
+  const { wikiTemplate } = require('../../lib/templates/wiki');
+
+  const mockNavFor = () => '';
+  const mockConfig = { siteTitle: 'Test', attachmentsDir: '_attachments' };
+
+  it('npc template uses displayTitle in heading', () => {
+    const page = {
+      title: 'Captain_James',
+      displayTitle: 'Captain James',
+      outputPath: 'characters/npcs/captain-james.html',
+      frontmatter: { type: 'npc' },
+    };
+    const processed = { html: '<p>Content</p>', relationships: '' };
+    const html = npcTemplate(page, processed, mockNavFor, mockConfig, {});
+    assert.ok(html.includes('<h1>Captain James'), 'Should use displayTitle in h1');
+    assert.ok(!html.includes('<h1>Captain_James'), 'Should not use raw title in h1');
+  });
+
+  it('wiki template uses displayTitle in heading', () => {
+    const page = {
+      title: 'Old_Fortress',
+      displayTitle: 'Old Fortress',
+      outputPath: 'locations/old-fortress.html',
+      frontmatter: { type: 'document' },
+    };
+    const processed = { html: '<p>Content</p>', relationships: '' };
+    const html = wikiTemplate(page, processed, mockNavFor, mockConfig, {});
+    assert.ok(html.includes('Old Fortress'), 'Should use displayTitle');
+    assert.ok(!html.includes('Old_Fortress'), 'Should not use raw title');
+  });
+});

--- a/tools/publish/test/unit/templates.test.js
+++ b/tools/publish/test/unit/templates.test.js
@@ -118,6 +118,94 @@ describe('parseParticipant', () => {
   });
 });
 
+describe('PC template display_meta', () => {
+  const { pcTemplate } = require('../../lib/templates/pc');
+
+  const mockNavFor = () => '';
+  const mockConfig = { siteTitle: 'Test', attachmentsDir: '_attachments' };
+
+  it('renders display_meta fields when set', () => {
+    const page = {
+      title: 'Test_Hero',
+      displayTitle: 'Test Hero',
+      outputPath: 'characters/pcs/test-hero.html',
+      frontmatter: {
+        type: 'pc',
+        player_name: 'Alice',
+        status: 'active',
+        point_total: 200,
+        age: 34,
+        TL: 8,
+        display_meta: ['point_total', 'age', 'TL'],
+      },
+    };
+    const processed = { html: '', relationships: '' };
+    const html = pcTemplate(page, processed, [], mockNavFor, mockConfig, {});
+    assert.ok(html.includes('Point Total'), 'Should render point_total label as title case');
+    assert.ok(html.includes('200'), 'Should render point_total value');
+    assert.ok(html.includes('Age'), 'Should render age label');
+    assert.ok(html.includes('34'), 'Should render age value');
+    assert.ok(html.includes('TL'), 'Should render TL label');
+    assert.ok(html.includes('8'), 'Should render TL value');
+  });
+
+  it('falls back to occupation/age/nationality when display_meta not set', () => {
+    const page = {
+      title: 'Fallback Hero',
+      displayTitle: 'Fallback Hero',
+      outputPath: 'characters/pcs/fallback-hero.html',
+      frontmatter: {
+        type: 'pc',
+        player_name: 'Bob',
+        status: 'active',
+        occupation: 'Detective',
+        age: 42,
+        nationality: 'British',
+      },
+    };
+    const processed = { html: '', relationships: '' };
+    const html = pcTemplate(page, processed, [], mockNavFor, mockConfig, {});
+    assert.ok(html.includes('Occupation'), 'Should show occupation label');
+    assert.ok(html.includes('Detective'), 'Should show occupation value');
+    assert.ok(html.includes('Age'), 'Should show age label');
+    assert.ok(html.includes('42'), 'Should show age value');
+    assert.ok(html.includes('Nationality'), 'Should show nationality label');
+    assert.ok(html.includes('British'), 'Should show nationality value');
+  });
+
+  it('skips missing fields silently', () => {
+    const page = {
+      title: 'Sparse Hero',
+      displayTitle: 'Sparse Hero',
+      outputPath: 'characters/pcs/sparse-hero.html',
+      frontmatter: {
+        type: 'pc',
+        player_name: 'Carol',
+        status: 'active',
+        display_meta: ['occupation', 'age', 'missing_field'],
+        occupation: 'Spy',
+      },
+    };
+    const processed = { html: '', relationships: '' };
+    const html = pcTemplate(page, processed, [], mockNavFor, mockConfig, {});
+    assert.ok(html.includes('Occupation'), 'Should show occupation');
+    assert.ok(html.includes('Spy'), 'Should show occupation value');
+    assert.ok(!html.includes('Missing Field'), 'Should not show missing_field label');
+  });
+
+  it('uses displayTitle in h1 and page title', () => {
+    const page = {
+      title: 'Captain_Hero',
+      displayTitle: 'Captain Hero',
+      outputPath: 'characters/pcs/captain-hero.html',
+      frontmatter: { type: 'pc', player_name: 'Dan', status: 'active' },
+    };
+    const processed = { html: '', relationships: '' };
+    const html = pcTemplate(page, processed, [], mockNavFor, mockConfig, {});
+    assert.ok(html.includes('<h1>Captain Hero</h1>'), 'Should use displayTitle in h1');
+  });
+});
+
 describe('displayTitle usage', () => {
   const { npcTemplate } = require('../../lib/templates/npc');
   const { wikiTemplate } = require('../../lib/templates/wiki');


### PR DESCRIPTION
## Summary

- **displayTitle**: Scanner produces `displayTitle` (underscores → spaces) on every page object; all 11 templates use it for rendering while `title` stays for link resolution. Processor relationship links also get underscore → space treatment.
- **Landing page Team/Fallen split**: PC roster splits into "The Team" (active) and "The Fallen" (dead/deceased/retired/unknown/missing) with inline SVG status category icons (skull, sunset, question mark).
- **Data-driven PC meta row**: New optional `display_meta` frontmatter array controls which fields render in the PC header. Falls back to `[occupation, age, nationality]`. Labels are title-cased with underscores → spaces. Replaces hardcoded GURPS `point_total`.
- **Schema + system references**: `display_meta` documented in entity schema, publish-site schema reference, and per-system character generation files (CoC 7e, GURPS 4e, D&D 5e, FitD).

Closes roadmap item #1 (score 15.0). Upstreams the node_modules patches from canticle-of-the-end so `npm install` no longer overwrites them.

## Test plan

- [x] 254/254 unit + integration tests pass
- [x] Schema validator passes (26 files)
- [ ] Rebuild canticle-of-the-end site with updated package and verify displayTitle, Team/Fallen split, and display_meta render correctly
- [ ] Verify `npm install` in canticle-of-the-end no longer requires manual patching