### PR TITLE
session-play enrichment: mid-game routing + capture shorthand

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.18] — 2026-05-03
+
+### Changed
+
+- **session-play enrichment** — expanded from 80 to 129 lines with direct routing for common mid-game needs (rules disputes, improv NPCs, spotlight management, combat pacing, scene recovery)
+- Added Common Mid-Game Lookups routing table pointing to exact files and sections in ttrpg-expert
+- Added Capture Shorthand section documenting entity extraction markers (`NEW-NPC:`, `NEW-LOC:`, `UPDATE:`, etc.) that session-wrapup expects
+- Explicit companion reference to `active-play-management.md` for GM-craft advice during play
+
+### Removed
+
+- Fix 9 (Filesystem Mode Honest Labeling) dropped from Fix and Fortify design spec
+
+---
+
 ## [1.4.17] — 2026-05-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.4.18]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.17...v1.4.18
 [1.4.17]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.16...v1.4.17
 [1.4.16]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.15...v1.4.16
 [1.4.15]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.14...v1.4.15

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -106,7 +106,7 @@ can extract entities automatically:
 | `CONFLICT` | Contradicts existing vault content |
 
 Example play note entry:
-```
+```text
 NEW-NPC: Madame Voss — fortune teller at the pier, nervous,
   knows about the missing ship but won't say why
 Scene 3: PCs investigated the harbour. Found bloodstains

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -69,6 +69,55 @@ file reference and advance `status` to `played`.
 Acknowledge and hold. No editing or analysis — processed during
 wrap-up. Note new entities for wrap-up attention.
 
+## Common Mid-Game Lookups
+
+Route these requests directly — don't search, load the file.
+
+| Need | Go to |
+|------|-------|
+| Rules dispute | `ttrpg-expert/systems/{system}/rules-reference.md` (CoC, D&D, FitD, Generic) or `mechanics.md` (GURPS) |
+| Combat mechanics | `ttrpg-expert/systems/{system}/combat-reference.md` (CoC) or `combat.md` (GURPS) or `conditions-rules.md` (D&D) or `mechanics.md` (FitD) |
+| Improvise NPC | `ttrpg-expert/npc-generation.md` §The 3-Line NPC (Quick Generation) |
+| Random encounter | `ttrpg-expert/random-generation.md` §Random Encounter Generation |
+| Random NPC | `ttrpg-expert/random-generation.md` §Random NPC Generator |
+| Spotlight imbalance | `ttrpg-expert/active-play-management.md` §Spotlight Management |
+| Combat dragging | `ttrpg-expert/active-play-management.md` §Combat Length |
+| Scene fell flat | `ttrpg-expert/active-play-management.md` §Mid-Session Adjustments |
+| Pacing / tension | `ttrpg-expert/active-play-management.md` §Pacing and Flow |
+| Improvisation help | `ttrpg-expert/active-play-management.md` §Improvisation |
+
+Read `ttrpg-expert/active-play-management.md` when the GM needs
+GM-craft advice (spotlight, pacing, improv, difficulty tuning)
+during play. Use it as a companion reference — don't summarize
+it, route to the relevant section and deliver the answer.
+
+## Capture Shorthand
+
+When taking play notes, use these markers so session-wrapup
+can extract entities automatically:
+
+| Marker | Use when |
+|--------|----------|
+| `NEW-NPC` | Improvised character appeared |
+| `NEW-LOC` | New location described |
+| `NEW-ITEM` | Item introduced |
+| `NEW-EVENT` | Significant event occurred |
+| `UPDATE` | Existing entity changed |
+| `CONFLICT` | Contradicts existing vault content |
+
+Example play note entry:
+```
+NEW-NPC: Madame Voss — fortune teller at the pier, nervous,
+  knows about the missing ship but won't say why
+Scene 3: PCs investigated the harbour. Found bloodstains
+  on the Merry Widow's deck. UPDATE: The Merry Widow —
+  confirmed abandoned, signs of struggle below decks
+```
+
+These markers match what session-wrapup expects in its entity
+extraction step — notes taken during play arrive pre-formatted
+for wrap-up processing.
+
 ## Behavior Rules
 
 - **1-5 sentences** unless GM asks for more

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.4.17"
+current_version: "1.4.18"
 ---
 
 # Vault Migration Registry
@@ -107,5 +107,9 @@ No vault schema changes. Version stamp only.
 No vault schema changes. Version stamp only.
 
 ## Migration: 1.4.17
+
+No vault schema changes. Version stamp only.
+
+## Migration: 1.4.18
 
 No vault schema changes. Version stamp only.


### PR DESCRIPTION
## Summary

- **session-play SKILL.md** expanded from 80 to 129 lines with two new sections:
  - **Common Mid-Game Lookups** — direct routing table for 10 common mid-game needs (rules disputes, improv NPCs, spotlight management, combat pacing, scene recovery) pointing to exact files and sections
  - **Capture Shorthand** — documents entity extraction markers (NEW-NPC, NEW-LOC, UPDATE, etc.) matching what session-wrapup expects, so play notes arrive pre-formatted for wrap-up
- Explicit companion reference to `active-play-management.md` for GM-craft advice during play
- Fix 9 (Filesystem Mode Honest Labeling) removed from Fix and Fortify design spec

## Smoke test results

3 queries run against baseline (80-line) and enriched (129-line) SKILL.md using Sonnet agents:

| Metric | Baseline (avg) | Enriched (avg) | Delta |
|--------|---------------|----------------|-------|
| Files read | 2.7 | 1.0 | -63% |
| Tool uses | 7.0 | 3.3 | -53% |
| Total tokens | 26,975 | 19,017 | -29% |
| Wall clock | 37.8s | 20.7s | -45% |

No quality degradation — both versions produced equivalent, table-ready responses. Biggest win: spotlight advice (Q3) went from 50s/31K tokens to 20s/19K tokens.

## Test plan

- [x] `python3 scripts/validate_schema.py` passes
- [x] `scripts/build-skill-zips.sh` produces 8 valid zips
- [x] All routing targets verified to exist with correct section headings
- [x] Capture shorthand markers match session-wrapup's recap-formats.md
- [x] SKILL.md stays under 150-line target (129 lines)
- [x] Before/after smoke test with 3 representative queries
- [ ] CI passes
- [ ] CodeRabbit review