### PR TITLE
Character sheet structure: templates, story format, schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.6] — 2026-04-25
+
+### Added
+
+- **Character sheet templates** — 8 canonical vault templates in `skills/shared/templates/` covering GURPS 4e, CoC 7e (base + Regency variant), D&D 5e 2024, FitD (scoundrel + crew), and a generic fallback
+- **Character story format** — `skills/shared/character-story-format.md` defines companion story file structure, narrative voice by campaign genre, writing rules, and append protocol
+- **PC body structure in entity schema** — canonical heading hierarchy (Stat Sheet → Background → System Sections → Equipment → Notes → GM Notes) and story companion convention documented in `entity-schema.md`
+
+---
+
 ## [1.4.5] — 2026-04-25
 
 ### Added

--- a/skills/shared/character-story-format.md
+++ b/skills/shared/character-story-format.md
@@ -1,0 +1,86 @@
+# Character Story Format
+
+Reference for PC companion story files. Each active PC has a
+story file that grows session by session — a rolling narrative
+of that character's journey through the campaign.
+
+## File Location
+
+Story files live alongside their PC entity file:
+`Characters/PCs/{Name}_Story.md`
+
+Discovered by naming convention, not frontmatter pointer.
+
+## Frontmatter
+
+```yaml
+---
+type: character-story
+character: "[[{Name}]]"
+campaign: ""
+source_confidence: DRAFT
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+```
+
+## Structure
+
+Each session adds one entry at the bottom of the file:
+
+```markdown
+## Session {N} — {Session Title}
+
+{2-4 paragraphs of narrative prose covering what this
+character did, decided, learned, and how they were changed.}
+```
+
+## Narrative Voice by Campaign Genre
+
+Voice is tied to the campaign's genre/tone, not the game
+system. A GURPS horror campaign uses atmospheric horror voice;
+a GURPS space opera uses something different.
+
+| Genre | Voice |
+|-------|-------|
+| Horror | Atmospheric, building dread, psychological weight |
+| Heroic Fantasy | Vivid action, consequence, wonder |
+| Noir/Industrial | Terse, street-level, moral grey |
+| Military/Tactical | Precise, competence-focused |
+| Pulp Adventure | Breathless pace, larger-than-life |
+| Mystery/Investigation | Observational, clue-driven, tension |
+| Social/Intrigue | Relationship-focused, subtext |
+| Generic | Neutral third-person, clear and direct |
+
+## Writing Rules
+
+- Character names, not player names
+- Past tense for events, present for ongoing states
+- Wiki-links (`[[Entity Name]]`) for every entity reference
+- Focus on this character's perspective, not full session recap
+- Include consequences: injuries, relationship shifts, new
+  knowledge, emotional impact
+- No bullet points — narrative prose only
+- 2-4 paragraphs per session entry
+
+## Append Protocol
+
+1. Read existing story file (or create from template if none)
+2. Append new `## Session {N} — {Title}` at the bottom
+3. Write narrative prose for this session
+4. Update `lastUpdated` and `asOfSession` in frontmatter
+5. Never edit prior session entries (append-only)
+
+## Story vs Wrap-Up Content
+
+Story files capture a single character's narrative arc.
+Session wrap-ups capture the full session for the whole party.
+
+| Content | Story file | Wrap-up |
+|---------|-----------|---------|
+| What this PC did | Yes | PC Carry-Forward only |
+| Full session narrative | No | Narrative Recap |
+| Mechanical changes | No (stat sheet) | Entity updates |
+| NPC relationship shifts | Yes, narratively | Carry-forward |
+| World state changes | No | World State section |

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -370,7 +370,7 @@ companion story file at `Characters/PCs/{Name}_Story.md`.
   `character: "[[{Name}]]"`, plus universal fields
 - Discovered by naming convention (`{Name}_Story.md`),
   not frontmatter pointer
-- Append-only — new sessions add a `## Session {N}` heading
+- Append-only — new sessions add a `## Session {N} — {Session Title}` heading
 - `campaign-qa` validates every active PC has a story file
 - See `shared/character-story-format.md` for narrative voice,
   genre matching, and append protocol

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -338,6 +338,43 @@ during Dissect mode.
 `display_meta` (optional array: ordered field names for published site meta row;
 defaults to `[occupation, age, nationality]` when omitted)
 
+### PC Body Structure
+
+All PC entity files follow this canonical heading hierarchy.
+Templates in `shared/templates/` implement the full structure
+per system; skills that create or update PC files follow the
+same skeleton.
+
+```text
+## Stat Sheet          — system-specific stats (always first body section)
+## Background          — backstory, personality, description
+## [System Sections]   — varies by system (see per-system template)
+## Equipment           — gear, possessions, wealth/encumbrance
+## Notes               — player-facing (protected: skills never modify)
+## GM Notes            — keeper-only (protected: skills never modify)
+```
+
+Templates may omit inapplicable sections (e.g., FitD crews
+have no `## Equipment` — gear is handled through Quality).
+
+`## Notes` and `## GM Notes` are **protected sections** — only
+the GM edits them directly. Automated skills must preserve
+their content unchanged.
+
+### Story Companion Convention
+
+Every PC entity `Characters/PCs/{Name}.md` may have a
+companion story file at `Characters/PCs/{Name}_Story.md`.
+
+- Frontmatter: `type: character-story`,
+  `character: "[[{Name}]]"`, plus universal fields
+- Discovered by naming convention (`{Name}_Story.md`),
+  not frontmatter pointer
+- Append-only — new sessions add a `## Session {N}` heading
+- `campaign-qa` validates every active PC has a story file
+- See `shared/character-story-format.md` for narrative voice,
+  genre matching, and append protocol
+
 **Location:** `location_type`, `parent_location` (wiki-link),
 `atmosphere`, `portrait` (optional)
 

--- a/skills/shared/templates/character-story.md
+++ b/skills/shared/templates/character-story.md
@@ -1,0 +1,17 @@
+---
+type: character-story
+character: "[[{Name}]]"
+campaign: ""
+source_confidence: DRAFT
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Session {N} — {Session Title}
+
+{2-4 paragraphs of narrative prose. Use the campaign's genre
+voice (see shared/character-story-format.md). Write in past
+tense for events, present for ongoing states. Wiki-link all
+entity references. Focus on this character's perspective —
+what they did, decided, learned, and how they were changed.}

--- a/skills/shared/templates/crew-fitd.md
+++ b/skills/shared/templates/crew-fitd.md
@@ -1,0 +1,125 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation]
+relationships:
+  - target: "[[]]"
+    type: headquartered_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+**Crew Type:** {Assassins / Bravos / Cult / Hawkers / Shadows / Smugglers}
+
+| Attribute | Value |
+|-----------|-------|
+| Tier | 0 |
+| Hold | Strong / Weak |
+| Rep | 0 / 12 |
+| Heat | 0 |
+| Wanted Level | 0 |
+| Coin | 0 |
+| Vaults | 0 |
+
+## Background
+
+**Lair:** {Lair description and location}
+
+**Reputation:** {Crew's reputation in the underworld}
+
+**Hunting Grounds:** {Territory type and location}
+
+## Special Abilities
+
+{Selected special abilities from crew type list.}
+
+## Cohorts
+
+| Cohort | Type | Quality | Status | Gang/Expert | Armor |
+|--------|------|---------|--------|-------------|-------|
+| | | 0 | Healthy | Gang / Expert | No |
+
+## Turf Claims
+
+| Claim | Benefit |
+|-------|---------|
+| | |
+
+## Crew Upgrades
+
+**Type-specific:**
+{Upgrades specific to crew type.}
+
+**Standard:**
+{Standard upgrades available to all crew types.}
+
+## Lair & Quality
+
+**Lair Upgrades:**
+{Lair-specific upgrades.}
+
+**Quality by Category:**
+| Category | Quality |
+|----------|---------|
+| Documents | 0 |
+| Gear | 0 |
+| Implements | 0 |
+| Supplies | 0 |
+| Tools | 0 |
+| Weapons | 0 |
+
+## Training
+
+| Category | Trained |
+|----------|---------|
+| Insight | No |
+| Prowess | No |
+| Resolve | No |
+| Personal | No |
+
+## Contacts
+
+| NPC | Relationship |
+|-----|-------------|
+| | |
+| | |
+| | |
+| | |
+| | |
+| | |
+
+## Prison Claims
+
+> Optional — include only when relevant.
+
+| Claim | Benefit |
+|-------|---------|
+| | |
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}

--- a/skills/shared/templates/crew-fitd.md
+++ b/skills/shared/templates/crew-fitd.md
@@ -17,7 +17,7 @@ portrait: ""
 display_meta: [occupation]
 relationships:
   - target: "[[]]"
-    type: headquartered_at
+    type: located_at
     tone: neutral
     strength: 5
     bidirectional: false
@@ -79,6 +79,7 @@ createdSession: ""
 {Lair-specific upgrades.}
 
 **Quality by Category:**
+
 | Category | Quality |
 |----------|---------|
 | Documents | 0 |

--- a/skills/shared/templates/pc-coc-7e-regency.md
+++ b/skills/shared/templates/pc-coc-7e-regency.md
@@ -184,6 +184,7 @@ createdSession: ""
 {Item list}
 
 **Wealth:**
+
 | Attribute | Value |
 |-----------|-------|
 | Spending Level | |

--- a/skills/shared/templates/pc-coc-7e-regency.md
+++ b/skills/shared/templates/pc-coc-7e-regency.md
@@ -1,0 +1,199 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation, age, nationality]
+relationships:
+  - target: "[[]]"
+    type: located_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+### Characteristics
+
+| Characteristic | Regular | Half | Fifth |
+|---------------|---------|------|-------|
+| STR | | | |
+| CON | | | |
+| DEX | | | |
+| INT | | | |
+| SIZ | | | |
+| POW | | | |
+| APP | | | |
+| EDU | | | |
+
+### Derived
+
+| Attribute | Max | Current |
+|-----------|-----|---------|
+| HP | | |
+| MP | | |
+| Luck | — | |
+| Sanity | | |
+
+### Reputation
+
+| Attribute | Value |
+|-----------|-------|
+| Starting Reputation | |
+| Current Reputation | |
+| Censure | |
+
+### Combat
+
+| Attribute | Value |
+|-----------|-------|
+| Move | |
+| Build | |
+| Damage Bonus | |
+| Dodge (Regular) | |
+| Dodge (Half) | |
+| Dodge (Fifth) | |
+
+### Status
+
+- [ ] Temporary Insanity
+- [ ] Indefinite Insanity
+- [ ] Major Wound
+- [ ] Unconscious
+- [ ] Dying
+
+## Background
+
+**Personal Description:** {Appearance and manner}
+
+**Traits:** {Personality traits}
+
+**Ideology & Beliefs:** {Core beliefs}
+
+**Significant People:** {Important relationships}
+
+**Meaningful Locations:** {Places of importance}
+
+**Treasured Possessions:** {Valued items}
+
+## Skills
+
+| Skill | Base | Regular | Half | Fifth |
+|-------|------|---------|------|-------|
+| Accounting | 05 | | | |
+| Anthropology | 01 | | | |
+| Appraise | 05 | | | |
+| Archaeology | 01 | | | |
+| Art/Craft () | 05 | | | |
+| Astronomy | 01 | | | |
+| Charm | 15 | | | |
+| Climb | 20 | | | |
+| Credit Rating | 00 | | | |
+| Cthulhu Mythos | 00 | | | |
+| Dancing | 05 | | | |
+| Disguise | 05 | | | |
+| Dodge | — | | | |
+| Drive Carriage | 20 | | | |
+| Etiquette | 15 | | | |
+| Fashion | 05 | | | |
+| Fast Talk | 05 | | | |
+| Fighting (Brawl) | 25 | | | |
+| Firearms (Pistol) | 20 | | | |
+| Firearms (Rifle/Blunderbuss) | 25 | | | |
+| First Aid | 30 | | | |
+| Gaming | 10 | | | |
+| History | 05 | | | |
+| Intimidate | 15 | | | |
+| Jump | 20 | | | |
+| Language (Own) | EDU | | | |
+| Language () | 01 | | | |
+| Law | 05 | | | |
+| Library Use | 20 | | | |
+| Listen | 20 | | | |
+| Locksmith | 01 | | | |
+| Mech. Repair | 10 | | | |
+| Medicine | 01 | | | |
+| Natural Philosophy | 01 | | | |
+| Natural World | 10 | | | |
+| Navigate | 10 | | | |
+| Occult | 05 | | | |
+| Operate Hvy. Machine | 01 | | | |
+| Persuade | 10 | | | |
+| Photography | 05 | | | |
+| Pilot () | 01 | | | |
+| Psychoanalysis | 01 | | | |
+| Psychology | 10 | | | |
+| Reassure | 10 | | | |
+| Religion | 05 | | | |
+| Ride | 05 | | | |
+| Science () | 01 | | | |
+| Sleight of Hand | 10 | | | |
+| Spot Hidden | 25 | | | |
+| Stealth | 20 | | | |
+| Survival () | 10 | | | |
+| Swim | 20 | | | |
+| Throw | 20 | | | |
+| Track | 10 | | | |
+
+## Injuries & Scars
+
+{Rolling record of injuries and permanent scars.}
+
+## Phobias & Manias
+
+{Acquired phobias and manias from sanity loss.}
+
+## Arcane Tomes & Spells
+
+{Mythos tomes read and spells learned.}
+
+## Encounters with Strange Entities
+
+{Rolling record of encounters with mythos creatures.}
+
+## Combat
+
+| Weapon | Skill % | Damage | Attacks | Range | Ammo | Malf |
+|--------|---------|--------|---------|-------|------|------|
+| Unarmed | | 1D3+DB | 1 | — | — | — |
+| | | | | | | |
+
+## Fellow Investigators
+
+{Links to other PC files in the party.}
+
+## Equipment
+
+**Gear & Possessions:**
+{Item list}
+
+**Wealth:**
+| Attribute | Value |
+|-----------|-------|
+| Spending Level | |
+| Cash | |
+| Assets | |
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-coc-7e.md
+++ b/skills/shared/templates/pc-coc-7e.md
@@ -169,6 +169,7 @@ createdSession: ""
 {Item list}
 
 **Wealth:**
+
 | Attribute | Value |
 |-----------|-------|
 | Spending Level | |

--- a/skills/shared/templates/pc-coc-7e.md
+++ b/skills/shared/templates/pc-coc-7e.md
@@ -1,0 +1,184 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation, age, nationality]
+relationships:
+  - target: "[[]]"
+    type: located_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+### Characteristics
+
+| Characteristic | Regular | Half | Fifth |
+|---------------|---------|------|-------|
+| STR | | | |
+| CON | | | |
+| DEX | | | |
+| INT | | | |
+| SIZ | | | |
+| POW | | | |
+| APP | | | |
+| EDU | | | |
+
+### Derived
+
+| Attribute | Max | Current |
+|-----------|-----|---------|
+| HP | | |
+| MP | | |
+| Luck | — | |
+| Sanity | | |
+
+### Combat
+
+| Attribute | Value |
+|-----------|-------|
+| Move | |
+| Build | |
+| Damage Bonus | |
+| Dodge (Regular) | |
+| Dodge (Half) | |
+| Dodge (Fifth) | |
+
+### Status
+
+- [ ] Temporary Insanity
+- [ ] Indefinite Insanity
+- [ ] Major Wound
+- [ ] Unconscious
+- [ ] Dying
+
+## Background
+
+**Personal Description:** {Appearance and manner}
+
+**Traits:** {Personality traits}
+
+**Ideology & Beliefs:** {Core beliefs}
+
+**Significant People:** {Important relationships}
+
+**Meaningful Locations:** {Places of importance}
+
+**Treasured Possessions:** {Valued items}
+
+## Skills
+
+| Skill | Base | Regular | Half | Fifth |
+|-------|------|---------|------|-------|
+| Accounting | 05 | | | |
+| Anthropology | 01 | | | |
+| Appraise | 05 | | | |
+| Archaeology | 01 | | | |
+| Art/Craft () | 05 | | | |
+| Charm | 15 | | | |
+| Climb | 20 | | | |
+| Credit Rating | 00 | | | |
+| Cthulhu Mythos | 00 | | | |
+| Disguise | 05 | | | |
+| Dodge | — | | | |
+| Drive Auto | 20 | | | |
+| Elec. Repair | 10 | | | |
+| Fast Talk | 05 | | | |
+| Fighting (Brawl) | 25 | | | |
+| Firearms (Handgun) | 20 | | | |
+| Firearms (Rifle/Shotgun) | 25 | | | |
+| First Aid | 30 | | | |
+| History | 05 | | | |
+| Intimidate | 15 | | | |
+| Jump | 20 | | | |
+| Language (Own) | EDU | | | |
+| Language () | 01 | | | |
+| Law | 05 | | | |
+| Library Use | 20 | | | |
+| Listen | 20 | | | |
+| Locksmith | 01 | | | |
+| Mech. Repair | 10 | | | |
+| Medicine | 01 | | | |
+| Natural World | 10 | | | |
+| Navigate | 10 | | | |
+| Occult | 05 | | | |
+| Operate Hvy. Machine | 01 | | | |
+| Persuade | 10 | | | |
+| Photography | 05 | | | |
+| Pilot () | 01 | | | |
+| Psychoanalysis | 01 | | | |
+| Psychology | 10 | | | |
+| Ride | 05 | | | |
+| Science () | 01 | | | |
+| Sleight of Hand | 10 | | | |
+| Spot Hidden | 25 | | | |
+| Stealth | 20 | | | |
+| Survival () | 10 | | | |
+| Swim | 20 | | | |
+| Throw | 20 | | | |
+| Track | 10 | | | |
+
+## Injuries & Scars
+
+{Rolling record of injuries and permanent scars.}
+
+## Phobias & Manias
+
+{Acquired phobias and manias from sanity loss.}
+
+## Arcane Tomes & Spells
+
+{Mythos tomes read and spells learned.}
+
+## Encounters with Strange Entities
+
+{Rolling record of encounters with mythos creatures.}
+
+## Combat
+
+| Weapon | Skill % | Damage | Attacks | Range | Ammo | Malf |
+|--------|---------|--------|---------|-------|------|------|
+| Unarmed | | 1D3+DB | 1 | — | — | — |
+| | | | | | | |
+
+## Fellow Investigators
+
+{Links to other PC files in the party.}
+
+## Equipment
+
+**Gear & Possessions:**
+{Item list}
+
+**Wealth:**
+| Attribute | Value |
+|-----------|-------|
+| Spending Level | |
+| Cash | |
+| Assets | |
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-dnd-5e-2024.md
+++ b/skills/shared/templates/pc-dnd-5e-2024.md
@@ -1,0 +1,189 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation, age, nationality]
+relationships:
+  - target: "[[]]"
+    type: located_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+### Core
+
+| Attribute | Value |
+|-----------|-------|
+| Level | 1 |
+| XP | 0 |
+| Proficiency Bonus | +2 |
+| Heroic Inspiration | No |
+
+### Ability Scores
+
+| Ability | Score | Modifier | Save Proficiency |
+|---------|-------|----------|-----------------|
+| STR | 10 | +0 | No |
+| DEX | 10 | +0 | No |
+| CON | 10 | +0 | No |
+| INT | 10 | +0 | No |
+| WIS | 10 | +0 | No |
+| CHA | 10 | +0 | No |
+
+### Combat
+
+| Attribute | Value |
+|-----------|-------|
+| AC | 10 |
+| Initiative | +0 |
+| Speed | 30 ft |
+| Size | Medium |
+| Passive Perception | 10 |
+| HP (Current) | |
+| HP (Max) | |
+| Hit Dice (Spent/Max) | 0/1 |
+| Death Saves (S/F) | 0/0 |
+
+## Background
+
+**Species:** {Species name}
+
+**Class/Subclass:** {Class (Subclass)}
+
+**Background:** {Background name}
+
+**Backstory & Personality:** {Character history and traits}
+
+**Alignment:** {Alignment}
+
+**Appearance:** {Physical description}
+
+## Skills
+
+| Skill | Ability | Proficient | Expertise | Modifier |
+|-------|---------|-----------|-----------|----------|
+| Acrobatics | DEX | No | No | +0 |
+| Animal Handling | WIS | No | No | +0 |
+| Arcana | INT | No | No | +0 |
+| Athletics | STR | No | No | +0 |
+| Deception | CHA | No | No | +0 |
+| History | INT | No | No | +0 |
+| Insight | WIS | No | No | +0 |
+| Intimidation | CHA | No | No | +0 |
+| Investigation | INT | No | No | +0 |
+| Medicine | WIS | No | No | +0 |
+| Nature | INT | No | No | +0 |
+| Perception | WIS | No | No | +0 |
+| Performance | CHA | No | No | +0 |
+| Persuasion | CHA | No | No | +0 |
+| Religion | INT | No | No | +0 |
+| Sleight of Hand | DEX | No | No | +0 |
+| Stealth | DEX | No | No | +0 |
+| Survival | WIS | No | No | +0 |
+
+## Class Features
+
+{Selected class features by level.}
+
+## Species Traits
+
+{Species features and traits.}
+
+## Feats
+
+{Selected feats with descriptions.}
+
+## Spellcasting
+
+> Omit this section if the character has no spellcasting.
+
+| Attribute | Value |
+|-----------|-------|
+| Spellcasting Ability | |
+| Spell Attack Modifier | |
+| Spell Save DC | |
+
+### Spell Slots
+
+| Level | Total | Expended |
+|-------|-------|----------|
+| 1st | | |
+| 2nd | | |
+| 3rd | | |
+| 4th | | |
+| 5th | | |
+| 6th | | |
+| 7th | | |
+| 8th | | |
+| 9th | | |
+
+### Prepared Spells
+
+**Cantrips:** {list}
+
+**1st Level:** {list}
+
+{Continue per level as needed.}
+
+## Proficiencies
+
+**Armor Training:** {list}
+
+**Weapons:** {list}
+
+**Tools:** {list}
+
+**Languages:** {list}
+
+## Equipment
+
+### Weapons & Damage Cantrips
+
+| Name | Atk Bonus / DC | Damage & Type | Notes |
+|------|----------------|---------------|-------|
+| | | | |
+
+### Gear
+
+{Item list}
+
+### Magic Item Attunement
+
+| Slot | Item |
+|------|------|
+| 1 | — |
+| 2 | — |
+| 3 | — |
+
+### Coins
+
+| CP | SP | EP | GP | PP |
+|----|----|----|----|----|
+| 0 | 0 | 0 | 0 | 0 |
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-fitd.md
+++ b/skills/shared/templates/pc-fitd.md
@@ -1,0 +1,138 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation, age, nationality]
+relationships:
+  - target: "[[]]"
+    type: located_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+**Playbook:** {Playbook name}
+
+### Action Ratings
+
+**Insight**
+| Action | Rating |
+|--------|--------|
+| Hunt | 0 |
+| Study | 0 |
+| Survey | 0 |
+| Tinker | 0 |
+
+**Prowess**
+| Action | Rating |
+|--------|--------|
+| Finesse | 0 |
+| Prowl | 0 |
+| Skirmish | 0 |
+| Wreck | 0 |
+
+**Resolve**
+| Action | Rating |
+|--------|--------|
+| Attune | 0 |
+| Command | 0 |
+| Consort | 0 |
+| Sway | 0 |
+
+### Stress & Trauma
+
+| Attribute | Value |
+|-----------|-------|
+| Stress | 0 / 9 |
+| Trauma | |
+
+### Harm
+
+| Level | Slot 1 | Slot 2 |
+|-------|--------|--------|
+| 3 (Fatal) | | — |
+| 2 (Serious) | | |
+| 1 (Minor) | | |
+
+### Armor Uses
+
+| Type | Used |
+|------|------|
+| Armor | No |
+| Heavy | No |
+| Special | No |
+
+### XP
+
+**Playbook XP:** 0 / 8
+
+## Background
+
+**Heritage:** {Heritage}
+
+**Background:** {Background}
+
+**Look:** {Physical description}
+
+**Vice/Purveyor:** {Vice type — Purveyor name}
+
+## Special Abilities
+
+{Selected special abilities from playbook list.}
+
+## Friends & Rivals
+
+| NPC | Relationship |
+|-----|-------------|
+| | Friend / Rival |
+| | Friend / Rival |
+| | Friend / Rival |
+| | Friend / Rival |
+| | Friend / Rival |
+
+## Long-Term Projects
+
+| Project | Clock | Progress |
+|---------|-------|----------|
+| | /8 | |
+
+## Stash & Coin
+
+| Attribute | Value |
+|-----------|-------|
+| Coin | 0 |
+| Stash | 0 / 40 |
+
+## Equipment
+
+**Load:** Light (3) / Normal (5) / Heavy (6)
+
+| Item | Load |
+|------|------|
+| | |
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-fitd.md
+++ b/skills/shared/templates/pc-fitd.md
@@ -34,6 +34,7 @@ createdSession: ""
 ### Action Ratings
 
 **Insight**
+
 | Action | Rating |
 |--------|--------|
 | Hunt | 0 |
@@ -42,6 +43,7 @@ createdSession: ""
 | Tinker | 0 |
 
 **Prowess**
+
 | Action | Rating |
 |--------|--------|
 | Finesse | 0 |
@@ -50,6 +52,7 @@ createdSession: ""
 | Wreck | 0 |
 
 **Resolve**
+
 | Action | Rating |
 |--------|--------|
 | Attune | 0 |

--- a/skills/shared/templates/pc-generic.md
+++ b/skills/shared/templates/pc-generic.md
@@ -1,0 +1,48 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation, age, nationality]
+relationships:
+  - target: "[[]]"
+    type: located_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+{Free-form stat block. Adapt to the game system in use.}
+
+## Background
+
+{Character background, personality, and description.}
+
+## Equipment
+
+{Gear, possessions, and wealth.}
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-gurps-4e.md
+++ b/skills/shared/templates/pc-gurps-4e.md
@@ -1,0 +1,194 @@
+---
+type: pc
+source_confidence: DRAFT
+aliases: []
+tags: []
+source_document: ""
+campaign: ""
+first_appearance: ""
+player_name: ""
+occupation: ""
+age:
+gender: ""
+nationality: ""
+status: alive
+key_traits: []
+portrait: ""
+display_meta: [occupation, age, nationality]
+relationships:
+  - target: "[[]]"
+    type: located_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+lastUpdated: ""
+asOfSession: ""
+createdSession: ""
+---
+
+## Stat Sheet
+
+### Primary Attributes
+
+| Attribute | Score | Modifier | Cost |
+|-----------|-------|----------|------|
+| ST | 10 | — | 0 |
+| DX | 10 | — | 0 |
+| IQ | 10 | — | 0 |
+| HT | 10 | — | 0 |
+
+### Secondary Characteristics
+
+| Characteristic | Value |
+|---------------|-------|
+| HP | 10 |
+| Will | 10 |
+| Per | 10 |
+| FP | 10 |
+| Basic Speed | 5.00 |
+| Basic Move | 5 |
+| Basic Lift | 20 lbs |
+| Damage (Thr) | 1d-2 |
+| Damage (Sw) | 1d |
+| Size Modifier | 0 |
+
+### Appearance & Social
+
+| Trait | Value |
+|-------|-------|
+| Age | |
+| Height | |
+| Weight | |
+| Build | |
+| Appearance | Average |
+| Status | 0 |
+| Reputation | |
+| Reaction Modifiers | |
+| TL | 3 |
+
+## Background
+
+{Free-form character background: personality, history,
+motivations, and description.}
+
+## Advantages & Perks
+
+| Name | Cost | Page Ref | Notes |
+|------|------|----------|-------|
+| | | | |
+
+## Disadvantages & Quirks
+
+| Name | Cost | Self-Control | Notes |
+|------|------|-------------|-------|
+| | | | |
+
+## Skills
+
+| Name | Difficulty | Relative Level | Points | Effective |
+|------|-----------|----------------|--------|-----------|
+| | | | | |
+
+## Techniques
+
+| Name | Default | Points | Effective |
+|------|---------|--------|-----------|
+| | | | |
+
+## Spells
+
+| Name | College | Skill Level | Energy | Maintain | Notes |
+|------|---------|-------------|--------|----------|-------|
+| | | | | | |
+
+## Languages
+
+| Language | Spoken | Written | Points |
+|----------|--------|---------|--------|
+| | | | |
+
+## Cultural Familiarities
+
+| Culture | Points |
+|---------|--------|
+| | |
+
+## Combat Action Chains
+
+Top 5 multi-step combat sequences for quick reference.
+
+1. **{Chain Name}:** {Step 1} → {Step 2} → {Step 3}
+2.
+3.
+4.
+5.
+
+## Melee Weapons
+
+| Weapon | Skill | Damage | Reach | Parry |
+|--------|-------|--------|-------|-------|
+| | | | | |
+
+## Ranged Weapons
+
+| Weapon | Skill | Damage | Acc | Range | RoF | Shots | Bulk |
+|--------|-------|--------|-----|-------|-----|-------|------|
+| | | | | | | | |
+
+## Active Defenses
+
+| Defense | Value | Source |
+|---------|-------|--------|
+| Dodge | | |
+| Parry | | |
+| Block | | |
+
+## DR by Hit Location
+
+| Location | DR | Source |
+|----------|-----|--------|
+| Skull | | |
+| Face | | |
+| Neck | | |
+| Torso | | |
+| Arms | | |
+| Hands | | |
+| Legs | | |
+| Feet | | |
+
+## Points Summary
+
+| Category | Points |
+|----------|--------|
+| Attributes | 0 |
+| Advantages & Perks | 0 |
+| Disadvantages & Quirks | 0 |
+| Skills | 0 |
+| Techniques | 0 |
+| Spells | 0 |
+| **Total** | **0** |
+
+## Equipment
+
+| Item | Weight | Cost | Location | Notes |
+|------|--------|------|----------|-------|
+| | | | | |
+
+### Encumbrance
+
+| Level | Max Weight | Move | Dodge |
+|-------|-----------|------|-------|
+| None (0) | | | |
+| Light (1) | | | |
+| Medium (2) | | | |
+| Heavy (3) | | | |
+| X-Heavy (4) | | | |
+
+## Notes
+
+{Player-facing notes. Protected — skills never modify.}
+
+## GM Notes
+
+{Keeper-only notes. Protected — skills never modify.}


### PR DESCRIPTION
## Summary

Sub-project 1 of the Character Sheet Overhaul. Formalizes PC character sheet structure across all supported systems.

- Extend entity schema with PC body structure (canonical heading hierarchy) and story companion convention
- Add character story format reference (narrative voice by genre, append protocol, writing rules)
- Create 8 vault templates in `skills/shared/templates/`: GURPS 4e, CoC 7e (base + Regency variant), D&D 5e 2024, FitD (scoundrel + crew), Generic, and story companion

Pure reference/template files — no skill behavior changes. Foundation for SP2 (story lifecycle) and SP3 (publish-site UI).

## Test Plan

- [x] `python3 scripts/validate_schema.py` passes (26 files validated)
- [ ] Verify each template follows the universal heading skeleton (Stat Sheet → Background → System Sections → Equipment → Notes → GM Notes)
- [ ] Verify CoC 7e Regency is standalone (not a diff of base), has Reputation section, period-appropriate skills
- [ ] Verify FitD crew omits Equipment section
- [ ] Verify Notes and GM Notes are marked as protected in all templates