### PR TITLE
Add story lifecycle to session-wrapup, vault-ingest, campaign-qa

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.7] — 2026-04-26
+
+### Added
+
+- **Story lifecycle** — session-wrapup Step 3b writes per-PC character story entries after each session; vault-ingest reconstructs consolidated backstory entries from historical material and recognizes wrap-up files as a source type; campaign-qa Graph Health validates story file existence and recency for active PCs
+
+---
+
 ## [1.4.6] — 2026-04-25
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,7 @@ Items are force-ranked by score. Higher score = do first.
 | ~~Publish tool: Landing page dashboard (recap, PC roster, key NPCs)~~ | 5 | 4 | M (2) | 7.0 | Done | |
 | ~~Remove model-specific prescriptions from all skills~~ | 3 | 3 | S (1) | 9.0 | Done | |
 | ~~Skill roles audit: clarify inter-skill relationships~~ | 4 | 4 | M (2) | 6.0 | Done | |
+| Entity creation must read template before writing | 5 | 4 | S (1) | 14.0 | Bug | campaign-organizer has no explicit step requiring agents to read `_Templates/_Template_{Type}.md` before creating entity files. Agents pattern-match off existing files instead, producing inconsistent structure. Add a hard gate to Dissect, Organize, and any entity-creation workflow: "Read the matching template before writing." Applies to vault-ingest Phase 5 handoff too. |
 | Pulp Cthulhu variant support | 4 | 4 | M (2) | 6.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality |
 | the-midwife: guided adventure creation skill | 4 | 2 | M (2) | 5.0 | Idea | Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots. |
 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
@@ -44,6 +45,7 @@ Items are force-ranked by score. Higher score = do first.
 | Publish tool: per-page header banner | 2 | 1 | S (1) | 5.0 | Idea | Custom banner image per page via frontmatter |
 | Decompose arc-spotlight reference into focused files | 2 | 1 | S (1) | 5.0 | Experiment | Split arc-spotlight-reference.md into arc-model.md, spotlight-planning.md, touchpoint-framework.md for token efficiency |
 | ~~Publish tool: Event dedicated template~~ | 3 | 2 | M (2) | 4.0 | Done | |
+| Portrait rendering in Obsidian vaults | 3 | 3 | M (2) | 4.5 | Idea | Obsidian doesn't render `portrait` frontmatter as images — needs Dataview inline, CSS snippet, or Templater approach. See [spec](docs/portrait-rendering-obsidian.md) |
 | Obsidian vault-picker | 3 | 2 | M (2) | 4.0 | Idea | Campaign config drives vault switching: on session start, disable Obsidian REST plugin + MCP server for other vaults, ensure this campaign's REST API / MCP server is running and configured. Triggered when LLM reads context memory. |
 | Publish tool: layout options (sidebar vs top nav, card grid vs list) | 3 | 2 | M (2) | 4.0 | Idea | Site-wide config for nav style and index page layout |
 | Publish tool: Landing page timeline snippet (recent campaign events) | 3 | 2 | M (2) | 4.0 | Idea | Visual timeline of recent events on the landing page |

--- a/docs/portrait-rendering-obsidian.md
+++ b/docs/portrait-rendering-obsidian.md
@@ -1,0 +1,103 @@
+# Portrait Rendering in Obsidian Vaults
+
+## Problem
+
+The entity schema defines a `portrait` field on all visual entity types
+(NPC, PC, Location, Faction, Item, Creature). Vault-ingest and
+campaign-organizer correctly file images into
+`_attachments/{type}/{slug}.ext` and set the portrait frontmatter value,
+but Obsidian doesn't render frontmatter properties as images. The
+portrait field shows up as plain text metadata in the Properties panel —
+the user never sees the actual image when viewing the note unless they
+manually embed it in the body with `![[filename]]`.
+
+## Desired Behaviour
+
+When a user opens any entity file that has a portrait value, the image
+should be visible in the note without the user doing anything extra.
+This should work in both Reading and Live Preview modes. It should
+degrade gracefully (no broken image placeholder) when portrait is empty
+or the file doesn't exist.
+
+## Scope
+
+This belongs in campaign-organizer as part of vault setup and
+maintenance. Specifically:
+
+1. **Vault initialisation** — When campaign-organizer creates the
+   `_meta/` layer and folder structure for a new vault, it should also
+   ensure the portrait-rendering mechanism is in place.
+2. **Entity templates** — The templates in `skills/shared/templates/`
+   should include whatever is needed so new entities get portrait
+   rendering by default.
+3. **Retroactive repair** — Campaign-organizer's Validate mode should
+   detect entity files that have a portrait value but are missing the
+   rendering mechanism, and offer to fix them.
+
+## Technical Context
+
+- gm-apprentice already lists Dataview as an expected plugin (used by
+  multiple skills). It's safe to depend on it.
+- The entity schema is in `skills/shared/entity-schema.md`. Entity
+  types with portrait: NPC, PC, Location, Faction, Item, Creature.
+- The default vault structure is in `skills/shared/vault-structure.md`.
+  Images live in `_attachments/{type}/`.
+- Portrait values are bare vault-relative paths, e.g.
+  `"_attachments/characters/colonel-moreau.png"` — no `![[]]` wrapping.
+- The publish tool (`tools/publish/`) has its own CSS pipeline for the
+  static site. That's a separate concern — this is about the Obsidian
+  editing experience.
+
+## Implementation Options to Evaluate
+
+**Option A: Dataview inline in templates.** Add a Dataview inline query
+to the body of each entity template that reads `this.portrait` and
+renders it as an embed. Something like
+`` `= this.portrait ? "![[" + this.portrait + "]]" : "" ` ``.
+Pros: simple, uses an existing dependency, works in both view modes.
+Cons: visible as a code span in Source mode; needs to be present in
+every entity file body (not just frontmatter).
+
+**Option B: CSS snippet.** Add an `.obsidian/snippets/` CSS file during
+vault init that renders the portrait property as an image. Obsidian 1.4+
+renders properties with `data-property-key` attributes in the DOM.
+Pros: invisible to the user, no template body changes.
+Cons: depends on Obsidian's internal DOM structure which can break
+across versions; CSS can't easily turn a text value into a rendered
+`<img>`.
+
+**Option C: Templater automation.** Use a Templater script to insert
+`![[portrait-path]]` into the body when a note is created from
+template.
+Pros: clean result.
+Cons: only works at creation time, doesn't help existing files, adds a
+Templater dependency.
+
+Evaluate these (and any other approach missed) and pick the one that
+best balances reliability, graceful degradation, and minimal maintenance
+burden. If going with Dataview inline, the rendering line should be near
+the top of the body (after the `# Title` heading) and should produce a
+reasonably sized image (consider whether Obsidian's `![[image|width]]`
+syntax is worth using for a default max width).
+
+## Files Likely to Change
+
+- `skills/shared/templates/*.md` — All templates with a portrait field
+- `skills/shared/entity-schema.md` — If the portrait field
+  documentation needs updating
+- `skills/shared/vault-structure.md` — If a snippets directory or new
+  file needs documenting
+- `skills/campaign-organizer/SKILL.md` — Vault init and Validate mode
+  procedures
+- `skills/campaign-organizer/references/` — If a new reference file is
+  needed for the CSS/rendering approach
+- Possibly a new file for the CSS snippet itself if Option B is chosen
+
+## Constraints
+
+- Must work in Obsidian 1.4+ (current property/metadata system)
+- Must degrade gracefully when portrait is empty or missing
+- Must not break the publish pipeline (the static site has its own
+  rendering)
+- Must not require any community plugins beyond what gm-apprentice
+  already expects (Dataview, Templater)

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -226,6 +226,10 @@ for the full procedure.
   at `wrap-up` status for multiple prep cycles (review was
   deferred too long), session index `documents:` links pointing
   to files that don't exist
+- Character story file validation: active PCs missing a
+  companion `{Name}_Story.md` file, story files where
+  `asOfSession` is more than 1 session behind the latest
+  wrap-up
 
 ### Full Audit
 

--- a/skills/campaign-qa/references/check-procedures.md
+++ b/skills/campaign-qa/references/check-procedures.md
@@ -354,7 +354,28 @@ required fields. For each entity:
 - Flag entities still marked as STUB that have been
   referenced in played sessions (they need fleshing out)
 
-### Step 4: Relationship Quality
+### Step 4: Character Story Validation
+
+**Story file existence:** For every PC entity where `status`
+is not `dead` or `retired`, verify that a companion story file
+exists at `Characters/PCs/{Name}_Story.md`.
+
+- Severity: **Warning**
+- Proposed fix: "Create story file from template for
+  [[{Name}]]" — use `shared/templates/character-story.md`
+
+**Story file recency:** For every story file that exists,
+read its `asOfSession` frontmatter field. Compare to the
+latest wrap-up's session number (from the session index or
+most recent `type: session-wrap-up` file).
+
+- If the story file is more than 1 session behind, flag it
+- Severity: **Warning**
+- Proposed fix: "Story file for [[{Name}]] is current to
+  session {X} but latest wrap-up is session {Y} — run
+  vault-ingest on the intervening wrap-ups to catch up"
+
+### Step 5: Relationship Quality
 
 **Generic types:** Flag uses of `associated_with` or similar
 vague relationship types where a more specific type exists
@@ -369,7 +390,7 @@ traversal. Two NPCs who share a location don't need a direct
 `associated_with` edge — the shared location is the
 relationship.
 
-### Step 5: Compile Findings
+### Step 6: Compile Findings
 
 For each issue:
 1. Note the entity/entities and files involved

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -45,6 +45,33 @@ relationships, exclusive information. Ground in observable
 behaviour, not generated emotional analysis. Write into
 Wrap-Up file.
 
+### 3b. Character Story Entries
+
+For each active PC in the session, append a story entry to
+their companion file. Read `shared/character-story-format.md`
+for the full format, voice, and append protocol.
+
+1. Look for `Characters/PCs/{Name}_Story.md` — if it doesn't
+   exist, create from `shared/templates/character-story.md`
+2. Determine the campaign's genre voice from the campaign
+   overview or world file
+3. Write 2–4 paragraphs of narrative prose: what this PC did,
+   decided, learned, and how they changed — from this
+   character's perspective, not a session recap
+4. Append as `## Session {N} — {Session Title}` at the bottom
+5. Update frontmatter: `lastUpdated` and `asOfSession` to
+   current session; `source_confidence` mirrors the Wrap-Up
+   file's confidence
+
+**Input:** Narrative Recap (Step 2) and PC Carry-Forward
+(Step 3). No new source gathering.
+
+**Output:** One appended entry per active PC's story file.
+
+Writes for the current session only — no backfilling. If prior
+sessions are missing from a story file, that's vault-ingest
+territory. Never edit prior session entries (append-only).
+
 ### 4. Update the World
 
 - **New entities** (improvised NPCs, locations, items):
@@ -124,6 +151,7 @@ Wrap-up **must** produce all sections so prep reads one file:
 | Keeper Checklist | Yes | Wrap-Up file |
 
 Entity files and timeline are updated separately (Step 4).
+Character story files are updated separately (Step 3b).
 The session index is updated to `wrap-up` status (or `reviewed`
 if reconcile completes).
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -147,6 +147,11 @@ starting the play-event interview, resolve image assignments:
    ask the GM to pick the portrait
 See `references/image-handling.md` for question templates.
 
+**PC arc questions:** After image resolution and before starting
+the play-event interview, ask one question per active PC about
+their personal arc across the ingested period. See
+`references/keeper-interview.md` § PC Narrative Arcs.
+
 ### Phase 5: Synthesize & Hand Off
 
 Read `references/synthesis-templates.md` for the output format.

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -162,6 +162,10 @@ Read `references/synthesis-templates.md` for the output format.
    `shared/session-document-chain.md`
 3. Follow `session-wrapup` workflow to produce the Wrap-Up
    file and create/update entities
+4. For each PC active during the ingested period, write a
+   consolidated character story entry per
+   `references/synthesis-templates.md` § Character Story
+   Backstory Entries
 
 Include `> [!info] Reconstruction Note` with source descriptions
 and limitations. Mark uncertain items with `<!-- UNVERIFIED -->`.

--- a/skills/vault-ingest/references/classification-taxonomy.md
+++ b/skills/vault-ingest/references/classification-taxonomy.md
@@ -15,6 +15,7 @@ distinct section within a document gets one classification.
 | Character sheet | PC or NPC stats, inventory, backstory | DRAFT until placed in timeline | Structured data: attributes, skills, equipment lists |
 | Image/map | Visual reference material — portraits, scene art, location shots, maps | Attachment — no canon status | Binary file (jpg, png, webp, gif, svg, heic, raw, tiff, bmp); classify then process per `image-handling.md` |
 | Spreadsheet/data | Tracking sheets, encounter tables | DRAFT — classify by content | Tabular data, formulas, tracking columns |
+| Session wrap-up | Existing Wrap-Up file from a prior session | AUTHORITATIVE | Contains Narrative Recap, PC Carry-Forward, World State sections; `type: session-wrap-up` frontmatter |
 
 ## Key Heuristics
 

--- a/skills/vault-ingest/references/keeper-interview.md
+++ b/skills/vault-ingest/references/keeper-interview.md
@@ -109,6 +109,24 @@ Which of the scenario's branching points did the players
 take? These are the moments where prep diverges most from
 play.
 
+### 7. PC Narrative Arcs
+
+One question per active PC covering their personal arc across
+the ingested period. This feeds character story file
+construction in Phase 5.
+
+Frame with character context — what the sources already show
+about this PC — and ask what drove them and what changed them.
+
+**Example:** "From the notes, Georgiana spent most of the Lyon
+chapter investigating the university murders and befriending
+Professor Lang. What was her personal arc across these
+sessions — what drove her, and how was she changed by it?"
+
+If the GM has little to add beyond what's in the sources,
+that's fine — the existing play events will still produce a
+story entry. Don't push for invented detail.
+
 ## Output
 
 After the interview, the confirmed events list from Phase 3

--- a/skills/vault-ingest/references/synthesis-templates.md
+++ b/skills/vault-ingest/references/synthesis-templates.md
@@ -124,7 +124,7 @@ type: character-story
 character: "[[{Name}]]"
 campaign: "Campaign Name"
 source_confidence: DRAFT
-lastUpdated: ""
+lastUpdated: "{last ingested session}"
 asOfSession: "{last ingested session}"
 createdSession: "{first ingested session}"
 ---

--- a/skills/vault-ingest/references/synthesis-templates.md
+++ b/skills/vault-ingest/references/synthesis-templates.md
@@ -106,3 +106,72 @@ content, not live capture.
 6. **Scene-by-scene when possible.** If the source material or
    keeper interview reveals a scene structure, use it. If not,
    organize by topic or entity cluster.
+
+## Character Story Backstory Entries
+
+In addition to Play Notes, Phase 5 produces a consolidated
+story entry for each PC active during the ingested period.
+These are written directly to the PC's story file, not to the
+Play Notes output.
+
+### Format
+
+Frontmatter:
+
+```yaml
+---
+type: character-story
+character: "[[{Name}]]"
+campaign: "Campaign Name"
+source_confidence: DRAFT
+lastUpdated: ""
+asOfSession: "{last ingested session}"
+createdSession: "{first ingested session}"
+---
+```
+
+Body:
+
+```markdown
+## Sessions {first}–{last} — {Summary Title}
+
+{Narrative prose covering this character's arc across the
+ingested period. Length proportional to available detail —
+no padding, no fabrication. If sources are sparse, write less
+rather than inventing specifics.}
+
+<!-- sparse source material -->
+{Include this comment only when the entry is thin due to
+limited source data, not a gap in the skill's work.}
+```
+
+### Synthesis Rules (Story Entries)
+
+1. **Compile from all sources.** Draw on extracted play events,
+   keeper interview answers (especially § PC Narrative Arcs),
+   and any per-character source material.
+
+2. **One consolidated entry per PC.** Headed
+   `## Sessions {first}–{last} — {Summary Title}`. Not
+   per-session entries — historical notes rarely have that
+   granularity.
+
+3. **Genre voice from campaign overview.** Same voice matching
+   as session-wrapup uses. See
+   `shared/character-story-format.md` for the genre-voice
+   table.
+
+4. **Scale prose to available data.** Rich sources get longer
+   entries. Sparse sources get shorter entries with a
+   `<!-- sparse source material -->` marker. Never fabricate
+   detail to fill space.
+
+5. **Create file from template if needed.** Use
+   `shared/templates/character-story.md`. If a story file
+   already exists (e.g., from a prior ingestion run or live
+   sessions), append the new consolidated entry below existing
+   content.
+
+6. **Follow character-story-format.md.** Character names not
+   player names, past tense for events, wiki-links for entity
+   references, character's perspective.


### PR DESCRIPTION
## Summary

- **session-wrapup**: New Step 3b writes per-PC character story entries after each session, using the story format and templates from SP1
- **vault-ingest**: Keeper interview gains a PC narrative arc question; Phase 5 synthesizes consolidated backstory entries per PC from historical material; wrap-up files recognized as a source type for catch-up ingestion
- **campaign-qa**: Graph Health validates story file existence for active PCs and flags stale story files more than 1 session behind the latest wrap-up

Sub-project 2 of the Character Sheet Overhaul (SP1 merged in #28). Session-prep and reconcile are intentionally untouched.

## Test plan

- [ ] Run `python3 scripts/validate_schema.py` — all 26 files pass
- [ ] Read each modified SKILL.md to verify step/phase numbering is sequential and cross-references resolve
- [ ] Verify session-wrapup Step 3b references `shared/character-story-format.md` and `shared/templates/character-story.md` (both delivered in SP1)
- [ ] Verify campaign-qa recency check fix suggestion points to vault-ingest (not session-wrapup)
- [ ] Verify no changes in `skills/session-prep/` or `skills/shared/`