### PR TITLE
GURPS sheet alphabetization and mobile HTML fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.10] — 2026-05-01
+
+### Fixed
+
+- **GURPS PC template** — Skills and Spells sections now enforce single alphabetized tables with no category sub-headings
+- **Mobile: accordion table scroll** — Wide tables inside accordion sections scroll horizontally on mobile instead of overflowing
+- **Mobile: back-to-top button** — Fixed-position button appears after 400px scroll on all published pages
+
+---
+
 ## [1.4.9] — 2026-04-26
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,10 @@ Items are force-ranked by score. Higher score = do first.
 | ~~Remove model-specific prescriptions from all skills~~ | 3 | 3 | S (1) | 9.0 | Done | |
 | ~~Skill roles audit: clarify inter-skill relationships~~ | 4 | 4 | M (2) | 6.0 | Done | |
 | ~~Entity creation must read template before writing~~ | 5 | 4 | S (1) | 14.0 | Done | campaign-organizer has no explicit step requiring agents to read `_Templates/_Template_{Type}.md` before creating entity files. Agents pattern-match off existing files instead, producing inconsistent structure. Add a hard gate to Dissect, Organize, and any entity-creation workflow: "Read the matching template before writing." Applies to vault-ingest Phase 5 handoff too. |
-| Pulp Cthulhu variant support | 4 | 4 | M (2) | 6.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality |
+| Session-prep: GM approval gate for new scenes | 5 | 4 | S (1) | 14.0 | Bug | When session-prep creates new scenes, it must present each to the GM first with framing questions (tone, objective, key entities, scene type) before writing. GM controls what goes into their session, not the skill. |
+| ~~Publish tool: GURPS PC sheet — single alphabetized skills list~~ | 5 | 4 | S (1) | 14.0 | Done | GURPS PC skills render as multiple lists instead of one alphabetized list |
+| ~~Publish tool: mobile HTML fixes~~ | 5 | 4 | S (1) | 14.0 | Done | Back-to-top button, horizontal scroll on tables, general mobile responsiveness fixes |
+| Pulp Cthulhu variant support | 4 | 4 | XL (4) | 3.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality. Blocked on finding a legit distributable source — Chaosium BRP ORC license may not cover Pulp-specific content. |
 | the-midwife: guided adventure creation skill | 4 | 2 | M (2) | 5.0 | Idea | Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots. |
 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
 | Publish tool: thematic cause-of-death icons for The Fallen | 2 | 1 | S (1) | 5.0 | Idea | New optional PC frontmatter field `cause_of_death` (combat, madness, eldritch, disease, etc.) with thematic SVG icons on Fallen cards. Builds on status-category icons shipping in rank 1. |
@@ -71,6 +74,8 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
+- ~~GURPS PC sheet: single alphabetized skills list~~ — Added inline comments to pc-gurps-4e.md template enforcing single alphabetized tables for Skills and Spells
+- ~~Mobile HTML fixes~~ — Accordion table horizontal scroll, back-to-top button with scroll-triggered fade
 - ~~Entity creation must read template before writing~~ — Added template-reading gate to campaign-organizer (Organize, Dissect, Stub), session-wrapup (Step 4), and vault-ingest synthesis handoff
 - ~~Remove model-specific prescriptions from all skills~~ — Replaced hardcoded model names with complexity guidance across vault-ingest (PR #26), session-wrapup, and removed inline model lines (PR #27)
 - ~~Skill roles audit~~ — Added skill taxonomy table to README, rewrote ttrpg-expert description to clarify advisor-only boundary, documented all skill roles and boundaries (PR #27)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,6 @@ Items are force-ranked by score. Higher score = do first.
 | Session-prep: GM approval gate for new scenes | 5 | 4 | S (1) | 14.0 | Bug | When session-prep creates new scenes, it must present each to the GM first with framing questions (tone, objective, key entities, scene type) before writing. GM controls what goes into their session, not the skill. |
 | ~~Publish tool: GURPS PC sheet — single alphabetized skills list~~ | 5 | 4 | S (1) | 14.0 | Done | GURPS PC skills render as multiple lists instead of one alphabetized list |
 | ~~Publish tool: mobile HTML fixes~~ | 5 | 4 | S (1) | 14.0 | Done | Back-to-top button, horizontal scroll on tables, general mobile responsiveness fixes |
-| Pulp Cthulhu variant support | 4 | 4 | XL (4) | 3.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality. Blocked on finding a legit distributable source — Chaosium BRP ORC license may not cover Pulp-specific content. |
 | the-midwife: guided adventure creation skill | 4 | 2 | M (2) | 5.0 | Idea | Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots. |
 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
 | Publish tool: thematic cause-of-death icons for The Fallen | 2 | 1 | S (1) | 5.0 | Idea | New optional PC frontmatter field `cause_of_death` (combat, madness, eldritch, disease, etc.) with thematic SVG icons on Fallen cards. Builds on status-category icons shipping in rank 1. |
@@ -58,6 +57,7 @@ Items are force-ranked by score. Higher score = do first.
 | Publish tool: system-specific PC sheet rendering | 4 | 3 | L (3) | 3.7 | Planned | Per-system HTML/CSS treatments for published PC pages (CoC parchment feel, GURPS stat blocks, D&D ability cards, etc.). Builds on SP3's C-ready template dispatch architecture — add one system at a time. |
 | Publish tool: Timeline auto-generation from events/sessions | 3 | 1 | M (2) | 3.5 | Idea | Generate timeline page from event/session dates in frontmatter |
 | Publish tool: Full-text client-side search (lunr) | 3 | 1 | M (2) | 3.5 | Idea | Client-side search index so players can find content in published site |
+| Pulp Cthulhu variant support | 4 | 4 | XL (4) | 3.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality. Blocked on finding a legit distributable source — Chaosium BRP ORC license may not cover Pulp-specific content. |
 | FitD SRD enrichment (Phase 5b) | 2 | 2 | M (2) | 3.0 | Planned | Expand FitD files to GURPS-level depth: more factions, crew types, entanglements |
 | Publish tool: Chapter/Session/Scene templates + hierarchy nav | 3 | 2 | L (3) | 2.7 | Idea | Dedicated templates for narrative hierarchy with parent/child nav |
 | Skill description optimization | 2 | 1 | M (2) | 2.5 | Idea | Marketplace description and SKILL.md routing improvements for discoverability |
@@ -74,8 +74,8 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
-- ~~GURPS PC sheet: single alphabetized skills list~~ — Added inline comments to pc-gurps-4e.md template enforcing single alphabetized tables for Skills and Spells
-- ~~Mobile HTML fixes~~ — Accordion table horizontal scroll, back-to-top button with scroll-triggered fade
+- ~~GURPS PC sheet: single alphabetized skills list~~ — Added inline comments to pc-gurps-4e.md template enforcing single alphabetized tables for Skills and Spells (PR #32)
+- ~~Mobile HTML fixes~~ — Accordion table horizontal scroll, back-to-top button with scroll-triggered fade (PR #32)
 - ~~Entity creation must read template before writing~~ — Added template-reading gate to campaign-organizer (Organize, Dissect, Stub), session-wrapup (Step 4), and vault-ingest synthesis handoff
 - ~~Remove model-specific prescriptions from all skills~~ — Replaced hardcoded model names with complexity guidance across vault-ingest (PR #26), session-wrapup, and removed inline model lines (PR #27)
 - ~~Skill roles audit~~ — Added skill taxonomy table to README, rewrote ttrpg-expert description to clarify advisor-only boundary, documented all skill roles and boundaries (PR #27)

--- a/skills/shared/templates/pc-gurps-4e.md
+++ b/skills/shared/templates/pc-gurps-4e.md
@@ -86,6 +86,8 @@ motivations, and description.}
 
 ## Skills
 
+<!-- Always a single alphabetized table. No category sub-headings. -->
+
 | Name | Difficulty | Relative Level | Points | Effective |
 |------|-----------|----------------|--------|-----------|
 | | | | | |
@@ -97,6 +99,8 @@ motivations, and description.}
 | | | | |
 
 ## Spells
+
+<!-- Always a single alphabetized table. No category sub-headings. -->
 
 | Name | College | Skill Level | Energy | Maintain | Notes |
 |------|---------|-------------|--------|----------|-------|

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -852,12 +852,14 @@ td .stat {
   font-size: 1.25rem;
   cursor: pointer;
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s, visibility 0.2s;
   z-index: 50;
 }
 .back-to-top.visible {
   opacity: 0.85;
+  visibility: visible;
   pointer-events: auto;
 }
 .back-to-top:hover {

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -838,6 +838,33 @@ td .stat {
   margin-top: 3rem;
 }
 
+/* ===== BACK TO TOP ===== */
+.back-to-top {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: none;
+  background: var(--medium);
+  color: var(--white);
+  font-size: 1.25rem;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 50;
+}
+.back-to-top.visible {
+  opacity: 0.85;
+  pointer-events: auto;
+}
+.back-to-top:hover {
+  background: var(--accent);
+  opacity: 1;
+}
+
 /* ===== NPC QUICK STATS ===== */
 .quick-stats {
   display: grid;
@@ -1066,7 +1093,8 @@ td .stat {
   .site-nav,
   .menu-toggle,
   .section-nav,
-  .site-footer {
+  .site-footer,
+  .back-to-top {
     display: none;
   }
   .accordion-body,

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -318,6 +318,8 @@ li {
   display: none;
   padding: 1rem;
   background: var(--card-bg);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 .accordion.open .accordion-body {
   display: block;

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -64,7 +64,7 @@ document.querySelectorAll('.site-nav a').forEach(a => {
   var btn = document.querySelector('.back-to-top');
   if (btn) window.addEventListener('scroll', function() {
     btn.classList.toggle('visible', window.scrollY > 400);
-  });
+  }, { passive: true });
 })();
 </script>
 

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -54,10 +54,18 @@ ${content}
 
 ${footerHtml}
 
+<button class="back-to-top" onclick="window.scrollTo({top:0})" aria-label="Back to top">&#8593;</button>
+
 <script>
 document.querySelectorAll('.site-nav a').forEach(a => {
   a.addEventListener('click', () => document.getElementById('nav').classList.remove('open'));
 });
+(function() {
+  var btn = document.querySelector('.back-to-top');
+  if (btn) window.addEventListener('scroll', function() {
+    btn.classList.toggle('visible', window.scrollY > 400);
+  });
+})();
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- GURPS PC template now enforces single alphabetized tables for Skills and Spells (no category sub-headings)
- Accordion bodies get horizontal scroll on mobile for wide tables (equipment, stats)
- Back-to-top button on all published pages — fixed bottom-right, fades in after 400px scroll

## Test plan
- [ ] Publish a vault with a GURPS PC and verify skills/spells render as single tables
- [ ] View published site on mobile — confirm wide tables scroll horizontally in accordions
- [ ] Scroll down on any page — confirm back-to-top button appears and works
- [ ] Print a page — confirm back-to-top button is hidden