### PR TITLE
session-wrapup: gmassistant.app export passthrough

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.20] — 2026-05-06
+
+### Added
+
+- **session-wrapup** gmassistant.app passthrough — when Play Notes are a gmassistant.app export (detected by `## Memorable Moments` heading), adopts the app's narrative summary verbatim and uses its structured NPC/Location/Item sections as entity input instead of regenerating from scratch
+
 ## [1.4.19] — 2026-05-03
 
 ### Added

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -98,6 +98,18 @@ territory. Never edit prior session entries (append-only).
 
 ### 4. Update the World
 
+**gmassistant.app path:** When the Play Notes are a
+gmassistant.app export, use the structured `## NPCs`,
+`## Locations`, and `## Items` sections as input for entity
+creation and updates. Each entry already has a name and
+description — use these as the basis for vault files instead
+of extracting entities from raw notes. Entity extraction
+markers (`NEW-NPC:`, `UPDATE:`, etc.) won't be present;
+instead, compare each listed NPC/Location/Item against the
+existing vault to determine new vs. update. Use the
+`## Scenes` section as the primary source for identifying
+events that meet the decomposition threshold.
+
 - **New entities** (improvised NPCs, locations, items):
   Read `_Templates/_Template_{Type}.md` first, then create
   the vault file using that template as the structure.

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -106,9 +106,14 @@ description — use these as the basis for vault files instead
 of extracting entities from raw notes. Entity extraction
 markers (`NEW-NPC:`, `UPDATE:`, etc.) won't be present;
 instead, compare each listed NPC/Location/Item against the
-existing vault to determine new vs. update. Use the
+existing vault to determine new vs. update. If the
+gmassistant description conflicts with existing vault
+content, flag the entity as CONFLICT for GM review. Use the
 `## Scenes` section as the primary source for identifying
-events that meet the decomposition threshold.
+events that meet the decomposition threshold. All standard
+rules below still apply: read templates before creating,
+`source_confidence: DRAFT` for new entities, receipt
+lifecycle, wiki-links.
 
 - **New entities** (improvised NPCs, locations, items):
   Read `_Templates/_Template_{Type}.md` first, then create

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -36,6 +36,14 @@ If no Play Notes file exists, ask the GM to provide play notes
 (paste, file path, or dictation). Read PC roster. Read the
 session's Plan file for planned-vs-actual comparison.
 
+**gmassistant.app detection:** After reading the Play Notes,
+check whether the content contains a `## Memorable Moments`
+heading. If present, the notes are a gmassistant.app export
+containing pre-written narrative (`## Summary`), structured
+entity sections (`## NPCs`, `## Locations`, `## Items`), and
+a scene-by-scene breakdown (`## Scenes`). Follow the
+gmassistant-specific instructions in Steps 2 and 4 below.
+
 ### 2. Narrative Recap
 
 3-5 paragraphs of campaign prose. Dramatic, character names,

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -53,10 +53,12 @@ Tone-calibrate per `references/recap-formats.md`. Also generate
 Wrap-Up file.
 
 **gmassistant.app path:** Adopt the content of the Play Notes'
-`## Summary` section verbatim into the Wrap-Up file under the
+`## Summary` section into the Wrap-Up file under the
 `## Narrative Recap` heading. No rewriting, no condensing, no
-tone adjustment. Skip Quick Bullets — the `## Scenes` section
-in the Play Notes already serves that purpose.
+tone adjustment — but do add `[[wiki-links]]` to every entity
+reference (matching the standard path's linking requirement).
+Skip Quick Bullets — the `## Scenes` section in the Play Notes
+already serves that purpose.
 
 This recap is the **single source of truth** regardless of
 path. Session-prep reads it later — never regenerates.

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -183,7 +183,7 @@ Wrap-up **must** produce all sections so prep reads one file:
 | Section | Required | Written to |
 |---------|----------|------------|
 | Narrative Recap | Yes | Wrap-Up file |
-| Quick Bullets | Yes | Wrap-Up file |
+| Quick Bullets | Standard path only | Wrap-Up file |
 | PC Carry-Forward | Yes | Wrap-Up file |
 | What Carries Forward | Yes | Wrap-Up file |
 | World State | Yes | Wrap-Up file |

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -46,14 +46,20 @@ gmassistant-specific instructions in Steps 2 and 4 below.
 
 ### 2. Narrative Recap
 
-3-5 paragraphs of campaign prose. Dramatic, character names,
-`[[wiki-links]]` for every entity. Tone-calibrate per
-`references/recap-formats.md`. Also generate **Quick Bullets**
-(5-8 points).
+**Standard path:** 3-5 paragraphs of campaign prose. Dramatic,
+character names, `[[wiki-links]]` for every entity.
+Tone-calibrate per `references/recap-formats.md`. Also generate
+**Quick Bullets** (5-8 points). Write both formats into the
+Wrap-Up file.
 
-This recap is the **single source of truth**. Session-prep
-reads it later — never regenerates. Write both formats into
-the Wrap-Up file.
+**gmassistant.app path:** Adopt the content of the Play Notes'
+`## Summary` section verbatim into the Wrap-Up file under the
+`## Narrative Recap` heading. No rewriting, no condensing, no
+tone adjustment. Skip Quick Bullets — the `## Scenes` section
+in the Play Notes already serves that purpose.
+
+This recap is the **single source of truth** regardless of
+path. Session-prep reads it later — never regenerates.
 
 ### 3. PC Carry-Forward
 


### PR DESCRIPTION
## Summary

- When Play Notes contain a `## Memorable Moments` heading (gmassistant.app export), session-wrapup now adopts the app's `## Summary` as the Narrative Recap instead of regenerating — with wiki-linking added to entity references
- Structured `## NPCs`, `## Locations`, `## Items` sections from the export are used as entity input for Step 4, with CONFLICT flagging for vault mismatches
- Quick Bullets skipped for gmassistant exports (the Scenes section serves that purpose); Handoff Contract updated accordingly
- Bumps to v1.4.20

## Test plan

- [ ] Run `python3 scripts/validate_schema.py` — all checks pass
- [ ] Invoke session-wrapup with a gmassistant.app Play Notes export (contains `## Memorable Moments`) — verify Summary is adopted verbatim with wiki-links, Quick Bullets skipped, entity sections used for vault file creation
- [ ] Invoke session-wrapup with standard raw Play Notes — verify original workflow unchanged (prose recap generated, Quick Bullets produced, entity extraction from notes)