### PR TITLE
Canon confidence payoff: badges, exclude_drafts, stale-DRAFT warning, SUPERSEDED enforcement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.4.19]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.18...v1.4.19
 [1.4.18]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.17...v1.4.18
 [1.4.17]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.16...v1.4.17
 [1.4.16]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.15...v1.4.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.19] — 2026-05-03
+
+### Added
+
+- Confidence badges in published sites (Draft, Stub, Superseded)
+- `exclude_drafts` publish config option to filter DRAFT entities from sites
+- Stale DRAFT detection in campaign-qa (WARNING after 3+ sessions)
+- SUPERSEDED entities must declare `superseded_by` (enforced in CI)
+- Session 4 + confidence test entities in benchmark campaign
+
+### Fixed
+
+- Publish tool now reads `source_confidence` field (was checking nonexistent `canon_status`)
+- SUPERSEDED link-map redirect now works against real vault entities
+
 ## [1.4.18] — 2026-05-03
 
 ### Changed

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -137,6 +137,12 @@ def validate_file(filepath: Path) -> list[str]:
                 f"Invalid source_confidence '{value}' — "
                 f"must be one of: {', '.join(sorted(SOURCE_CONFIDENCE))}"
             )
+        elif value == "SUPERSEDED":
+            superseded_by = frontmatter.get("superseded_by", "")
+            if not superseded_by:
+                errors.append(
+                    "SUPERSEDED entity missing 'superseded_by' reference"
+                )
 
     # Validate session status
     if entity_type == "session" and "status" in frontmatter:

--- a/skills/campaign-qa/references/check-procedures.md
+++ b/skills/campaign-qa/references/check-procedures.md
@@ -16,6 +16,7 @@ perform each check systematically.
 3. [Name Similarity](#name-similarity)
 4. [Clue Redundancy](#clue-redundancy)
 5. [Graph Health](#graph-health)
+6. [Stale DRAFT Detection](#stale-draft-detection)
 
 ---
 
@@ -407,8 +408,6 @@ For each issue:
 ---
 
 ## Stale DRAFT Detection
-
-### Stale DRAFT Detection
 
 **Severity:** WARNING
 **Trigger:** Entity has `source_confidence: DRAFT` and has been

--- a/skills/campaign-qa/references/check-procedures.md
+++ b/skills/campaign-qa/references/check-procedures.md
@@ -403,3 +403,45 @@ For each issue:
      for creation
    - For schema violations: suggest the missing fields
    - For quality issues: suggest specific improvements
+
+---
+
+## Stale DRAFT Detection
+
+### Stale DRAFT Detection
+
+**Severity:** WARNING
+**Trigger:** Entity has `source_confidence: DRAFT` and has been
+DRAFT for 3 or more sessions.
+
+**Procedure:**
+
+1. Determine the current session number — the highest
+   `session_number` value across all session-index entities in
+   the vault
+2. For each entity with `source_confidence: DRAFT`:
+   - Extract the session number from `createdSession` (e.g.
+     "Session 1" → 1)
+   - Calculate age: `current_session - created_session`
+   - If age >= 3: flag as WARNING
+3. Entities without `createdSession` that are DRAFT: flag as
+   WARNING with different message
+
+**Messages:**
+
+- With age: "Stale DRAFT (created session N, now session M) —
+  promote to AUTHORITATIVE or delete. Entity has been
+  unconfirmed for 3+ sessions."
+- Without createdSession: "DRAFT entity missing createdSession —
+  cannot determine staleness. Add createdSession or promote."
+
+**Rationale:** DRAFT entities are meant to be temporary — they
+represent unconfirmed content awaiting GM review. After 3
+sessions, the GM has had ample opportunity to confirm or reject.
+Lingering DRAFTs indicate either forgotten content or content
+that should have been deleted.
+
+**Not flagged:** DRAFT entities less than 3 sessions old are
+normal and expected (Info level at most). Prep content
+(session-plan type) is always DRAFT and is exempt from this
+check.

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -21,6 +21,7 @@ any equivalent in `vault.config.json`.
 | Theme genre | `publish.theme.genre` | Genre tag for theming hints |
 | 404 message | `publish.four_oh_four.message` | Custom in-world 404 text |
 | Overrides | `publish.overrides` | Per-file include/exclude/field overrides |
+| Exclude drafts | `publish.exclude_drafts` | When `true`, DRAFT entities are excluded entirely (default: `false`) |
 | Setting year | `setting_year` | In-game date shown on the landing page |
 
 ## `vault.config.json` (in the site repo)
@@ -47,3 +48,21 @@ When both files define the same setting (e.g. `excludeSections`
 in `vault.config.json` and `publish.exclude_sections` in
 `vault-config.md`), the vault-config.md value wins. The JSON
 file values are used only as fallbacks.
+
+---
+
+## Content Filtering: DRAFT Entities
+
+```yaml
+publish:
+  exclude_drafts: false
+```
+
+When `true`, entities with `source_confidence: DRAFT` are
+excluded entirely from the published site — they won't appear
+in navigation, index pages, or as individual pages. Wiki-links
+to excluded DRAFT entities will not resolve.
+
+Default `false` — DRAFT entities publish normally with a visible
+"Draft" badge, letting players see work-in-progress content
+while knowing it's unconfirmed.

--- a/skills/publish-site/references/schema-reference.md
+++ b/skills/publish-site/references/schema-reference.md
@@ -231,10 +231,27 @@ These fields are read by all templates if present:
 | Field | Description |
 |-------|-------------|
 | `aliases` | List of alternate names used for wiki-link resolution |
-| `canon_status` | DRAFT / AUTHORITATIVE / SUPERSEDED — SUPERSEDED entities render a redirect banner |
-| `superseded_by` | `[[wiki-link]]` shown in the redirect banner if `canon_status` is SUPERSEDED |
+| `source_confidence` | DRAFT / AUTHORITATIVE / SUPERSEDED / STUB — renders a confidence badge (see below) |
+| `canon_status` | Legacy name for `source_confidence` — still works as fallback |
+| `superseded_by` | `[[wiki-link]]` — SUPERSEDED entities redirect links to this target |
 | `relationships` | List of `{ target, type, description }` objects rendered as a Relationships section |
 | `tags` | Used for NPC importance scoring on the landing page; not rendered on entity pages |
+
+### Confidence Badges
+
+The publish tool reads `source_confidence` from entity frontmatter
+(falls back to `canon_status` for backwards compatibility) and
+renders a badge next to the page title:
+
+| Value | Badge | Appearance |
+|-------|-------|-----------|
+| AUTHORITATIVE | None | Normal page (no badge) |
+| DRAFT | "Draft" | Amber badge — content not yet confirmed |
+| STUB | "Stub" | Warning-coloured badge — placeholder only |
+| SUPERSEDED | "Superseded" | Grey badge — replaced by newer content |
+
+SUPERSEDED entities also redirect wiki-links to their
+`superseded_by` target when that target exists in the site.
 
 **Page title:** The page title is always derived from the vault
 filename (without the `.md` extension), not from frontmatter. To

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.4.18"
+current_version: "1.4.19"
 ---
 
 # Vault Migration Registry

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Scene - The Confrontation.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Scene - The Confrontation.md
@@ -1,0 +1,11 @@
+---
+type: scene
+source_confidence: AUTHORITATIVE
+scene_type: combat
+status: played
+session: 4
+---
+
+# The Confrontation
+
+The investigators storm the mill and interrupt Father Blackwood's ritual. Combat breaks out between the party and cult guards while Blackwood attempts to complete the ceremony.

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning - Wrap-Up.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning - Wrap-Up.md
@@ -1,0 +1,33 @@
+---
+type: session-wrap-up
+session: "[[Session 04 - The Reckoning]]"
+chapter: "[[Chapter 1 - The Ashford Case]]"
+campaign: "The Ashford Case"
+source_confidence: AUTHORITATIVE
+created_by: session-wrapup
+tags: []
+---
+
+# Session 4: The Reckoning
+
+## Session Summary
+
+The investigators confronted [[Father Blackwood]] at [[The Old Mill]] after tracing the cult's supply route from [[Kingsport Docks]]. The confrontation revealed Blackwood's true allegiance to the [[Order of the Silver Twilight]] and his role in [[Professor Ashford]]'s disappearance.
+
+## Key Events
+
+### The Mill Approach (afternoon)
+The party scouted [[The Old Mill]] from a distance, confirming activity inside. [[The Hooded Figure]] was spotted entering through a side door.
+
+### The Confrontation
+Direct confrontation with [[Father Blackwood]], who attempted to complete a ritual. The investigators disrupted the ceremony but Blackwood escaped into the tunnels beneath the mill.
+
+## Entities Introduced
+
+- [[Father Blackwood]] — revealed as cult leader (supersedes earlier version)
+- [[The Old Mill]] — cult meeting site, tunnels beneath
+
+## Next Session Hooks
+
+- Pursue Blackwood through the tunnel network
+- The ritual was partially completed — consequences unknown

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning.md
@@ -1,0 +1,15 @@
+---
+type: session
+session_number: 4
+chapter: "[[Chapter 1 - The Ashford Case]]"
+campaign: "The Ashford Case"
+planned_date: null
+actual_date: "2024-02-15"
+status: reviewed
+documents:
+  plan: null
+  play_notes: null
+  wrap_up: "[[Session 04 - The Reckoning - Wrap-Up]]"
+scenes: []
+tags: []
+---

--- a/tests/benchmark-campaign/Locations/The_Old_Mill.md
+++ b/tests/benchmark-campaign/Locations/The_Old_Mill.md
@@ -1,0 +1,22 @@
+---
+type: location
+createdSession: "Session 2"
+lastUpdated: "Session 4"
+source_confidence: DRAFT
+aliases:
+  - "Old Mill"
+  - "The Mill"
+tags:
+  - cult
+  - dungeon
+---
+
+# The Old Mill
+
+## Overview
+**Type:** Abandoned industrial building
+**Region:** Outskirts of Kingsport
+
+## Description
+
+A disused grain mill on the edge of town. Recently discovered to be a meeting place for the [[Order of the Silver Twilight]]. Tunnels beneath connect to unknown locations.

--- a/tests/benchmark-campaign/NPCs/Father_Blackwood.md
+++ b/tests/benchmark-campaign/NPCs/Father_Blackwood.md
@@ -1,0 +1,31 @@
+---
+type: npc
+createdSession: "Session 4"
+lastUpdated: "Session 4"
+source_confidence: AUTHORITATIVE
+status: "missing"
+aliases:
+  - "Blackwood"
+  - "Father B"
+tags:
+  - cult
+  - antagonist
+---
+
+# Father Blackwood
+
+## Overview
+**Role:** Cult leader, primary antagonist.
+**Age:** 55
+**Occupation:** Parish priest (cover identity)
+**Status:** Missing — escaped into tunnels beneath [[The Old Mill]]
+
+## True Nature
+
+Leader of the local [[Order of the Silver Twilight]] cell. Responsible for [[Professor Ashford]]'s disappearance. Used his position as parish priest to deflect suspicion while coordinating cult activities through the docks and the mill.
+
+## Relationships
+
+- [[Professor Ashford]] — target, knew too much
+- [[Order of the Silver Twilight]] — leads the local cell
+- [[Brother Ezra]] — subordinate in the Order

--- a/tests/benchmark-campaign/NPCs/Father_Blackwood_v1.md
+++ b/tests/benchmark-campaign/NPCs/Father_Blackwood_v1.md
@@ -1,0 +1,21 @@
+---
+type: npc
+createdSession: "Session 1"
+lastUpdated: "Session 3"
+source_confidence: SUPERSEDED
+superseded_by: "[[Father Blackwood]]"
+status: "alive"
+aliases: []
+tags:
+  - clergy
+---
+
+# Father Blackwood (Initial)
+
+## Overview
+**Role:** Local parish priest, helpful community contact.
+**Status:** SUPERSEDED — true nature revealed in Session 4.
+
+## Notes
+
+Initial impression of Blackwood as a helpful NPC. Superseded when his true allegiance to the Order was revealed.

--- a/tests/benchmark-campaign/NPCs/The_Hooded_Figure.md
+++ b/tests/benchmark-campaign/NPCs/The_Hooded_Figure.md
@@ -1,0 +1,27 @@
+---
+type: npc
+createdSession: "Session 1"
+lastUpdated: "Session 1"
+source_confidence: DRAFT
+status: "alive"
+aliases:
+  - "Hooded Figure"
+  - "The Figure"
+tags:
+  - mystery
+  - unidentified
+---
+
+# The Hooded Figure
+
+## Overview
+**Role:** Unidentified antagonist seen at multiple locations.
+**Status:** Identity unknown — DRAFT pending GM confirmation.
+
+## Appearances
+
+Spotted near [[Professor Ashford]]'s residence on the night of his disappearance. Seen again at [[Kingsport Docks]] during the warehouse stakeout. Most recently observed entering [[The Old Mill]].
+
+## GM Notes
+
+Identity not yet confirmed. May be [[Father Blackwood]] or a separate cultist.

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -169,8 +169,9 @@ The `type` frontmatter field determines which template renders each page.
 | `event`, `clue`, `document`, `chapter`, `session`, `scene` | Smart wiki | Frontmatter badges + body |
 | anything else | Smart wiki | All frontmatter shown as badges |
 
-Pages with `source_confidence: SUPERSEDED` render a redirect banner pointing
-to the superseding entity (also supports legacy `canon_status` as fallback).
+Pages with `source_confidence: SUPERSEDED` resolve wiki-links to the
+superseding entity and show a `Superseded` badge (also supports legacy
+`canon_status` as fallback).
 
 ### Landing page (dashboard)
 

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -169,8 +169,8 @@ The `type` frontmatter field determines which template renders each page.
 | `event`, `clue`, `document`, `chapter`, `session`, `scene` | Smart wiki | Frontmatter badges + body |
 | anything else | Smart wiki | All frontmatter shown as badges |
 
-Pages with `canon_status: SUPERSEDED` render a redirect banner pointing
-to the superseding entity.
+Pages with `source_confidence: SUPERSEDED` render a redirect banner pointing
+to the superseding entity (also supports legacy `canon_status` as fallback).
 
 ### Landing page (dashboard)
 

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -523,11 +523,11 @@ td .stat {
   margin-bottom: 0;
 }
 
-/* ===== STUB BADGE ===== */
-.stub-badge {
+/* ===== CONFIDENCE BADGES ===== */
+.badge-stub,
+.badge-draft,
+.badge-superseded {
   display: inline-block;
-  background: var(--warning);
-  color: var(--dark);
   font-size: 0.7rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -536,6 +536,21 @@ td .stat {
   border-radius: 0.2rem;
   vertical-align: middle;
   margin-left: 0.5rem;
+}
+
+.badge-stub {
+  background: var(--warning);
+  color: var(--dark);
+}
+
+.badge-draft {
+  background: #e8b84d;
+  color: var(--dark);
+}
+
+.badge-superseded {
+  background: var(--border);
+  color: var(--text-muted);
 }
 
 /* needs development box */

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -98,10 +98,18 @@ function build(options = {}) {
   // Main build logic
   assertSafeOutputDir();
   console.log('Scanning vault:', config.vaultPath);
-  config.excludeDrafts = publishConfig.exclude_drafts;
   let pages = scanVault(config);
   console.log(`Found ${pages.length} pages`);
   pairStoryFiles(pages, config.vaultPath);
+
+  // Exclude DRAFT entities when configured (after pairing so story files resolve)
+  if (publishConfig.exclude_drafts) {
+    const { getConfidence } = require('./templates/base');
+    const before = pages.length;
+    pages = pages.filter(p => getConfidence(p.frontmatter) !== 'DRAFT');
+    const excluded = before - pages.length;
+    if (excluded > 0) console.log(`Excluded ${excluded} DRAFT entity/entities`);
+  }
 
   // Auto-exclude prep/draft files based on frontmatter (player mode only)
   function isAutoExcluded(fm) {

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -98,6 +98,7 @@ function build(options = {}) {
   // Main build logic
   assertSafeOutputDir();
   console.log('Scanning vault:', config.vaultPath);
+  config.excludeDrafts = publishConfig.exclude_drafts;
   let pages = scanVault(config);
   console.log(`Found ${pages.length} pages`);
   pairStoryFiles(pages, config.vaultPath);

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -4,6 +4,7 @@ const matter = require('gray-matter');
 
 const PUBLISH_DEFAULTS = {
   mode: 'player',
+  exclude_drafts: false,
   exclude_sections: ['GM Notes'],
   exclude_fields: ['secrets', 'current_plan', 'plan_progress'],
   exclude_dirs: ['_meta', '_Templates'],
@@ -51,6 +52,7 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
   const merged = {
     mode: publish.mode || PUBLISH_DEFAULTS.mode,
     system: publish.system || null,
+    exclude_drafts: publish.exclude_drafts ?? PUBLISH_DEFAULTS.exclude_drafts,
     exclude_sections: publish.exclude_sections
       || (jsonConfigFallback.excludeSections
         ? [...jsonConfigFallback.excludeSections]

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -79,11 +79,6 @@ function scanVault(config) {
   }
 
   walk(vaultPath);
-
-  if (config.excludeDrafts) {
-    return pages.filter(p => getConfidence(p.frontmatter) !== 'DRAFT');
-  }
-
   return pages;
 }
 

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -79,6 +79,11 @@ function scanVault(config) {
   }
 
   walk(vaultPath);
+
+  if (config.excludeDrafts) {
+    return pages.filter(p => getConfidence(p.frontmatter) !== 'DRAFT');
+  }
+
   return pages;
 }
 

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
+const { getConfidence } = require('./templates/base');
 
 function slugify(name) {
   const slug = name
@@ -86,14 +87,14 @@ function buildLinkMap(pages) {
 
   // Pass 1: add all canonical titles (non-superseded first so they claim their own names)
   for (const page of pages) {
-    if (page.frontmatter.canon_status !== 'SUPERSEDED') {
+    if (getConfidence(page.frontmatter) !== 'SUPERSEDED') {
       map[page.title] = page.outputPath;
     }
   }
 
   // Pass 2: add superseded titles, redirecting to their superseded_by target if possible
   for (const page of pages) {
-    if (page.frontmatter.canon_status === 'SUPERSEDED') {
+    if (getConfidence(page.frontmatter) === 'SUPERSEDED') {
       if (page.title in map) continue;
       const supersededBy = page.frontmatter.superseded_by;
       if (supersededBy) {

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -72,11 +72,22 @@ document.querySelectorAll('.site-nav a').forEach(a => {
 </html>`;
 }
 
-function stubBadge(frontmatter) {
-  if (frontmatter.canon_status === 'STUB') {
-    return ' <span class="stub-badge">Stub</span>';
+function getConfidence(frontmatter) {
+  return frontmatter.source_confidence || frontmatter.canon_status || null;
+}
+
+function confidenceBadge(frontmatter) {
+  const confidence = getConfidence(frontmatter);
+  switch (confidence) {
+    case 'STUB':
+      return ' <span class="badge badge-stub">Stub</span>';
+    case 'DRAFT':
+      return ' <span class="badge badge-draft">Draft</span>';
+    case 'SUPERSEDED':
+      return ' <span class="badge badge-superseded">Superseded</span>';
+    default:
+      return '';
   }
-  return '';
 }
 
 // Maps entity types to frontmatter fields that should render as metadata badges.
@@ -136,7 +147,8 @@ module.exports = {
   cssPath,
   rootPath,
   baseShell,
-  stubBadge,
+  getConfidence,
+  confidenceBadge,
   TYPE_BADGE_FIELDS,
   metadataBadgesFor,
   portraitImg,

--- a/tools/publish/lib/templates/creature.js
+++ b/tools/publish/lib/templates/creature.js
@@ -1,5 +1,5 @@
 const { escapeHtml } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, portraitImg } = require('./base');
 
 function creatureTemplate(page, processedContent, navFor, config, imageMap) {
   const fm = page.frontmatter;
@@ -43,7 +43,7 @@ function creatureTemplate(page, processedContent, navFor, config, imageMap) {
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${badgeHtml}\n${statBlock}\n${abilities}\n${weaknesses}\n${processedContent.html}\n${processedContent.relationships}`;

--- a/tools/publish/lib/templates/event.js
+++ b/tools/publish/lib/templates/event.js
@@ -1,5 +1,5 @@
 const { escapeHtml, relativePath } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, portraitImg } = require('./base');
 
 function parseParticipant(raw) {
   const str = String(raw).trim();
@@ -54,7 +54,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
   ${metaHtml}
 </div>`;
 

--- a/tools/publish/lib/templates/faction.js
+++ b/tools/publish/lib/templates/faction.js
@@ -1,5 +1,5 @@
 const { escapeHtml, relativePath } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, portraitImg } = require('./base');
 
 function factionTemplate(page, processedContent, navFor, config, imageMap, linkMap, allPages) {
   const fm = page.frontmatter;
@@ -71,7 +71,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${badgeHtml}\n${leadershipHtml}\n${territoryHtml}\n${goals}\n${membersHtml}\n${processedContent.html}\n${processedContent.relationships}`;

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -1,5 +1,5 @@
 const { escapeHtml, relativePath } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge } = require('./base');
 
 function indexTemplate(outputDir, title, pages, navFor, config) {
   const outputPath = outputDir ? `${outputDir}/index.html` : 'index.html';
@@ -14,7 +14,7 @@ function indexTemplate(outputDir, title, pages, navFor, config) {
           : relativePath(currentDir, p.outputPath);
         return `
 <div class="roster-card">
-  <h3><a href="${href}">${escapeHtml(p.displayTitle)}</a>${stubBadge(fm)}</h3>
+  <h3><a href="${href}">${escapeHtml(p.displayTitle)}</a>${confidenceBadge(fm)}</h3>
   ${subtitle ? `<div class="role">${escapeHtml(subtitle)}</div>` : ''}
 </div>`;
       }).join('\n')}</div>`

--- a/tools/publish/lib/templates/index.js
+++ b/tools/publish/lib/templates/index.js
@@ -1,4 +1,4 @@
-const { DIR_LABELS, cssPath, rootPath, baseShell, stubBadge, TYPE_BADGE_FIELDS, metadataBadgesFor, portraitImg } = require('./base');
+const { DIR_LABELS, cssPath, rootPath, baseShell, confidenceBadge, TYPE_BADGE_FIELDS, metadataBadgesFor, portraitImg } = require('./base');
 const { generateNav } = require('./nav');
 const { pcTemplate } = require('./pc');
 const { npcTemplate } = require('./npc');
@@ -18,7 +18,7 @@ module.exports = {
   cssPath,
   rootPath,
   baseShell,
-  stubBadge,
+  confidenceBadge,
   TYPE_BADGE_FIELDS,
   metadataBadgesFor,
   portraitImg,

--- a/tools/publish/lib/templates/item.js
+++ b/tools/publish/lib/templates/item.js
@@ -1,5 +1,5 @@
 const { escapeHtml, relativePath } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, portraitImg } = require('./base');
 
 function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap) {
   const fm = page.frontmatter;
@@ -59,7 +59,7 @@ function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap)
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${badgeHtml}\n${statBlock}\n${holderHtml}\n${originHtml}\n${processedContent.html}\n${processedContent.relationships}`;

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -1,5 +1,5 @@
 const { escapeHtml } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, portraitImg } = require('./base');
 
 function locationTemplate(page, processedContent, navFor, config, imageMap) {
   const fm = page.frontmatter;
@@ -21,7 +21,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap) {
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
 </div>`;
 
   const content = `${headerCard}\n${breadcrumb}\n${badgeHtml}\n${processedContent.html}\n${processedContent.relationships}`;

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -1,5 +1,5 @@
 const { escapeHtml } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, portraitImg } = require('./base');
 
 function npcTemplate(page, processedContent, navFor, config, imageMap) {
   const fm = page.frontmatter;
@@ -8,7 +8,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap) {
   const headerCard = `
 <div class="char-header">
   ${portrait}
-  <h1>${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
   <div class="meta">
     ${fm.occupation ? `<span><span class="label">Role</span> ${escapeHtml(fm.occupation)}</span>` : ''}
     ${fm.nationality ? `<span><span class="label">Nationality</span> ${escapeHtml(fm.nationality)}</span>` : ''}

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -1,12 +1,12 @@
 const { escapeHtml } = require('../processor');
-const { baseShell, cssPath, rootPath, stubBadge, metadataBadgesFor, portraitImg } = require('./base');
+const { baseShell, cssPath, rootPath, confidenceBadge, metadataBadgesFor, portraitImg } = require('./base');
 
 function wikiTemplate(page, processedContent, navFor, config, imageMap) {
   const fm = page.frontmatter;
   const badges = metadataBadgesFor(fm);
   const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
 
-  const content = `<h1 class="page-title">${escapeHtml(page.displayTitle)}${stubBadge(fm)}</h1>\n${portrait}\n${badges}\n${processedContent.html}\n${processedContent.relationships}`;
+  const content = `<h1 class="page-title">${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>\n${portrait}\n${badges}\n${processedContent.html}\n${processedContent.relationships}`;
 
   return baseShell({
     title: page.displayTitle,

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -24,6 +24,13 @@ describe('PUBLISH_DEFAULTS', () => {
   });
 });
 
+describe('exclude_drafts', () => {
+  it('defaults to false', () => {
+    const config = loadPublishConfig('/nonexistent/path');
+    assert.strictEqual(config.exclude_drafts, false);
+  });
+});
+
 describe('loadPublishConfig', () => {
   it('returns defaults when vault-config.md has no publish section', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -93,6 +93,17 @@ describe('buildLinkMap', () => {
     const map = buildLinkMap(pages);
     assert.strictEqual(map['Old Name'], 'new.html');
   });
+
+  it('excludes DRAFT pages when excludeDrafts is set', () => {
+    const pages = [
+      { title: 'Active NPC', outputPath: 'npc.html', frontmatter: { source_confidence: 'AUTHORITATIVE' } },
+      { title: 'Draft NPC', outputPath: 'draft.html', frontmatter: { source_confidence: 'DRAFT' } },
+    ];
+    const filtered = pages.filter(p => (p.frontmatter.source_confidence || p.frontmatter.canon_status) !== 'DRAFT');
+    const map = buildLinkMap(filtered);
+    assert.ok('Active NPC' in map);
+    assert.ok(!('Draft NPC' in map));
+  });
 });
 
 describe('scanVault displayTitle', () => {

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert');
 const path = require('path');
 const fs = require('fs');
 const { slugify, mapFolder, buildLinkMap, scanVault, pairStoryFiles } = require('../../lib/scanner');
+const { getConfidence } = require('../../lib/templates/base');
 
 describe('slugify', () => {
   it('converts to lowercase', () => {
@@ -94,15 +95,17 @@ describe('buildLinkMap', () => {
     assert.strictEqual(map['Old Name'], 'new.html');
   });
 
-  it('excludes DRAFT pages when excludeDrafts is set', () => {
+  it('excludes DRAFT pages using getConfidence filter (same predicate as build.js)', () => {
     const pages = [
       { title: 'Active NPC', outputPath: 'npc.html', frontmatter: { source_confidence: 'AUTHORITATIVE' } },
       { title: 'Draft NPC', outputPath: 'draft.html', frontmatter: { source_confidence: 'DRAFT' } },
+      { title: 'Legacy Draft', outputPath: 'legacy.html', frontmatter: { canon_status: 'DRAFT' } },
     ];
-    const filtered = pages.filter(p => (p.frontmatter.source_confidence || p.frontmatter.canon_status) !== 'DRAFT');
+    const filtered = pages.filter(p => getConfidence(p.frontmatter) !== 'DRAFT');
     const map = buildLinkMap(filtered);
     assert.ok('Active NPC' in map);
     assert.ok(!('Draft NPC' in map));
+    assert.ok(!('Legacy Draft' in map));
   });
 });
 

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -76,7 +76,16 @@ describe('buildLinkMap', () => {
     assert.strictEqual(map['John'], 'a.html');
   });
 
-  it('redirects superseded entities', () => {
+  it('redirects superseded entities via source_confidence', () => {
+    const pages = [
+      { title: 'New Name', outputPath: 'new.html', frontmatter: {} },
+      { title: 'Old Name', outputPath: 'old.html', frontmatter: { source_confidence: 'SUPERSEDED', superseded_by: '[[New Name]]' } },
+    ];
+    const map = buildLinkMap(pages);
+    assert.strictEqual(map['Old Name'], 'new.html');
+  });
+
+  it('redirects superseded entities via canon_status fallback', () => {
     const pages = [
       { title: 'New Name', outputPath: 'new.html', frontmatter: {} },
       { title: 'Old Name', outputPath: 'old.html', frontmatter: { canon_status: 'SUPERSEDED', superseded_by: '[[New Name]]' } },

--- a/tools/publish/test/unit/templates.test.js
+++ b/tools/publish/test/unit/templates.test.js
@@ -1,18 +1,52 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { stubBadge, metadataBadgesFor, cssPath, rootPath } = require('../../lib/templates/base');
+const { confidenceBadge, getConfidence, metadataBadgesFor, cssPath, rootPath } = require('../../lib/templates/base');
 const { parseParticipant } = require('../../lib/templates/event');
 
-describe('stubBadge', () => {
-  it('returns badge for STUB status', () => {
-    const result = stubBadge({ canon_status: 'STUB' });
-    assert.ok(result.includes('stub-badge'));
+describe('getConfidence', () => {
+  it('prefers source_confidence over canon_status', () => {
+    assert.strictEqual(getConfidence({ source_confidence: 'DRAFT', canon_status: 'STUB' }), 'DRAFT');
+  });
+
+  it('falls back to canon_status', () => {
+    assert.strictEqual(getConfidence({ canon_status: 'STUB' }), 'STUB');
+  });
+
+  it('returns null when neither present', () => {
+    assert.strictEqual(getConfidence({}), null);
+  });
+});
+
+describe('confidenceBadge', () => {
+  it('returns badge for STUB via source_confidence', () => {
+    const result = confidenceBadge({ source_confidence: 'STUB' });
+    assert.ok(result.includes('badge-stub'));
     assert.ok(result.includes('Stub'));
   });
 
-  it('returns empty string for non-stub', () => {
-    assert.strictEqual(stubBadge({ canon_status: 'ACTIVE' }), '');
-    assert.strictEqual(stubBadge({}), '');
+  it('returns badge for STUB via canon_status fallback', () => {
+    const result = confidenceBadge({ canon_status: 'STUB' });
+    assert.ok(result.includes('badge-stub'));
+  });
+
+  it('returns badge for DRAFT', () => {
+    const result = confidenceBadge({ source_confidence: 'DRAFT' });
+    assert.ok(result.includes('badge-draft'));
+    assert.ok(result.includes('Draft'));
+  });
+
+  it('returns badge for SUPERSEDED', () => {
+    const result = confidenceBadge({ source_confidence: 'SUPERSEDED' });
+    assert.ok(result.includes('badge-superseded'));
+    assert.ok(result.includes('Superseded'));
+  });
+
+  it('returns empty string for AUTHORITATIVE', () => {
+    assert.strictEqual(confidenceBadge({ source_confidence: 'AUTHORITATIVE' }), '');
+  });
+
+  it('returns empty string when no confidence field', () => {
+    assert.strictEqual(confidenceBadge({}), '');
   });
 });
 


### PR DESCRIPTION
## Summary

- **validate_schema.py** — SUPERSEDED entities must declare `superseded_by` (CI enforcement, catches orphaned supersessions at commit time)
- **Publish tool** — Replace broken `stubBadge`/`canon_status` with `getConfidence`/`confidenceBadge` using `source_confidence` with fallback; badges for DRAFT, STUB, SUPERSEDED states; new `exclude_drafts` config option
- **Campaign-QA** — Stale DRAFT warning (WARNING severity when entity has been DRAFT for >= 3 sessions)
- **Benchmark campaign** — Session 4 (The Reckoning) + confidence test entities covering stale/non-stale DRAFT boundary and valid SUPERSEDED with replacement
- **Skill references** — Document badge rendering and `exclude_drafts` in publish-site references

## Test plan

- [x] `python3 scripts/validate_schema.py tests/benchmark-campaign` passes
- [x] `python3 scripts/validate_schema.py filtering tests/benchmark-campaign` passes
- [x] `npm test` in tools/publish — 285 tests pass, 0 fail
- [x] `./scripts/build-skill-zips.sh` produces 8 valid zips
- [x] markdownlint clean on all changed files
- [x] No `canon_status:` references in skills/ or tests/
- [x] SUPERSEDED entity without `superseded_by` correctly rejected by validator
- [x] Zero remaining `stubBadge` or `.stub-badge` references in codebase