### PR TITLE
Vault versioning and migration system

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.9] — 2026-04-26
+
+### Added
+
+- **Vault versioning and migration system** — vaults now track `gm_apprentice_version` in vault-config; every vault-aware skill checks the version on first invocation and runs campaign-organizer's migration workflow if the vault is behind the plugin version
+- **Migration registry** — `skills/shared/migrations.md` defines the current version and per-version migration steps in three categories: structural (auto), content (opt-in), and tooling (opt-in)
+- **Publish site directory in vault-config** — `publish.site_dir` field stores the site repo path so the publish-site skill reads it directly instead of asking each session
+- **Vault-config field documentation** — entity schema now documents all vault-config frontmatter fields
+
+---
+
 ## [1.4.8] — 2026-04-26
 
 ### Added
@@ -230,6 +241,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.4.9]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.8...v1.4.9
 [1.4.8]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.7...v1.4.8
 [1.4.7]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.6...v1.4.7
 [1.4.6]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.5...v1.4.6

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -102,6 +102,28 @@ On first contact with a vault:
    `references/index-template.md` for the index structure. The
    index starts empty.
 
+### Version Check
+
+After initialization confirms `_meta/` exists, check the vault
+version before proceeding with any user request:
+
+1. Read `gm_apprentice_version` from `_meta/vault-config.md`
+   frontmatter
+2. Read `current_version` from `shared/migrations.md` frontmatter
+3. If versions match or vault is higher — proceed normally
+4. If vault version is lower or absent — run the migration
+   workflow from `references/migration-procedure.md` before
+   proceeding
+
+This check runs once per session on first vault contact. It
+does not apply during first-time vault setup (when `_meta/` is
+missing and initialization creates it — stamp the current
+version as part of setup).
+
+When initialization creates a new vault, set
+`gm_apprentice_version` in vault-config to the
+`current_version` from `shared/migrations.md`.
+
 ### Schema Evolution
 
 When content doesn't fit existing types:

--- a/skills/campaign-organizer/references/migration-procedure.md
+++ b/skills/campaign-organizer/references/migration-procedure.md
@@ -1,0 +1,133 @@
+# Vault Migration Procedure
+
+Step-by-step procedure for upgrading a vault to the current
+plugin version. Campaign-organizer runs this directly when it
+detects a version mismatch. Other skills hand off to
+campaign-organizer, which then follows this procedure.
+
+## Trigger
+
+The vault's `gm_apprentice_version` (from `_meta/vault-config.md`
+frontmatter) is lower than `current_version` (from
+`shared/migrations.md` frontmatter), or the field is absent.
+
+## Step 1: Gather state
+
+Read the following:
+
+- `gm_apprentice_version` from `_meta/vault-config.md`
+  (absent = "pre-versioning")
+- `current_version` from `shared/migrations.md`
+- List files in `_meta/` — which of the four schema files exist?
+- List files in `_Templates/` — which templates are present?
+- List all PC files (`type: pc`) and check for
+  `{Name}_Story.md` companions in the same directory
+- If `publish.site_dir` exists in vault-config, read the
+  installed npm version from
+  `{site_dir}/node_modules/gm-apprentice-publish/package.json`
+
+## Step 2: Collect pending migrations
+
+Read `shared/migrations.md`. Find all migration entries that
+apply between the vault's current version and the plugin's
+current version. For pre-versioning vaults, this is the
+baseline entry. For vaults at an intermediate version, collect
+all entries above that version in ascending order.
+
+## Step 3: Diff against vault
+
+For each step in the collected migrations, check whether it is
+already satisfied:
+
+- **Folder exists** → skip
+- **Vault-config field already set** → skip
+- **Template in `_Templates/` matches `shared/templates/`** →
+  skip (compare content, not just existence)
+- **Template in `_Templates/` differs from `shared/templates/`**
+  → mark as "updated — offer overwrite"
+- **Story file already exists for PC** → skip
+- **`_meta/` file already exists** → skip
+- **npm package already at expected version** → skip
+
+Only unsatisfied steps appear in the preview.
+
+## Step 4: Build preview
+
+Group remaining steps into three categories and format as a
+preview for the user:
+
+**Structural (will apply after confirmation):**
+List each structural change as a bullet. Example:
+> - Add `gm_apprentice_version: "1.4.9"` to vault-config
+> - Add `publish.system: "coc-7e"` to vault-config
+> - Create missing `_meta/entity-types.md`
+
+**Content (choose which to apply):**
+List each content change as a checkbox. Example:
+> - [ ] Copy `pc-coc-7e.md` to `_Templates/`
+> - [ ] Overwrite `pc-generic.md` in `_Templates/` (local
+>       version differs from plugin version)
+> - [ ] Create `Lord_Blackwood_Story.md` companion file
+
+**Tooling (choose which to apply):**
+List each tooling change as a checkbox. Example:
+> - [ ] Update gm-apprentice-publish 1.0.0 → 1.1.1
+
+If a category has no pending items, omit it from the preview.
+If all categories are empty (everything already satisfied),
+skip to Step 7 (stamp version).
+
+## Step 5: Present and confirm
+
+Show the preview to the user:
+
+> "Your vault is at version {old} — the plugin is now {new}.
+> Here's what needs to change:"
+>
+> [preview from Step 4]
+>
+> "The structural changes will be applied automatically. For
+> the items marked with checkboxes, let me know which you'd
+> like to include."
+
+Wait for the user to confirm the structural batch and select
+which content/tooling items to apply.
+
+## Step 6: Execute
+
+Apply all confirmed changes in this order:
+
+1. Write vault-config field updates (structural)
+2. Create missing `_meta/` files (structural)
+3. Create missing folders (structural)
+4. Copy selected templates to `_Templates/` (content)
+5. Overwrite selected templates in `_Templates/` (content)
+6. Create selected story files using
+   `shared/templates/character-story.md` as the base, filling
+   in the PC name and campaign from the PC file's frontmatter
+   (content)
+7. Run `npm update gm-apprentice-publish` in site directory if
+   selected (tooling)
+
+## Step 7: Stamp version
+
+Set `gm_apprentice_version` in `_meta/vault-config.md`
+frontmatter to the `current_version` value from
+`shared/migrations.md`.
+
+This happens regardless of which opt-in items the user
+accepted. The vault is now "at" this version. Declined
+content/tooling items will not re-prompt on the next session.
+
+## Step 8: Report and return
+
+Summarize what was changed:
+
+> "Vault upgraded to version {new}. Changes applied:
+> - [list of structural changes]
+> - [list of accepted content changes]
+> - [list of accepted tooling changes]"
+
+Return control to the calling skill, or proceed with the
+user's original request if campaign-organizer was the skill
+that detected the mismatch.

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -57,6 +57,16 @@ Obsidian MCP tools (`search_vault`, `list_vault_files`,
 `get_vault_file`). See `shared/filesystem-mode.md` for the
 full tool mapping and environment detection procedure.
 
+**Version check:** After environment detection, read
+`gm_apprentice_version` from `_meta/vault-config.md` and
+`current_version` from `shared/migrations.md`. If the vault
+version is lower or absent, announce the mismatch and hand off
+to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`) before
+running any audits. Resume after migration completes. Skip this
+check if `_meta/` doesn't exist (that's first-time setup, not
+migration).
+
 Both Obsidian mode and filesystem mode run the same audit
 procedures — only the tools differ. The procedures in
 `references/check-procedures.md` use generic operation names

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -14,6 +14,16 @@ troubleshooting — clearly and without jargon. Most GMs using
 this skill are not technical. Never assume they know what npm,
 git, or a terminal command does without explaining it.
 
+**Version check:** On first invocation, read
+`gm_apprentice_version` from `_meta/vault-config.md` and
+`current_version` from `shared/migrations.md`. If the vault
+version is lower or absent, announce the mismatch and hand off
+to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`) before
+proceeding. Resume after migration completes. Skip this check
+if `_meta/` doesn't exist (that's first-time setup, not
+migration).
+
 ## npm Package
 
 All build logic is handled by the `gm-apprentice-publish` package.
@@ -49,7 +59,9 @@ Do not improvise the setup flow or skip steps.
 "I've updated the vault, refresh the site"
 
 Workflow:
-1. Confirm the site repo path (ask if not known).
+1. Read `publish.site_dir` from `_meta/vault-config.md`. If not
+   set, ask for the absolute path to the site repo directory and
+   offer to save it to vault-config for future sessions.
 2. **Check manifest freshness.** Compare the vault's publishable
    files against `_meta/publish-manifest.md`. Look for:
    - **New files:** vault files not in the manifest. Apply the
@@ -86,7 +98,9 @@ the fix directly after explaining it.
 "new folder in the vault", "pages missing after an update"
 
 Workflow:
-1. Read the site's `vault.config.json` (ask for path if needed).
+1. Read `publish.site_dir` from `_meta/vault-config.md` to
+   locate the site repo. If not set, ask for the path and offer
+   to save it. Then read `vault.config.json` from that directory.
 2. Compare its `folderMap` to the vault's actual folder structure.
 3. Propose any additions needed to `folderMap` or `excludeDirs`.
 4. Apply changes after confirmation.

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -17,6 +17,16 @@ to the Play Notes file for note capture.
 (`type: session-plan`) if it exists. This gives you the GM's
 intended scenes, NPCs, and hooks for quick reference during play.
 
+**Version check:** On first invocation, read
+`gm_apprentice_version` from `_meta/vault-config.md` and
+`current_version` from `shared/migrations.md`. If the vault
+version is lower or absent, announce the mismatch and hand off
+to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`) before
+proceeding with play support. Resume after migration completes.
+Skip this check if `_meta/` doesn't exist (that's first-time
+setup, not migration).
+
 **Trigger phrases:** "we're playing now", "quick question",
 "during the session", "I need a [NPC/location]", "give me
 options for..."

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -10,6 +10,16 @@ Workflow: Reconcile → Gather → Plan → Verify → Handoff.
 **Shared references:** Read `shared/session-principles.md` on
 first invocation.
 
+**Version check:** On first invocation, read
+`gm_apprentice_version` from `_meta/vault-config.md` and
+`current_version` from `shared/migrations.md`. If the vault
+version is lower or absent, announce the mismatch and hand off
+to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`) before
+proceeding with prep. Resume after migration completes. Skip
+this check if `_meta/` doesn't exist (that's first-time setup,
+not migration).
+
 **Document chain:** Read `shared/session-document-chain.md`.
 Session-prep writes Plan files and updates the session index.
 It reads previous Wrap-Up files for context — normally never

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -10,6 +10,16 @@ via the Wrap-Up file.
 **Shared references:** Read `shared/session-principles.md` on
 first invocation.
 
+**Version check:** On first invocation, read
+`gm_apprentice_version` from `_meta/vault-config.md` and
+`current_version` from `shared/migrations.md`. If the vault
+version is lower or absent, announce the mismatch and hand off
+to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`) before
+proceeding with wrap-up. Resume after migration completes. Skip
+this check if `_meta/` doesn't exist (that's first-time setup,
+not migration).
+
 **Document chain:** Read `shared/session-document-chain.md`.
 Session-wrapup reads the Play Notes file and writes the Wrap-Up
 file. It also creates/updates entity files and timeline entries.

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -456,4 +456,31 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | creature (all subtypes) | Creatures/ |
 | event (all subtypes) | Events/ |
 | document (all subtypes) | Documents/ |
+
+## Vault Configuration Fields
+
+The vault's `_meta/vault-config.md` file uses YAML frontmatter
+for campaign-wide settings. These fields are read by multiple
+skills.
+
+### Core fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gm_apprentice_version` | string | Plugin version this vault was last migrated to. Set by the migration system. Skills compare this to `current_version` in `shared/migrations.md` to detect when migration is needed. |
+| `setting_year` | string | In-game date displayed on the published site |
+
+### Publish fields (under `publish:` key)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `system` | string | Game system identifier (`coc-7e`, `coc-7e-regency`, `gurps-4e`, `dnd-5e-2024`, `fitd`). Read by publish tool for system-specific rendering. |
+| `site_dir` | string | Absolute path to the site repo directory. Read by publish-site skill instead of asking each session. Optional — omit if vault doesn't use the publish tool. |
+| `mode` | string | `"player"` or `"full"` — controls GM-only content visibility |
+| `exclude_sections` | array | H2 heading names to strip from published output (default: `["GM Notes"]`) |
+| `exclude_fields` | array | Frontmatter field names to strip (default: `["secrets", "current_plan", "plan_progress"]`) |
+| `exclude_dirs` | array | Vault folders to exclude from publishing (default: `["_meta", "_Templates"]`) |
+| `theme` | object | Theme configuration: `genre`, `palette`, `fonts`, `campaign_image` |
+| `four_oh_four` | object | Custom 404 page: `style`, `message` |
+| `overrides` | object | Per-file include/exclude/field overrides |
 | clue | Clues/ |

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -456,6 +456,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | creature (all subtypes) | Creatures/ |
 | event (all subtypes) | Events/ |
 | document (all subtypes) | Documents/ |
+| clue | Clues/ |
 
 ## Vault Configuration Fields
 
@@ -483,4 +484,3 @@ skills.
 | `theme` | object | Theme configuration: `genre`, `palette`, `fonts`, `campaign_image` |
 | `four_oh_four` | object | Custom 404 page: `style`, `message` |
 | `overrides` | object | Per-file include/exclude/field overrides |
-| clue | Clues/ |

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,0 +1,78 @@
+---
+current_version: "1.4.9"
+---
+
+# Vault Migration Registry
+
+Each vault-aware skill reads `current_version` from this file
+and compares it to `gm_apprentice_version` in the vault's
+`_meta/vault-config.md`. When the vault version is lower or
+absent, campaign-organizer's migration workflow runs before the
+skill proceeds.
+
+When adding a new migration entry: bump `current_version` in
+the frontmatter to match, and add the entry in ascending version
+order at the end of this file.
+
+## How migrations work
+
+Each entry lists changes in three categories:
+
+- **Structural** — applied automatically after user confirms the
+  preview (fields, folders, scaffolding)
+- **Content** — opt-in per item (templates, story files, anything
+  in the user's content space)
+- **Tooling** — opt-in (npm package updates, external tool
+  changes)
+
+The migration procedure diff-checks each step against the vault's
+current state. Steps already satisfied are skipped. See
+`campaign-organizer/references/migration-procedure.md` for the
+full workflow.
+
+## Migration: Baseline (pre-versioning → 1.4.9)
+
+Applies to any vault with no `gm_apprentice_version` field or
+a version below 1.4.9. This is the catch-up migration for all
+vaults created before the versioning system existed.
+
+### Structural
+
+- Add `gm_apprentice_version: "1.4.9"` to `_meta/vault-config.md`
+  frontmatter
+- Add `publish.system` to vault-config if absent (read from
+  campaign context or ask the user which game system this
+  campaign uses)
+- Add `publish.site_dir` to vault-config if the user uses the
+  publish tool (ask for the absolute path to the site repo
+  directory; skip if user doesn't use the publish tool)
+- Ensure all four `_meta/` files exist: `vault-config.md`,
+  `entity-types.md`, `relationship-types.md`, `index.md`
+
+### Content
+
+- Copy any missing PC templates from `shared/templates/` to the
+  vault's `_Templates/` directory. List each template by name
+  and let the user choose which to add:
+  - `pc-generic.md`
+  - `pc-coc-7e.md`
+  - `pc-coc-7e-regency.md`
+  - `pc-dnd-5e-2024.md`
+  - `pc-gurps-4e.md`
+  - `pc-fitd.md`
+  - `crew-fitd.md`
+  - `character-story.md`
+- For templates that already exist in `_Templates/` but differ
+  from the `shared/templates/` version: offer to overwrite,
+  noting that local customizations will be lost
+- Create `{Name}_Story.md` companion files for any PCs that
+  lack them, using `shared/templates/character-story.md` as the
+  template. List each PC and let the user choose which to create.
+
+### Tooling
+
+- If `publish.site_dir` is set in vault-config: check the
+  installed `gm-apprentice-publish` version in
+  `{site_dir}/node_modules/gm-apprentice-publish/package.json`.
+  If lower than 1.1.1, offer to run
+  `npm update gm-apprentice-publish` in the site directory.

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -52,6 +52,14 @@ If no vault detected:
 
 Do not proceed without a vault.
 
+**Version check:** After confirming the vault exists, read
+`gm_apprentice_version` from `_meta/vault-config.md` and
+`current_version` from `shared/migrations.md`. If the vault
+version is lower or absent, announce the mismatch and hand off
+to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`) before
+proceeding with ingestion. Resume after migration completes.
+
 ## The Pipeline
 
 Six phases, sequential. Phases 1-4 owned by vault-ingest.

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -59,6 +59,8 @@ version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before
 proceeding with ingestion. Resume after migration completes.
+Skip this check if `_meta/` doesn't exist (that's first-time
+setup, not migration).
 
 ## The Pipeline
 


### PR DESCRIPTION
## Summary

- **Vault versioning** — vaults now track `gm_apprentice_version` in `_meta/vault-config.md` frontmatter. Every vault-aware skill checks this on first invocation and hands off to campaign-organizer's migration workflow if the vault is behind the plugin version.
- **Migration registry** — `skills/shared/migrations.md` defines the current version and per-version migration steps in three categories: structural (auto after confirmation), content (opt-in per item), and tooling (opt-in). Ships with a single baseline entry for pre-versioning vaults.
- **Publish site directory** — `publish.site_dir` field in vault-config stores the site repo path so publish-site reads it directly instead of asking each session.
- **Vault-config documentation** — entity schema now documents all vault-config frontmatter fields.

Tested live migration on specialforces_vault (GURPS campaign) — structural fields applied, templates copied, story files already present.

## Test plan

- [ ] Vault with no `gm_apprentice_version` triggers migration on any skill invocation
- [ ] Campaign-organizer runs migration directly (no circular handoff)
- [ ] Other skills hand off to campaign-organizer and resume after migration
- [ ] Migration preview shows three categories (structural / content / tooling)
- [ ] Structural changes applied after single confirmation
- [ ] Content and tooling changes are opt-in per item
- [ ] Version stamped regardless of which opt-in items accepted
- [ ] Vault at current version gets no migration prompt
- [ ] ttrpg-expert has no version check (excluded by design)
- [ ] publish-site reads `site_dir` from vault-config instead of asking