### PR TITLE
Add development workflow and CI enforcement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,3 +70,51 @@ jobs:
 
       - name: Validate campaign entity schemas
         run: python scripts/validate_schema.py tests/benchmark-campaign
+
+  pr-discipline:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        continue-on-error: true
+        run: |
+          PR_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          git fetch origin main --quiet
+          MAIN_VERSION=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo "::warning::No version bump detected — no release will be created on merge"
+            exit 1
+          fi
+
+      - name: Check changelog updated
+        continue-on-error: true
+        run: |
+          PR_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          git fetch origin main --quiet
+          MAIN_VERSION=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
+          if [ "$PR_VERSION" != "$MAIN_VERSION" ]; then
+            if ! git diff origin/main -- CHANGELOG.md | grep -q '^+'; then
+              echo "::warning::Version bumped but CHANGELOG.md not updated"
+              exit 1
+            fi
+          fi
+
+      - name: Test build script
+        run: |
+          ./scripts/build-skill-zips.sh
+          ZIP_COUNT=$(ls dist/*.zip 2>/dev/null | wc -l | xargs)
+          if [ "$ZIP_COUNT" -ne 8 ]; then
+            echo "::error::Expected 8 skill zips, got $ZIP_COUNT"
+            exit 1
+          fi
+          for z in dist/*.zip; do
+            if ! unzip -l "$z" | grep -q 'SKILL.md'; then
+              echo "::error::$(basename "$z") missing SKILL.md"
+              exit 1
+            fi
+          done
+          echo "All 8 skill zips valid"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,8 +96,8 @@ jobs:
           PR_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
           MAIN_VERSION=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
           if [ "$PR_VERSION" != "$MAIN_VERSION" ]; then
-            if ! git diff origin/main -- CHANGELOG.md | grep -q '^+[^+]'; then
-              echo "::warning::Version bumped but CHANGELOG.md not updated"
+            if ! git diff origin/main -- CHANGELOG.md | grep -Eq "^\+## \[$PR_VERSION\]"; then
+              echo "::warning::Version bumped to $PR_VERSION but no CHANGELOG entry for this version"
               exit 1
             fi
           fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,10 +94,9 @@ jobs:
         continue-on-error: true
         run: |
           PR_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-          git fetch origin main --quiet
           MAIN_VERSION=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
           if [ "$PR_VERSION" != "$MAIN_VERSION" ]; then
-            if ! git diff origin/main -- CHANGELOG.md | grep -q '^+'; then
+            if ! git diff origin/main -- CHANGELOG.md | grep -q '^+[^+]'; then
               echo "::warning::Version bumped but CHANGELOG.md not updated"
               exit 1
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.11] — 2026-05-01
+
+### Added
+
+- **Automated releases** — GitHub Action creates tagged releases with
+  skill zips on version bump; skill zips attached as release assets
+  for users who can't install plugins
+- **Build script** — `scripts/build-skill-zips.sh` packages each skill
+  as a self-contained zip with shared references bundled
+- **Individual skill upload docs** — README and quickstart updated with
+  instructions for uploading skill zips to Claude Desktop
+
+### Fixed
+
+- **ttrpg-expert description** — trimmed to 983 chars to fit the
+  1024-character limit for skill descriptions
+- **Claude Desktop install instructions** — updated for the new
+  Cowork > Customize > Personal plugins UI flow
+- **Stale skill counts** — README Obsidian section and quickstart now
+  reference all 8 skills
+
+---
+
 ## [1.4.10] — 2026-05-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.4.12]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.11...v1.4.12
+[1.4.11]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.10...v1.4.11
+[1.4.10]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.9...v1.4.10
 [1.4.9]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.8...v1.4.9
 [1.4.8]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.7...v1.4.8
 [1.4.7]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.6...v1.4.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.12] — 2026-05-01
+
+### Added
+
+- **Development workflow** — CLAUDE.md now documents the required
+  branch → implement → version bump → changelog → review → PR → merge
+  sequence for all non-trivial changes
+- **PR discipline checks** — CI warns on missing version bumps and
+  changelog updates; blocks on broken build script output
+
+---
+
 ## [1.4.11] — 2026-05-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,9 +131,12 @@ Every non-trivial change follows this sequence:
    under the new version in `CHANGELOG.md`, following the existing format
 5. **Local review** — dispatch the code-reviewer agent against the branch
    before pushing; fix all findings
-6. **Push + PR** — push the branch and open a PR to main
-7. **CI** — wait for all checks to pass
-8. **Merge** — the release workflow creates the tag and GitHub Release
+6. **Ask before pushing** — present a summary of what will be pushed and
+   wait for explicit user confirmation before running `git push` or
+   `gh pr create`. Never push or open a PR autonomously.
+7. **Push + PR** — push the branch and open a PR to main
+8. **CI** — wait for all checks to pass
+9. **Merge** — the release workflow creates the tag and GitHub Release
    with skill zips automatically
 
 **What counts as trivial:** single file, 1-2 lines, user explicitly says

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,31 @@ and move it to the "Completed" section with a PR number or commit SHA.
   prefixes
 - Prefer small, focused commits over batched changes
 
+## Development workflow
+
+Every non-trivial change follows this sequence:
+
+1. **Branch** — create a feature branch from main
+2. **Implement** — write code and tests for any scripts or tooling
+3. **Version bump** — bump `version` in `.claude-plugin/plugin.json`
+   (patch by default unless the user specifies otherwise)
+4. **CHANGELOG** — add a categorized entry (Added/Changed/Fixed/Removed)
+   under the new version in `CHANGELOG.md`, following the existing format
+5. **Local review** — dispatch the code-reviewer agent against the branch
+   before pushing; fix all findings
+6. **Push + PR** — push the branch and open a PR to main
+7. **CI** — wait for all checks to pass
+8. **Merge** — the release workflow creates the tag and GitHub Release
+   with skill zips automatically
+
+**What counts as trivial:** single file, 1-2 lines, user explicitly says
+"push to main." Everything else gets a branch and PR.
+
+**Test requirements:** at minimum, run `python3 scripts/validate_schema.py`
+and verify markdown lint passes. For script or tooling changes, verify the
+scripts work locally (e.g., `./scripts/build-skill-zips.sh` produces 8
+valid zips). For publish tool changes, run the publish tool test suite.
+
 ## Skill edits
 
 - **Use Opus** (not Sonnet/Haiku) for any skill file modifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,10 @@ Every non-trivial change follows this sequence:
    `gh pr create`. Never push or open a PR autonomously.
 7. **Push + PR** — push the branch and open a PR to main
 8. **CI** — wait for all checks to pass
-9. **Merge** — the release workflow creates the tag and GitHub Release
-   with skill zips automatically
+9. **CodeRabbit** — check for unresolved CodeRabbit comments on the PR;
+   address all findings before merging
+10. **Merge** — the release workflow creates the tag and GitHub Release
+    with skill zips automatically
 
 **What counts as trivial:** single file, 1-2 lines, user explicitly says
 "push to main." Everything else gets a branch and PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Context for Claude sessions working in this repository.
 ## What this is
 
 A Claude Code plugin marketplace at `AntTheLimey/gm-apprentice` containing
-seven TTRPG Game Master skills:
+eight TTRPG Game Master skills:
 
 - `ttrpg-expert` — rules, content generation, session planning
 - `campaign-organizer` — vault structure, knowledge graph metadata
@@ -14,6 +14,7 @@ seven TTRPG Game Master skills:
 - `session-play` — at-the-table GM support (speed-optimised)
 - `session-wrapup` — post-session processing, entity creation, recaps
 - `vault-ingest` — ingestion of old campaign materials into the vault
+- `publish-site` — publish campaign vault as a static website
 
 Supported systems: CoC 7e (+ Regency Cthulhu variant), GURPS 4e, FitD,
 D&D 5e 2024.


### PR DESCRIPTION
## Summary

- Add development workflow section to CLAUDE.md defining the
  branch → PR → review → merge process for all non-trivial changes
- Add CI checks: version bump warning, changelog warning, build
  script validation (blocking)
- Add missing CHANGELOG entries for v1.4.11 and v1.4.12
- Fix stale skill count in CLAUDE.md (seven → eight, add publish-site)

## Test plan

- [ ] CI checks pass on this PR
- [ ] Version bump warning does not fire (version is bumped)
- [ ] Changelog warning does not fire (changelog is updated)
- [ ] Build script test passes (8 valid zips)