### PR TITLE
Add image handling to vault-ingest skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,35 +31,38 @@ Items are force-ranked by score. Higher score = do first.
 
 ## The List
 
-| Rank | Item | Impact | Urgency | Effort | Score | Status | Notes |
-|:----:|------|:------:|:-------:|:------:|:-----:|--------|-------|
-| 1 | ~~Publish tool: displayTitle + template overhaul~~ | 5 | 5 | S (1) | 15.0 | Done | |
-| 2 | ~~Publish tool: Landing page dashboard (recap, PC roster, key NPCs)~~ | 5 | 4 | M (2) | 7.0 | Done | |
-| 3 | Skill roles audit: clarify inter-skill relationships | 4 | 4 | M (2) | 6.0 | Idea | Review all 6 skill descriptions, routing, companion skill refs to ensure clear advisor/doer boundaries |
-| 4 | Pulp Cthulhu variant support | 4 | 4 | M (2) | 6.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality |
-| 5 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
-| 6 | Publish tool: per-page header banner | 2 | 1 | S (1) | 5.0 | Idea | Custom banner image per page via frontmatter |
-| 7 | Decompose arc-spotlight reference into focused files | 2 | 1 | S (1) | 5.0 | Experiment | Split arc-spotlight-reference.md into arc-model.md, spotlight-planning.md, touchpoint-framework.md for token efficiency |
-| 8 | ~~Publish tool: Event dedicated template~~ | 3 | 2 | M (2) | 4.0 | Done | |
-| 9 | Publish tool: layout options (sidebar vs top nav, card grid vs list) | 3 | 2 | M (2) | 4.0 | Idea | Site-wide config for nav style and index page layout |
-| 10 | Publish tool: Landing page timeline snippet (recent campaign events) | 3 | 2 | M (2) | 4.0 | Idea | Visual timeline of recent events on the landing page |
-| 11 | ~~CoC/BRP SRD enrichment (Phase 5a)~~ | 4 | 3 | L (3) | 3.7 | Done | |
-| 12 | Publish tool: Timeline auto-generation from events/sessions | 3 | 1 | M (2) | 3.5 | Idea | Generate timeline page from event/session dates in frontmatter |
-| 13 | Publish tool: Full-text client-side search (lunr) | 3 | 1 | M (2) | 3.5 | Idea | Client-side search index so players can find content in published site |
-| 14 | FitD SRD enrichment (Phase 5b) | 2 | 2 | M (2) | 3.0 | Planned | Expand FitD files to GURPS-level depth: more factions, crew types, entanglements |
-| 15 | Publish tool: Chapter/Session/Scene templates + hierarchy nav | 3 | 2 | L (3) | 2.7 | Idea | Dedicated templates for narrative hierarchy with parent/child nav |
-| 16 | Character sheet templates | 2 | 1 | M (2) | 2.5 | Idea | Printable/viewable character sheet templates per system in published site |
-| 17 | Skill description optimization | 2 | 1 | M (2) | 2.5 | Idea | Marketplace description and SKILL.md routing improvements for discoverability |
-| 18 | Publish tool: Clue dedicated template | 2 | 1 | M (2) | 2.5 | Idea | Template for clue entities with status, linked scenes, discovery conditions |
-| 19 | Publish tool: Document dedicated template | 2 | 1 | M (2) | 2.5 | Idea | Template for in-world documents (letters, newspapers, journals) |
-| 20 | Publish tool: Tag-based browsing (tag index pages) | 2 | 1 | M (2) | 2.5 | Idea | Auto-generated index pages per tag from frontmatter |
-| 21 | Eval suite for all skills | 3 | 1 | L (3) | 2.3 | Idea | Extend benchmark methodology to all 7 skills, not just ttrpg-expert |
-| 22 | Publish tool: Relationship graph visualisation | 3 | 1 | L (3) | 2.3 | Idea | Interactive graph of entity relationships (d3/force-directed) |
-| 23 | Publish tool: full site identity (logo variants, social preview) | 3 | 1 | L (3) | 2.3 | Idea | Logo generation, og:image, social card previews for shared links |
-| 24 | D&D SRD enrichment (Phase 5c) | 2 | 2 | L (3) | 2.0 | Planned | Expand D&D files: more monster stat blocks, subclass features, encounter building |
-| 25 | PDF-to-markdown converter | 3 | 1 | XL (4) | 1.8 | Idea | Tool to convert published adventure PDFs into vault-compatible markdown |
-| 26 | Auto-download SRDs on setup | 1 | 1 | M (2) | 1.5 | Idea | First-run script to fetch CC-BY SRDs (D&D 5.2, FitD) into systems/ |
-| 27 | Publish tool: favicon generation from campaign image | 1 | 1 | M (2) | 1.5 | Idea | Auto-generate favicon from campaign hero image during publish |
+| Item | Impact | Urgency | Effort | Score | Status | Notes |
+|------|:------:|:-------:|:------:|:-----:|--------|-------|
+| ~~Publish tool: displayTitle + template overhaul~~ | 5 | 5 | S (1) | 15.0 | Done | |
+| ~~Publish tool: Landing page dashboard (recap, PC roster, key NPCs)~~ | 5 | 4 | M (2) | 7.0 | Done | |
+| Remove model-specific prescriptions from all skills | 3 | 3 | S (1) | 9.0 | Idea | Replace hardcoded model names (Sonnet/Opus) in model selection tables with complexity guidance (Light/Heavy). Skills should be model-agnostic — users may not be on Claude. Vault-ingest done in PR #26. |
+| Skill roles audit: clarify inter-skill relationships | 4 | 4 | M (2) | 6.0 | Idea | Review all 6 skill descriptions, routing, companion skill refs to ensure clear advisor/doer boundaries |
+| Pulp Cthulhu variant support | 4 | 4 | M (2) | 6.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality |
+| Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
+| Publish tool: thematic cause-of-death icons for The Fallen | 2 | 1 | S (1) | 5.0 | Idea | New optional PC frontmatter field `cause_of_death` (combat, madness, eldritch, disease, etc.) with thematic SVG icons on Fallen cards. Builds on status-category icons shipping in rank 1. |
+| Publish tool: per-page header banner | 2 | 1 | S (1) | 5.0 | Idea | Custom banner image per page via frontmatter |
+| Decompose arc-spotlight reference into focused files | 2 | 1 | S (1) | 5.0 | Experiment | Split arc-spotlight-reference.md into arc-model.md, spotlight-planning.md, touchpoint-framework.md for token efficiency |
+| ~~Publish tool: Event dedicated template~~ | 3 | 2 | M (2) | 4.0 | Done | |
+| Obsidian vault-picker | 3 | 2 | M (2) | 4.0 | Idea | Campaign config drives vault switching: on session start, disable Obsidian REST plugin + MCP server for other vaults, ensure this campaign's REST API / MCP server is running and configured. Triggered when LLM reads context memory. |
+| Publish tool: layout options (sidebar vs top nav, card grid vs list) | 3 | 2 | M (2) | 4.0 | Idea | Site-wide config for nav style and index page layout |
+| Publish tool: Landing page timeline snippet (recent campaign events) | 3 | 2 | M (2) | 4.0 | Idea | Visual timeline of recent events on the landing page |
+| ~~CoC/BRP SRD enrichment (Phase 5a)~~ | 4 | 3 | L (3) | 3.7 | Done | |
+| Publish tool: Timeline auto-generation from events/sessions | 3 | 1 | M (2) | 3.5 | Idea | Generate timeline page from event/session dates in frontmatter |
+| Publish tool: Full-text client-side search (lunr) | 3 | 1 | M (2) | 3.5 | Idea | Client-side search index so players can find content in published site |
+| FitD SRD enrichment (Phase 5b) | 2 | 2 | M (2) | 3.0 | Planned | Expand FitD files to GURPS-level depth: more factions, crew types, entanglements |
+| Publish tool: Chapter/Session/Scene templates + hierarchy nav | 3 | 2 | L (3) | 2.7 | Idea | Dedicated templates for narrative hierarchy with parent/child nav |
+| Character sheet templates | 2 | 1 | M (2) | 2.5 | Idea | Printable/viewable character sheet templates per system in published site |
+| Skill description optimization | 2 | 1 | M (2) | 2.5 | Idea | Marketplace description and SKILL.md routing improvements for discoverability |
+| Publish tool: Clue dedicated template | 2 | 1 | M (2) | 2.5 | Idea | Template for clue entities with status, linked scenes, discovery conditions |
+| Publish tool: Document dedicated template | 2 | 1 | M (2) | 2.5 | Idea | Template for in-world documents (letters, newspapers, journals) |
+| Publish tool: Tag-based browsing (tag index pages) | 2 | 1 | M (2) | 2.5 | Idea | Auto-generated index pages per tag from frontmatter |
+| Eval suite for all skills | 3 | 1 | L (3) | 2.3 | Idea | Extend benchmark methodology to all 7 skills, not just ttrpg-expert |
+| Publish tool: Relationship graph visualisation | 3 | 1 | L (3) | 2.3 | Idea | Interactive graph of entity relationships (d3/force-directed) |
+| Publish tool: full site identity (logo variants, social preview) | 3 | 1 | L (3) | 2.3 | Idea | Logo generation, og:image, social card previews for shared links |
+| D&D SRD enrichment (Phase 5c) | 2 | 2 | L (3) | 2.0 | Planned | Expand D&D files: more monster stat blocks, subclass features, encounter building |
+| PDF-to-markdown converter | 3 | 1 | XL (4) | 1.8 | Idea | Tool to convert published adventure PDFs into vault-compatible markdown |
+| Auto-download SRDs on setup | 1 | 1 | M (2) | 1.5 | Idea | First-run script to fetch CC-BY SRDs (D&D 5.2, FitD) into systems/ |
+| Publish tool: favicon generation from campaign image | 1 | 1 | M (2) | 1.5 | Idea | Auto-generate favicon from campaign hero image during publish |
 
 ## Completed
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -119,6 +119,13 @@ confirmed play events.
 - Confirmed events (with source citations)
 - Gaps (things prep says could have happened but unconfirmed)
 
+**Image linking:** For each entity created or updated in this
+bucket, check filed images (from Phase 1) for matches. Single
+match → set `portrait`. Multiple matches with clear default
+(unsuffixed filename) → set `portrait`, embed rest via
+`![[filename]]`. Multiple matches with no default → defer
+portrait selection to Phase 4. See `references/image-handling.md`.
+
 ### Phase 4: Keeper Interview
 
 The skill's exclusive value. Read
@@ -134,6 +141,14 @@ The skill's exclusive value. Read
 
 First resolve any unsorted items from Phase 2 before starting
 the play-event interview.
+
+**Image questions:** After resolving unsorted items and before
+starting the play-event interview, resolve image assignments:
+1. Show each unmatched image — ask the GM which entity it
+   belongs to (or "atmosphere art" → `_attachments/documents/`)
+2. For entities with multiple images and no clear default —
+   ask the GM to pick the portrait
+See `references/image-handling.md` for question templates.
 
 ### Phase 5: Synthesize & Hand Off
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -14,6 +14,7 @@ can process. Adapter + Orchestrator pattern.
 
 **Skill references:** Read before each phase:
 - `references/classification-taxonomy.md` — Phase 1
+- `references/image-handling.md` — Phase 1 (when images present)
 - `references/keeper-interview.md` — Phase 4
 - `references/synthesis-templates.md` — Phase 5
 
@@ -205,7 +206,7 @@ check. Don't force.
 | 1-2 | Sonnet | Classification, grouping |
 | 3-6 | Opus (inherit) | Judgment, synthesis, GM interaction |
 | Entity subagents | Sonnet | Structured file creation |
-| Image extraction | Sonnet | Vision tasks |
+| Image filing | Sonnet | Format conversion, filename matching |
 
 ## Sub-agent Opportunity
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -201,12 +201,16 @@ check. Don't force.
 
 ## Model Selection
 
-| Phase | Model | Why |
+Match model capability to task complexity. These are
+guidelines, not requirements — use whatever models are
+available and appropriate for your setup.
+
+| Phase | Complexity | Why |
 |---|---|---|
-| 1-2 | Sonnet | Classification, grouping |
-| 3-6 | Opus (inherit) | Judgment, synthesis, GM interaction |
-| Entity subagents | Sonnet | Structured file creation |
-| Image filing | Sonnet | Format conversion, filename matching |
+| 1-2 | Light | Classification, grouping — pattern matching |
+| 3-6 | Heavy | Judgment, synthesis, GM interaction |
+| Entity subagents | Light | Structured file creation from templates |
+| Image filing | Light | Format conversion, filename matching |
 
 ## Sub-agent Opportunity
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -70,11 +70,12 @@ taxonomy and heuristics.
 check results, or specific PC actions, those lines are play
 records regardless of what surrounds them.
 
-**Image handling:** File every image in `_attachments/` with
-correct subfolder and link to its entity. Attempt extraction
-on data-bearing images (character sheets, legible handwriting,
-labelled maps). Flag extracted content for GM confirmation in
-Phase 4. Artistic images: file and link only.
+**Image handling:** Read `references/image-handling.md` for
+full procedures. Summary: classify every image file, convert
+non-web-safe formats (best-effort via `sips` or `magick`),
+match to entities by slugified filename, file in the correct
+`_attachments/` subfolder, and link to matched entities.
+Unmatched images go on the Phase 4 keeper interview list.
 
 **Output:** Classified manifest — summary table of every source
 item with classification, brief content summary, and time-period

--- a/skills/vault-ingest/references/classification-taxonomy.md
+++ b/skills/vault-ingest/references/classification-taxonomy.md
@@ -13,7 +13,7 @@ distinct section within a document gets one classification.
 | Research/brainstorm | Worldbuilding Q&A, "what if" explorations | NOT CANON unless confirmed | Questions and answers about possibilities; no play indicators |
 | Keeper recollection | GM's memory of what happened | AUTHORITATIVE | First person ("I remember", "the group did"), past tense, specific details |
 | Character sheet | PC or NPC stats, inventory, backstory | DRAFT until placed in timeline | Structured data: attributes, skills, equipment lists |
-| Image/map | Visual reference material — portraits, scene art, location shots, maps | Attachment — no canon status | Binary file (jpg, png, webp, gif, svg, heic, raw, tiff, bmp); classify then process per `references/image-handling.md` |
+| Image/map | Visual reference material — portraits, scene art, location shots, maps | Attachment — no canon status | Binary file (jpg, png, webp, gif, svg, heic, raw, tiff, bmp); classify then process per `image-handling.md` |
 | Spreadsheet/data | Tracking sheets, encounter tables | DRAFT — classify by content | Tabular data, formulas, tracking columns |
 
 ## Key Heuristics

--- a/skills/vault-ingest/references/classification-taxonomy.md
+++ b/skills/vault-ingest/references/classification-taxonomy.md
@@ -13,7 +13,7 @@ distinct section within a document gets one classification.
 | Research/brainstorm | Worldbuilding Q&A, "what if" explorations | NOT CANON unless confirmed | Questions and answers about possibilities; no play indicators |
 | Keeper recollection | GM's memory of what happened | AUTHORITATIVE | First person ("I remember", "the group did"), past tense, specific details |
 | Character sheet | PC or NPC stats, inventory, backstory | DRAFT until placed in timeline | Structured data: attributes, skills, equipment lists |
-| Image/map | Visual reference material | Attachment — no canon status | Binary file or embedded image |
+| Image/map | Visual reference material — portraits, scene art, location shots, maps | Attachment — no canon status | Binary file (jpg, png, webp, gif, svg, heic, raw, tiff, bmp); classify then process per `references/image-handling.md` |
 | Spreadsheet/data | Tracking sheets, encounter tables | DRAFT — classify by content | Tabular data, formulas, tracking columns |
 
 ## Key Heuristics

--- a/skills/vault-ingest/references/image-handling.md
+++ b/skills/vault-ingest/references/image-handling.md
@@ -1,0 +1,137 @@
+# Image Handling
+
+Reference for image processing during vault ingestion. Read when
+any source material includes image files.
+
+## Supported Formats
+
+**Web-safe (pass through):** jpg, jpeg, png, webp, gif, svg
+
+**Non-web-safe (convert or skip):** heic, tiff, tif, bmp, raw,
+cr2, nef, arw, dng
+
+## Format Conversion
+
+When a non-web-safe image is encountered:
+
+1. Check for `sips` (macOS built-in):
+   `sips -s format jpeg input.heic --out output.jpg`
+2. If `sips` unavailable, check for `magick` (ImageMagick):
+   `magick input.heic output.jpg`
+3. If neither available, skip the image and report:
+   > "Skipped `filename.heic` — not a web-safe format and no
+   > conversion tool available. Convert to jpg/png/webp manually
+   > and re-ingest."
+
+Use the original filename stem with `.jpg` extension for
+converted files. Delete the non-web-safe original from the
+vault after successful conversion (it was just copied in).
+
+## Entity Matching
+
+Slugify the image filename (strip extension, lowercase, replace
+spaces and underscores with hyphens) and match against entity
+files in the vault.
+
+**Matching order — try each, stop at first hit:**
+
+1. **Exact slug match:** `ronnie-vint.jpg` → find any entity
+   file whose slug is `ronnie-vint` (e.g., `NPCs/Ronnie Vint.md`)
+2. **Batch match:** same slug check against entity files being
+   created in the current ingestion batch
+3. **Suffix strip:** remove the last hyphenated segment and
+   retry steps 1-2 (e.g., `ronnie-vint-young.jpg` → try
+   `ronnie-vint`). Only strip one segment.
+
+Slugify rule: strip file extension, lowercase the rest, replace
+spaces and underscores with hyphens, collapse consecutive
+hyphens.
+
+**Unmatched images** go on the keeper interview list for
+Phase 4.
+
+## Filing Destination
+
+Once an image matches an entity (or is assigned by the GM in
+Phase 4), copy it to the correct `_attachments/` subfolder:
+
+| Entity type            | Subfolder      |
+|------------------------|----------------|
+| PC, NPC                | `characters/`  |
+| Location               | `locations/`   |
+| Faction, Organization  | `factions/`    |
+| Item                   | `items/`       |
+| Creature               | `creatures/`   |
+| Event, Session         | `events/`      |
+
+Images the GM marks as "general atmosphere art" (no entity)
+go to `_attachments/documents/`.
+
+Rename the filed image to match the slug convention:
+lowercase, hyphens, preserving any variant suffix. Example:
+`Ronnie Vint Young.png` → `_attachments/characters/ronnie-vint-young.png`
+
+## Entity Linking
+
+### Single image for an entity
+
+Set the entity's `portrait` frontmatter field:
+
+```yaml
+portrait: "_attachments/characters/ronnie-vint.jpg"
+```
+
+### Multiple images for an entity
+
+File all images in the correct subfolder. Then:
+
+- **If one image is unsuffixed** (e.g., `ronnie-vint.jpg`
+  alongside `ronnie-vint-young.jpg`): the unsuffixed image
+  becomes the `portrait`. Embed the others in the entity body:
+  ```markdown
+  ![[ronnie-vint-young.jpg]]
+  ```
+
+- **If all images are suffixed** (no clear default): defer
+  portrait selection to the keeper interview (Phase 4). Ask
+  the GM which image should be the portrait. Set it, then
+  embed the rest in the body.
+
+### Entity already has a portrait
+
+If the entity already has a `portrait` field set, the new
+image becomes a body embed only. Do not overwrite an existing
+portrait without GM confirmation.
+
+### Mid-conversation images
+
+When an image arrives during an active ingestion session
+(not part of the initial batch), apply the same
+classify → file → match → link flow immediately.
+
+## Keeper Interview Questions
+
+Two new question types for Phase 4. Slot these into the
+existing interview flow — they are not a separate pass.
+
+### Unmatched images
+
+For each unmatched image, show it to the GM and ask:
+
+> "I found `[filename]` but couldn't match it to an entity.
+> Which entity does this belong to, or is it general
+> atmosphere art?"
+
+If assigned to an entity, file and link per the rules above.
+If marked as atmosphere art, file in `_attachments/documents/`.
+
+### Portrait selection
+
+When an entity has multiple suffixed images and no clear
+default:
+
+> "I have [N] images for [Entity Name]: [list filenames].
+> Which one should be the main portrait?"
+
+Set the chosen image as `portrait`, embed the rest in the
+entity body.

--- a/skills/vault-ingest/references/image-handling.md
+++ b/skills/vault-ingest/references/image-handling.md
@@ -71,6 +71,31 @@ Rename the filed image to match the slug convention:
 lowercase, hyphens, preserving any variant suffix. Example:
 `Ronnie Vint Young.png` → `_attachments/characters/ronnie-vint-young.png`
 
+## Duplicate Detection
+
+Before copying an image to `_attachments/`, check whether a
+file with the same name already exists at the destination.
+
+**Identical file:** If the existing and new files are the same
+(same size and content), skip the copy silently. The image is
+already filed — no action needed.
+
+**Different file, same name:** Flag for the GM in Phase 4:
+
+> "`ronnie-vint.jpg` already exists in `_attachments/characters/`
+> but the new image looks different. Replace the existing one,
+> keep both (I'll rename the new one), or skip the new one?"
+
+If the GM chooses "keep both," rename the new image with a
+numeric suffix: `ronnie-vint-2.jpg`.
+
+**Same-batch duplicates:** If the same filename appears more
+than once in a single ingestion batch, keep the first
+occurrence and skip the rest with a note:
+
+> "Found duplicate `ronnie-vint.jpg` in the batch — using
+> the first copy."
+
 ## Entity Linking
 
 ### Single image for an entity


### PR DESCRIPTION
## Summary

- Add `references/image-handling.md` — complete procedures for classifying, converting, filing, and linking images during vault ingestion
- Update SKILL.md Phases 1, 3, and 4 with image handling instructions and keeper interview questions
- Expand Image/map classification heuristics and add image-handling reference to skill loading list

## Details

Images arriving via any input channel (folder, one-at-a-time, mixed batch) are now:
- Classified by format (web-safe pass through, non-web-safe converted via sips/magick or skipped)
- Matched to entities by slugified filename (exact → batch → suffix strip)
- Filed in the correct `_attachments/` subfolder by entity type
- Linked via `portrait` frontmatter or `![[embed]]` body syntax
- Surfaced in the keeper interview when unmatched or when portrait selection is ambiguous

No changes to vault structure, entity schema, campaign-organizer, or publish-site — all existing image infrastructure already supports this.

## Test plan

- [ ] Run vault-ingest on a campaign with mixed image+text materials
- [ ] Verify images with entity-matching filenames are auto-filed and linked
- [ ] Verify unmatched images are surfaced in keeper interview
- [ ] Verify multiple images per entity trigger portrait selection question
- [ ] Verify non-web-safe format conversion (or skip message) works
- [ ] Verify published site renders portraits and body embeds correctly