### PR TITLE
Fix publish-site bugs found during end-to-end testing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,6 +485,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.4.22]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.21...v1.4.22
 [1.4.19]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.18...v1.4.19
 [1.4.18]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.17...v1.4.18
 [1.4.17]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.16...v1.4.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.22] — 2026-05-08
+
+### Fixed
+
+- **Timeline date parsing** — timeline now reads `in_game_date` (falling
+  back to `date` for pre-migration vaults). Vague dates like "Autumn 1813"
+  now parse to approximate months instead of defaulting to January 1.
+- **Chapter-session matching** — chapter pages now find their sessions via
+  three-stage matching (exact filename, filename with spaces, display title
+  substring). Previously failed when session `chapter:` values didn't
+  exactly match the chapter page title.
+- **Genre preset override** — custom theme.css no longer stomps genre
+  preset colors when no custom palette is provided. Config sets palette to
+  null instead of spreading defaults.
+- **Stale npm detection** — publish-site routine updates now check the
+  build tool version against the plugin cache and auto-update the `file:`
+  dependency path if stale.
+
+### Changed
+
+- **Schema: event `date` → `in_game_date`** — event entity frontmatter
+  field renamed for consistency. Migration 1.4.22 auto-applies the rename.
+- **Schema: session `planned_date`/`actual_date` → `play_date`** — two
+  legacy fields consolidated into one. Migration 1.4.22 picks the
+  `actual_date` value (or `planned_date` if that's all that exists) and
+  removes both old fields.
+- **Session wrap-up conventions** — standardized filename
+  (`Session_NN_Wrap_Up.md`), frontmatter type (`session_wrap`), and date
+  format guidance (JS-parseable values only).
+- **Publish tool field references** — landing page, location pages, badges,
+  and event sorting all use new field names with backward-compatible
+  fallbacks.
+
+### Added
+
+- **Migration 1.4.22** in `shared/migrations.md` — structural renames for
+  event and session date fields; opt-in wrap-up `type` standardization
+- **Deprecation warnings** in `validate_schema.py` — flags `date` on events
+  and `planned_date`/`actual_date` on sessions
+- **`session_wrap` type** recognized in schema validation alongside legacy
+  `session-wrap-up`
+
 ## [1.4.21] — 2026-05-06
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,6 +67,7 @@ Items are force-ranked by score. Higher score = do first.
 | Publish tool: Tag-based browsing (tag index pages) | 2 | 1 | M (2) | 2.5 | Idea | Auto-generated index pages per tag from frontmatter |
 | Eval suite for all skills | 3 | 1 | L (3) | 2.3 | Idea | Extend benchmark methodology to all 7 skills, not just ttrpg-expert |
 | ~~Publish tool: Relationship graph visualisation~~ | 3 | 1 | L (3) | 2.3 | Done | Static SVG relationship graphs with force-directed layout |
+| Build-time section extraction for routing | 3 | 1 | M (2) | 3.5 | Experiment | Pre-process multi-section reference files into per-section extracts or line-range indexes at build time, so section routing loads only the needed section instead of the whole file. [Findings](docs/experiment-section-extraction.md) |
 | Publish tool: full site identity (logo variants, social preview) | 3 | 1 | L (3) | 2.3 | Idea | Logo generation, og:image, social card previews for shared links |
 | D&D SRD enrichment (Phase 5c) | 2 | 2 | L (3) | 2.0 | Planned | Expand D&D files: more monster stat blocks, subclass features, encounter building |
 | PDF-to-markdown converter | 3 | 1 | XL (4) | 1.8 | Idea | Tool to convert published adventure PDFs into vault-compatible markdown |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,6 +57,7 @@ Items are force-ranked by score. Higher score = do first.
 | ~~Publish tool: system-specific PC sheet rendering~~ | 4 | 3 | L (3) | 3.7 | Done | Per-system HTML/CSS treatments for published PC pages (CoC parchment feel, GURPS stat blocks, D&D ability cards, etc.). Builds on SP3's C-ready template dispatch architecture — add one system at a time. |
 | ~~Publish tool: Timeline auto-generation from events/sessions~~ | 3 | 1 | M (2) | 3.5 | Done | Generate timeline page from event/session dates in frontmatter |
 | ~~Publish tool: Full-text client-side search (lunr)~~ | 3 | 1 | M (2) | 3.5 | Done | Client-side search index so players can find content in published site |
+| Build-time section extraction for routing | 3 | 1 | M (2) | 3.5 | Experiment | Pre-process multi-section reference files into per-section extracts or line-range indexes at build time, so section routing loads only the needed section instead of the whole file. [Findings](docs/experiment-section-extraction.md) |
 | LoM-style 8-bit scene illustration | 4 | 1 | L (3) | 3.0 | Experiment | Programmatic 8-bit landscape vistas (Lords of Midnight style) from vault metadata using Pillow. No AI models, no API cost. [Prototype findings](docs/image-gen-lom-prototype-findings.md) |
 | Pulp Cthulhu variant support | 4 | 4 | XL (4) | 3.0 | Idea | CoC variant overlay: hero/pulp talents, psychic powers, archetypes, adjusted lethality. Blocked on finding a legit distributable source — Chaosium BRP ORC license may not cover Pulp-specific content. |
 | FitD SRD enrichment (Phase 5b) | 2 | 2 | M (2) | 3.0 | Planned | Expand FitD files to GURPS-level depth: more factions, crew types, entanglements |
@@ -67,7 +68,6 @@ Items are force-ranked by score. Higher score = do first.
 | Publish tool: Tag-based browsing (tag index pages) | 2 | 1 | M (2) | 2.5 | Idea | Auto-generated index pages per tag from frontmatter |
 | Eval suite for all skills | 3 | 1 | L (3) | 2.3 | Idea | Extend benchmark methodology to all 7 skills, not just ttrpg-expert |
 | ~~Publish tool: Relationship graph visualisation~~ | 3 | 1 | L (3) | 2.3 | Done | Static SVG relationship graphs with force-directed layout |
-| Build-time section extraction for routing | 3 | 1 | M (2) | 3.5 | Experiment | Pre-process multi-section reference files into per-section extracts or line-range indexes at build time, so section routing loads only the needed section instead of the whole file. [Findings](docs/experiment-section-extraction.md) |
 | Publish tool: full site identity (logo variants, social preview) | 3 | 1 | L (3) | 2.3 | Idea | Logo generation, og:image, social card previews for shared links |
 | D&D SRD enrichment (Phase 5c) | 2 | 2 | L (3) | 2.0 | Planned | Expand D&D files: more monster stat blocks, subclass features, encounter building |
 | PDF-to-markdown converter | 3 | 1 | XL (4) | 1.8 | Idea | Tool to convert published adventure PDFs into vault-compatible markdown |

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -44,6 +44,7 @@ REQUIRED_FIELDS = {
     "session-plan": ["type", "source_confidence", "session"],
     "session-play-notes": ["type", "source_confidence", "session"],
     "session-wrap-up": ["type", "source_confidence", "session"],
+    "session_wrap": ["type", "source_confidence", "session"],
     "scene": ["type", "source_confidence", "scene_type", "status"],
     "chapter": ["type"],
     "meta": ["type"],
@@ -53,6 +54,13 @@ REQUIRED_FIELDS = {
 
 # Optional fields that support portraits (for future validation)
 PORTRAIT_TYPES = {"npc", "pc", "location", "faction", "organization", "item", "creature"}
+
+# Valid optional fields per entity type (used for deprecation warnings)
+DEPRECATED_FIELDS: dict[str, list[tuple[str, str]]] = {
+    # (old_field, replacement_field)
+    "event": [("date", "in_game_date")],
+    "session": [("planned_date", "play_date"), ("actual_date", "play_date")],
+}
 
 
 def extract_frontmatter(content: str) -> dict | None:
@@ -202,6 +210,15 @@ def validate_file(filepath: Path) -> list[str]:
                 f"Invalid portrait path '{portrait}' — "
                 f"must start with '_attachments/'"
             )
+
+    # Deprecation warnings for renamed date fields
+    if entity_type in DEPRECATED_FIELDS:
+        for old_field, new_field in DEPRECATED_FIELDS[entity_type]:
+            if old_field in frontmatter:
+                errors.append(
+                    f"Deprecated field '{old_field}' — "
+                    f"rename to '{new_field}' (run migration 1.4.22)"
+                )
 
     return errors
 

--- a/skills/campaign-organizer/references/event-template.md
+++ b/skills/campaign-organizer/references/event-template.md
@@ -28,7 +28,7 @@ tags: []
 source_document: ""
 campaign: ""
 event_type: ""        # battle, discovery, betrayal, ritual, meeting, disaster
-date: ""              # in-game date
+in_game_date: ""      # in-game date
 location: ""          # [[wiki-link]]
 participants:
   - ""                # "[[Entity]] (role annotation)"

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -62,7 +62,26 @@ Workflow:
 1. Read `publish.site_dir` from `_meta/vault-config.md`. If not
    set, ask for the absolute path to the site repo directory and
    offer to save it to vault-config for future sessions.
-2. **Check manifest freshness.** Compare the vault's publishable
+2. **Check publish tool version.** Make sure the site repo is
+   using the current version of the build tool:
+   a. Read the plugin version from `.claude-plugin/plugin.json`
+      in the gm-apprentice plugin directory (or infer it from the
+      skill's own cache path). This is the **expected version**.
+   b. Read the site repo's `package.json` and find the
+      `gm-apprentice-publish` dependency value. Also read
+      `node_modules/gm-apprentice-publish/package.json` in the
+      site repo to find the **installed version**.
+   c. The dependency should be a `file:` path pointing at:
+      `~/.claude/plugins/cache/gm-apprentice/gm-apprentice/{plugin-version}/tools/publish`
+      If the path contains an old version, or if the installed
+      version differs from the expected version:
+      - Update the `file:` dependency in the site repo's
+        `package.json` to point at the current cache path.
+      - Run `npm install` in the site repo directory.
+      - Tell the GM: "Updated gm-apprentice-publish from
+        {old version} to {new version}."
+   d. If everything matches, continue silently.
+3. **Check manifest freshness.** Compare the vault's publishable
    files against `_meta/publish-manifest.md`. Look for:
    - **New files:** vault files not in the manifest. Apply the
      same categorization rules as capability 6 (always-exclude
@@ -73,13 +92,13 @@ Workflow:
      longer exist. Remove them from the manifest and note which
      pages will disappear from the site.
    - If no changes, say so and proceed.
-3. Run `npm run build` from that directory.
-4. Review the output for errors. If any appear, treat them as
+4. Run `npm run build` from that directory.
+5. Review the output for errors. If any appear, treat them as
    troubleshooting triggers (see capability 3).
-5. Stage the `docs/` folder: `git add docs/`.
-6. Commit: `git commit -m "Rebuild site"`.
-7. Push: `git push`.
-8. Confirm: "Your site will update on GitHub Pages in a minute or two.
+6. Stage the `docs/` folder: `git add docs/`.
+7. Commit: `git commit -m "Rebuild site"`.
+8. Push: `git push`.
+9. Confirm: "Your site will update on GitHub Pages in a minute or two.
    Check the Actions tab if it takes longer than five minutes."
 
 ### 3. Troubleshooting

--- a/skills/publish-site/references/schema-reference.md
+++ b/skills/publish-site/references/schema-reference.md
@@ -213,7 +213,7 @@ Badges rendered: `sort_order`
 
 `type: session`
 
-Badges rendered: `session_number`, `actual_date`, `status`,
+Badges rendered: `session_number`, `play_date`, `status`,
 `stage`
 
 ### Scene

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -141,7 +141,34 @@ If the command fails with "command not found", explain:
 
 ---
 
-## Step 7: Fill in vault.config.json
+## Step 7: Pin the build tool dependency
+
+Open `package.json` in `<targetDir>`. Find the `gm-apprentice-publish`
+dependency — the scaffold sets it to `"latest"` by default, which can
+resolve to a stale cached version.
+
+Replace it with a `file:` path pointing at the current plugin cache:
+
+```json
+{
+  "dependencies": {
+    "gm-apprentice-publish": "file:~/.claude/plugins/cache/gm-apprentice/gm-apprentice/<plugin-version>/tools/publish"
+  }
+}
+```
+
+Where `<plugin-version>` is the current gm-apprentice plugin version
+(read it from `.claude-plugin/plugin.json` in the plugin directory, or
+infer it from the skill's own cache path).
+
+This ensures the site always builds with the exact version of the
+publish tool that matches the installed plugin. The version check in
+routine updates (capability 2) will keep this path current when the
+plugin updates.
+
+---
+
+## Step 8: Fill in vault.config.json
 
 Open `vault.config.json` in `<targetDir>` and update these fields
 with the values gathered above:
@@ -165,7 +192,7 @@ edit the JSON manually unless they prefer to.
 
 ---
 
-## Step 8: Campaign image
+## Step 9: Campaign image
 
 Ask:
 
@@ -194,7 +221,7 @@ If no, skip — the site will work without a campaign image.
 
 ---
 
-## Step 9: 404 message
+## Step 10: 404 message
 
 Ask:
 
@@ -215,7 +242,7 @@ Accept a custom message if the GM prefers. Store it in
 
 ---
 
-## Step 10: Theme confirmation
+## Step 11: Theme confirmation
 
 Read genre tags from the vault's `_Campaign/Campaign Overview.md`
 or `vault-config.md` if available. Propose a colour palette and
@@ -234,7 +261,7 @@ fonts, neutral blue-grey palette).
 
 ---
 
-## Step 11: Install dependencies
+## Step 12: Install dependencies
 
 In the terminal, navigate to `<targetDir>` and run:
 
@@ -247,7 +274,7 @@ dependencies. It will take a moment on first run.
 
 ---
 
-## Step 12: Initial build
+## Step 13: Initial build
 
 Run:
 
@@ -274,7 +301,7 @@ shown here reflects only publishable content.
 
 ---
 
-## Step 13: Review initial build
+## Step 14: Review initial build
 
 Tell the GM:
 
@@ -288,7 +315,7 @@ content, broken layout), troubleshoot before continuing.
 
 ---
 
-## Step 14: Create publish manifest
+## Step 15: Create publish manifest
 
 Run the content-filtering workflow from `references/content-filtering.md`:
 
@@ -309,7 +336,7 @@ Tell the GM:
 
 ---
 
-## Step 15: Filtered rebuild
+## Step 16: Filtered rebuild
 
 Rebuild with the manifest in place:
 
@@ -326,7 +353,7 @@ If the GM wants to adjust, edit the manifest and rebuild again.
 
 ---
 
-## Step 16: Initialise git
+## Step 17: Initialise git
 
 In the terminal, inside `<targetDir>`, run:
 
@@ -339,7 +366,7 @@ git commit -m "Initial site scaffold"
 
 ---
 
-## Step 17: Create the GitHub repository
+## Step 18: Create the GitHub repository
 
 Check whether the `gh` CLI is available:
 
@@ -380,9 +407,9 @@ Provide numbered manual steps:
 
 ---
 
-## Step 18: Enable GitHub Pages
+## Step 19: Enable GitHub Pages
 
-**If `gh` was used in Step 17 (repo creation):**
+**If `gh` was used in Step 18 (repo creation):**
 
 Offer to enable Pages programmatically:
 
@@ -420,7 +447,7 @@ Summarise:
 
 ---
 
-## Step 19: Confirm
+## Step 20: Confirm
 
 Once GitHub Pages is enabled and the first deployment finishes,
 the site will be live at:

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -147,17 +147,20 @@ Open `package.json` in `<targetDir>`. Find the `gm-apprentice-publish`
 dependency — the scaffold sets it to `"latest"` by default, which can
 resolve to a stale cached version.
 
-Replace it with a `file:` path pointing at the current plugin cache:
+Replace it with a `file:` path pointing at the current plugin cache
+for the GM's platform:
 
 ```json
 {
   "dependencies": {
-    "gm-apprentice-publish": "file:~/.claude/plugins/cache/gm-apprentice/gm-apprentice/<plugin-version>/tools/publish"
+    "gm-apprentice-publish": "file:<plugin-cache-path>/gm-apprentice/<plugin-version>/tools/publish"
   }
 }
 ```
 
-Where `<plugin-version>` is the current gm-apprentice plugin version
+Use the plugin cache path for the GM's OS (e.g.
+`~/.claude/plugins/cache/gm-apprentice` on macOS/Linux). Where
+`<plugin-version>` is the current gm-apprentice plugin version
 (read it from `.claude-plugin/plugin.json` in the plugin directory, or
 infer it from the skill's own cache path).
 

--- a/skills/publish-site/references/troubleshooting.md
+++ b/skills/publish-site/references/troubleshooting.md
@@ -269,6 +269,59 @@ The `docs/` folder was built, but either:
 
 ---
 
+## Failure 7: Build uses old templates or missing features
+
+### Symptom
+
+The build completes without errors, but the output does not
+reflect recent plugin updates. Pages may use old templates,
+missing layout improvements, or lack new features that should
+be available.
+
+### Cause
+
+The site repo's `package.json` still points at an old version
+of the `gm-apprentice-publish` package in the plugin cache. When
+the plugin updates (new version installed), the cache path changes
+but existing site repos keep their old `file:` dependency, so
+builds continue using the stale code.
+
+This can also happen if the dependency was set to `"latest"` —
+npm resolves that to whatever version is already installed locally,
+which may be outdated.
+
+### Diagnosis steps
+
+1. Open the site repo's `package.json`. Find the
+   `gm-apprentice-publish` dependency. It should be a `file:` path
+   like:
+   ```json
+   "gm-apprentice-publish": "file:~/.claude/plugins/cache/gm-apprentice/gm-apprentice/1.4.21/tools/publish"
+   ```
+2. Check the version number in that path against the current plugin
+   version (readable from `.claude-plugin/plugin.json` in the
+   gm-apprentice plugin directory). If they differ, the dependency
+   is stale.
+3. Also check `node_modules/gm-apprentice-publish/package.json` in
+   the site repo — its `version` field shows what is actually
+   installed.
+
+### Fix
+
+Run the routine update workflow ("update my site"). Step 2 of
+that workflow automatically detects version mismatches and updates
+the dependency.
+
+To fix manually:
+
+1. Update the `file:` path in the site repo's `package.json` to
+   point at the current plugin cache version.
+2. Run `npm install` in the site repo directory to pull in the
+   updated package.
+3. Rebuild with `npm run build`.
+
+---
+
 ## Getting more information from the build
 
 If none of the above explains the problem, run the build and

--- a/skills/session-prep/references/session-templates.md
+++ b/skills/session-prep/references/session-templates.md
@@ -197,8 +197,8 @@ promoted to AUTHORITATIVE via reconcile.
 
 ```markdown
 ---
-type: session-wrap-up
-session: "[[Session NN - Title]]"
+type: session_wrap
+session: "[[Session_NN_Wrap_Up]]"
 chapter: "[[Chapter N - Title]]"
 campaign: ""
 source_confidence: DRAFT

--- a/skills/session-prep/references/session-templates.md
+++ b/skills/session-prep/references/session-templates.md
@@ -198,7 +198,7 @@ promoted to AUTHORITATIVE via reconcile.
 ```markdown
 ---
 type: session_wrap
-session: "[[Session_NN_Wrap_Up]]"
+session: "[[Session NN - Title]]"
 chapter: "[[Chapter N - Title]]"
 campaign: ""
 source_confidence: DRAFT

--- a/skills/session-prep/references/session-templates.md
+++ b/skills/session-prep/references/session-templates.md
@@ -17,14 +17,13 @@ type: session
 session_number: N
 chapter: "[[Chapter N - Title]]"
 campaign: ""
-planned_date: null
-actual_date: null
+play_date: null             # real-world date session was played, YYYY-MM-DD
 in_game_date: null          # In-game date(s): string "YYYY-MM-DD" or array ["YYYY-MM-DD", ...]
 status: planned
 documents:
   plan: "[[Session NN - Title - Plan]]"
   play_notes: "[[Session NN - Title - Play Notes]]"
-  wrap_up: "[[Session NN - Title - Wrap-Up]]"
+  wrap_up: "[[Session_NN_Wrap_Up]]"
 scenes:
   - "[[Scene Title]]"
 tags: []

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -24,6 +24,20 @@ not migration).
 Session-wrapup reads the Play Notes file and writes the Wrap-Up
 file. It also creates/updates entity files and timeline entries.
 
+**Wrap-Up file conventions:**
+- Filename: `Session_NN_Wrap_Up.md` (zero-padded, underscores,
+  no session title). Example: `Session_07_Wrap_Up.md`.
+- Location: the session's own directory, e.g.,
+  `Chapters/Chapter 3 - Vienna/Sessions/Session 07/Session_07_Wrap_Up.md`
+- Frontmatter type: `type: session_wrap`
+- Session index `documents.wrap_up` link:
+  `"[[Session_NN_Wrap_Up]]"`
+
+**Session index fields:** The session index uses `play_date:`
+(real-world date played) and `in_game_date:` (fictional date).
+When updating the session index during wrap-up, use these field
+names — not `planned_date` or `actual_date`.
+
 **Trigger phrases:** "session's over", "wrap up", "post-session",
 "process my notes", "what happened today"
 
@@ -129,14 +143,21 @@ lifecycle, wiki-links.
   ONE file per entity. No separate "update" files.
 
 - **Timeline**: Linked events:
-  `- **{date}** — [[Event_Name]] — {summary}`.
-  Inline events: `- **{date}** — {description}`.
+  `- **{in_game_date}** — [[Event_Name]] — {summary}`.
+  Inline events: `- **{in_game_date}** — {description}`.
 
 - **Event decomposition**: Create Event entity files for
   moments meeting the threshold (≥2 of: changes entity state,
   multiple named participants, forward consequences, will be
   referenced from multiple entities). Use
-  `campaign-organizer/references/event-template.md`.
+  `campaign-organizer/references/event-template.md`. Event
+  frontmatter uses `in_game_date:` (not `date:`).
+
+  **Date format:** All date values (`in_game_date`, `play_date`)
+  must be parseable by JS `new Date()`. Good: `"August 11, 1814"`,
+  `"June 12, 1814"`, `"July 1814"`. Bad: `"Evening, 11 August 1814"`,
+  `"Midnight–dawn, August 7–8, 1814"`. Time-of-day or narrative
+  context belongs in the event body text, not the date field.
 
 **Receipt lifecycle:** Show new/updated entity content to the
 GM **in the conversation** as `## New Entity Files` and
@@ -199,7 +220,8 @@ Wrap-up **must** produce all sections so prep reads one file:
 Entity files and timeline are updated separately (Step 4).
 Character story files are updated separately (Step 3b).
 The session index is updated to `wrap-up` status (or `reviewed`
-if reconcile completes).
+if reconcile completes). Update `play_date` and `in_game_date`
+on the session index if not already set.
 
 ## Sub-agent Opportunity (Claude Code only)
 

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -252,7 +252,7 @@ Extraction defaults:
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | event_type | string | Battle, ritual, meeting, etc. |
-| date | string | In-game date |
+| in_game_date | string | In-game date |
 | location | string | Where (wiki-link to Location entity) |
 | participants | array | Who — entries can be `[[Entity]] (role)`, `[[Entity\|Display]] (role)`, or plain text |
 | outcome | string | Result |
@@ -288,8 +288,7 @@ type: session
 session_number: 1
 chapter: "[[Chapter 1 - Title]]"
 campaign: ""
-planned_date: null        # Real-world date
-actual_date: null
+play_date: null           # Real-world date session was played, YYYY-MM-DD
 in_game_date: null        # In-game date(s) — string or array
 status: planned           # planned | prepped | played | reviewed
 stage: outline            # outline | draft | ready | in_play | wrap_up
@@ -386,7 +385,7 @@ etc.), `goals`, `leadership` (wiki-link), `territory` (wiki-link),
 **Item:** `item_type` (weapon, armor, relic, etc.),
 `current_holder` (wiki-link), `origin`, `portrait` (optional)
 
-**Event:** `event_type` (battle, ritual, etc.), `date` (in-game),
+**Event:** `event_type` (battle, ritual, etc.), `in_game_date` (in-game),
 `location` (wiki-link), `participants` (wiki-links), `outcome`
 
 **Clue:** `clue_type` (physical, testimonial, documentary),

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.4.21"
+current_version: "1.4.22"
 ---
 
 # Vault Migration Registry
@@ -129,3 +129,24 @@ No vault schema changes. Version stamp only.
 - **Publish tool:** Timeline now reads `in_game_date` from sessions
   to place them on the in-game chronological timeline. Sessions
   without `in_game_date` are excluded from the timeline.
+
+## Migration: 1.4.21 → 1.4.22
+
+Standardizes date field names across session and event entities.
+
+### Structural
+
+- **Event entity files** (files with `type: event`): rename
+  frontmatter field `date:` → `in_game_date:`. Value is unchanged —
+  this is a key rename only.
+- **Session entity files** (files with `type: session`): rename
+  `planned_date:` → `play_date:`. If both `planned_date` and
+  `actual_date` exist, use the value of `actual_date` as `play_date`
+  (the actual played date takes precedence); otherwise use whichever
+  exists. Remove `actual_date:` after migration.
+
+### Content
+
+- **Session wrap-up files**: standardize `type:` to `session_wrap`
+  (from any of: `session-wrap-up`, `session_wrap_up`, `session_note`).
+  Opt-in per file — review before applying.

--- a/skills/shared/session-document-chain.md
+++ b/skills/shared/session-document-chain.md
@@ -16,18 +16,26 @@ type: session
 session_number: N
 chapter: "[[Chapter N - Title]]"
 campaign: ""
-planned_date: null
-actual_date: null
+play_date: null
+in_game_date: null
 status: planned
 documents:
   plan: "[[Session NN - Title - Plan]]"
   play_notes: "[[Session NN - Title - Play Notes]]"
-  wrap_up: "[[Session NN - Title - Wrap-Up]]"
+  wrap_up: "[[Session_NN_Wrap_Up]]"
 scenes:
   - "[[Scene Title]]"
 tags: []
 ---
 ```
+
+**Date fields:** `play_date` is the real-world date the session
+was played. `in_game_date` is the fictional in-world date. Both
+must be parseable by JS `new Date()` — use formats like
+`"August 11, 1814"`, `"June 12, 1814"`, or `"July 1814"`.
+Do not include narrative time-of-day prefixes (e.g.,
+"Evening, 11 August 1814") — those belong in prose, not
+metadata.
 
 **Status** reflects the furthest document that exists:
 
@@ -75,15 +83,20 @@ tags: []
 ---
 ```
 
-### 4. Session Wrap-Up (`Session {NN} - {Title} - Wrap-Up.md`)
+### 4. Session Wrap-Up (`Session_NN_Wrap_Up.md`)
 
 Canonical record: narrative recap, quick bullets, PC
 carry-forward, world state changes, keeper checklist.
 Starts DRAFT, promoted to AUTHORITATIVE via reconcile.
 
+Filename uses zero-padded session number with underscores:
+`Session_07_Wrap_Up.md`, `Session_12_Wrap_Up.md`. No session
+title in the filename. The file lives in the session's own
+directory (e.g., `Sessions/Session 07/Session_07_Wrap_Up.md`).
+
 ```yaml
 ---
-type: session-wrap-up
+type: session_wrap
 session: "[[Session NN - Title]]"
 chapter: "[[Chapter N - Title]]"
 campaign: ""
@@ -125,14 +138,16 @@ Reconstruction Note callout at the top of the document:
 
 ## File Layout
 
-All session documents live in the chapter's Sessions/ folder:
+Each session has its own directory inside the chapter's
+Sessions/ folder:
 
 ```text
 Chapters/Chapter N - Title/Sessions/
-├── Session 01 - The Arrival.md           (index)
-├── Session 01 - The Arrival - Plan.md
-├── Session 01 - The Arrival - Play Notes.md
-└── Session 01 - The Arrival - Wrap-Up.md
+└── Session 01/
+    ├── Session 01 - The Arrival.md           (index)
+    ├── Session 01 - The Arrival - Plan.md
+    ├── Session 01 - The Arrival - Play Notes.md
+    └── Session_01_Wrap_Up.md
 ```
 
 ## Companion References

--- a/skills/ttrpg-expert/campaign-structure.md
+++ b/skills/ttrpg-expert/campaign-structure.md
@@ -42,8 +42,8 @@ PLANNED → COMPLETED
 | Field | Type | Description |
 |-------|------|-------------|
 | session_number | integer | Sequential number |
-| planned_date | date | Scheduled date |
-| actual_date | date | When it happened |
+| play_date | date | Real-world date session was played |
+| in_game_date | date | In-game fictional date |
 | status | enum | PLANNED/COMPLETED/SKIPPED |
 | prep_notes | text | GM preparation (GM-only) |
 | planned_scenes | JSONB | Anticipated scenes |

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 01 - The Missing Professor.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 01 - The Missing Professor.md
@@ -3,8 +3,7 @@ type: session
 session_number: 1
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
-planned_date: null
-actual_date: "2024-01-20"
+play_date: "2024-01-20"
 status: reviewed
 documents:
   plan: null

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 02 - The Docks at Night.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 02 - The Docks at Night.md
@@ -3,8 +3,7 @@ type: session
 session_number: 2
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
-planned_date: null
-actual_date: "2024-02-03"
+play_date: "2024-02-03"
 status: reviewed
 documents:
   plan: null

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 03 - The Inner Sanctum.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 03 - The Inner Sanctum.md
@@ -3,8 +3,7 @@ type: session
 session_number: 3
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
-planned_date: "2024-02-17"
-actual_date: null
+play_date: "2024-02-17"
 status: prepped
 documents:
   plan: "[[Session 03 - The Inner Sanctum - Plan]]"

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning.md
@@ -3,8 +3,7 @@ type: session
 session_number: 4
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
-planned_date: null
-actual_date: "2024-02-15"
+play_date: "2024-02-15"
 status: reviewed
 documents:
   plan: null

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -381,7 +381,7 @@ function build(options = {}) {
             extraSidebar = { mentionedNPCs: sessionMentionedNPCs, events: sessionEvents };
           }
           if (page.frontmatter.type === 'chapter') {
-            const chapterTitle = String(page.frontmatter.title || '');
+            const chapterTitle = String(page.frontmatter.title || page.displayTitle || '');
             const chapterTitleNorm = chapterTitle.toLowerCase();
             const chapterFilename = page.title.replace(/_/g, ' ');
             const chapterSessions = (pages || []).filter(p => {

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -381,10 +381,22 @@ function build(options = {}) {
             extraSidebar = { mentionedNPCs: sessionMentionedNPCs, events: sessionEvents };
           }
           if (page.frontmatter.type === 'chapter') {
-            const chapterSessions = (pages || []).filter(p =>
-              p.frontmatter.type === 'session' &&
-              String(p.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '').trim() === page.title
-            ).map(p => ({ displayTitle: p.displayTitle, outputPath: p.outputPath, type: 'session' }));
+            const chapterTitle = String(page.frontmatter.title || '');
+            const chapterTitleNorm = chapterTitle.toLowerCase();
+            const chapterFilename = page.title.replace(/_/g, ' ');
+            const chapterSessions = (pages || []).filter(p => {
+              if (p.frontmatter.type !== 'session') return false;
+              const chapterRef = String(p.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '').trim();
+              if (!chapterRef) return false;
+              // 1. Exact match against page filename stem (e.g. "Chapter_1_Overview")
+              if (chapterRef === page.title) return true;
+              // 2. Match against filename stem with underscores as spaces (e.g. "Chapter 1 Overview")
+              if (chapterRef === chapterFilename) return true;
+              // 3. Case-insensitive substring: chapter's display title appears in the session's chapter ref
+              //    (e.g. "London" in "Chapter 1 — London: The Orphean Society")
+              if (chapterTitleNorm && chapterRef.toLowerCase().includes(chapterTitleNorm)) return true;
+              return false;
+            }).map(p => ({ displayTitle: p.displayTitle, outputPath: p.outputPath, type: 'session' }));
 
             extraSidebar = { constituentSessions: chapterSessions };
           }

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -65,10 +65,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
     theme: {
       ...PUBLISH_DEFAULTS.theme,
       ...publish.theme,
-      palette: {
-        ...PUBLISH_DEFAULTS.theme.palette,
-        ...(publish.theme && publish.theme.palette),
-      },
+      palette: (publish.theme && publish.theme.palette)
+        ? { ...PUBLISH_DEFAULTS.theme.palette, ...publish.theme.palette }
+        : null,
       fonts: {
         ...PUBLISH_DEFAULTS.theme.fonts,
         ...(publish.theme && publish.theme.fonts),

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -67,7 +67,7 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
       ...publish.theme,
       palette: (publish.theme && publish.theme.palette)
         ? { ...PUBLISH_DEFAULTS.theme.palette, ...publish.theme.palette }
-        : null,
+        : ((publish.theme && publish.theme.genre) ? null : { ...PUBLISH_DEFAULTS.theme.palette }),
       fonts: {
         ...PUBLISH_DEFAULTS.theme.fonts,
         ...(publish.theme && publish.theme.fonts),

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -114,7 +114,7 @@ function confidenceBadge(frontmatter) {
 const TYPE_BADGE_FIELDS = {
   organization: ['faction_type'],
   faction: ['faction_type'],
-  event: ['event_type', 'date', 'location'],
+  event: ['event_type', 'in_game_date', 'location'],
   item: ['item_type', 'tl', 'origin'],
   creature: ['creature_type', 'location'],
   clue: ['clue_type', 'reliability', 'found_by'],
@@ -124,13 +124,18 @@ const TYPE_BADGE_FIELDS = {
   chapter: ['sort_order'],
 };
 
+const FIELD_FALLBACKS = { in_game_date: 'date', play_date: 'actual_date' };
+
 function metadataBadgesFor(frontmatter) {
   const fields = TYPE_BADGE_FIELDS[frontmatter.type];
   if (!fields) return '';
 
   const badges = [];
   for (const field of fields) {
-    const raw = frontmatter[field];
+    let raw = frontmatter[field];
+    if ((raw === undefined || raw === null || raw === '') && FIELD_FALLBACKS[field]) {
+      raw = frontmatter[FIELD_FALLBACKS[field]];
+    }
     if (raw === undefined || raw === null || raw === '') continue;
     // Strip wiki-link brackets if present
     const value = String(raw).replace(/\[\[|\]\]/g, '').trim();

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -119,7 +119,7 @@ const TYPE_BADGE_FIELDS = {
   creature: ['creature_type', 'location'],
   clue: ['clue_type', 'reliability', 'found_by'],
   document: ['document_type', 'author', 'classification', 'date_written'],
-  session: ['session_number', 'actual_date', 'status', 'stage'],
+  session: ['session_number', 'play_date', 'status', 'stage'],
   scene: ['scene_type', 'status'],
   chapter: ['sort_order'],
 };

--- a/tools/publish/lib/templates/event.js
+++ b/tools/publish/lib/templates/event.js
@@ -34,8 +34,9 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
     : '';
 
   const metaItems = [];
-  if (fm.date) {
-    metaItems.push(`<span><span class="label">Date</span> ${escapeHtml(fm.date)}</span>`);
+  const dateVal = fm.in_game_date || fm.date;
+  if (dateVal) {
+    metaItems.push(`<span><span class="label">Date</span> ${escapeHtml(dateVal)}</span>`);
   }
   if (fm.location) {
     const locRaw = String(fm.location).trim();

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -178,10 +178,10 @@ function getExploreDescriptions(genre, overrides) {
 
 function getRecentEvents(pages, max) {
   return pages
-    .filter(p => p.frontmatter.type === 'event' && p.frontmatter.date)
+    .filter(p => p.frontmatter.type === 'event' && (p.frontmatter.in_game_date || p.frontmatter.date))
     .sort((a, b) => {
-      const da = new Date(a.frontmatter.date);
-      const db = new Date(b.frontmatter.date);
+      const da = new Date(a.frontmatter.in_game_date || a.frontmatter.date);
+      const db = new Date(b.frontmatter.in_game_date || b.frontmatter.date);
       return db - da;
     })
     .slice(0, max || 4);

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -59,7 +59,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap) {
   let recapZone = '';
   if (latestSession) {
     const recap = extractRecap(latestSession);
-    const dateStr = formatDate(latestSession.frontmatter.actual_date);
+    const dateStr = formatDate(latestSession.frontmatter.play_date || latestSession.frontmatter.actual_date);
     const dateBadge = dateStr ? ` <span style="opacity:0.7;font-size:0.85rem"> — ${escapeHtml(dateStr)}</span>` : '';
     const recapLink = `<a class="recap-link" href="${escapeHtml(latestSession.outputPath)}">Read full session &rarr;</a>`;
     recapZone = `<div class="dashboard-section">

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -108,15 +108,15 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   const locEvents = (pages || []).filter(p =>
     p.frontmatter.type === 'event' && matchesRef(p.frontmatter.location, page.title)
   ).sort((a, b) => {
-    const da = new Date(a.frontmatter.date || 0).getTime();
-    const db = new Date(b.frontmatter.date || 0).getTime();
+    const da = new Date(a.frontmatter.in_game_date || a.frontmatter.date || 0).getTime();
+    const db = new Date(b.frontmatter.in_game_date || b.frontmatter.date || 0).getTime();
     return (isNaN(da) ? 0 : da) - (isNaN(db) ? 0 : db);
   });
   let timelineHtml = '';
   if (locEvents.length > 0) {
     const nodes = locEvents.map(ev => {
       const href = relativePath(page.outputPath, ev.outputPath);
-      const date = ev.frontmatter.date || '';
+      const date = ev.frontmatter.in_game_date || ev.frontmatter.date || '';
       const outcome = ev.frontmatter.outcome || '';
       return `<div class="timeline-node">
   <span class="timeline-date">${escapeHtml(date)}</span>

--- a/tools/publish/lib/theme.js
+++ b/tools/publish/lib/theme.js
@@ -72,15 +72,27 @@ function hexToRgba(hex, alpha) {
 }
 
 function generateThemeCSS(config) {
-  const palette = config.palette || {};
+  const palette = config.palette;
   const fonts = config.fonts || {};
 
+  // When a genre preset is active and no custom palette was provided,
+  // emit only font overrides — the preset CSS handles colors.
+  if (!palette && config.genre && resolveGenrePreset(config.genre)) {
+    const fontVars = [];
+    if (fonts.heading) fontVars.push(`  --font-heading: ${cssFontValue(fonts.heading, 'serif')};`);
+    if (fonts.body) fontVars.push(`  --font-body: ${cssFontValue(fonts.body, 'sans-serif')};`);
+    if (fontVars.length === 0) return '/* Genre preset active — no overrides */\n';
+    const fontsImport = googleFontsImport(fonts);
+    return `${fontsImport}:root {\n${fontVars.join('\n')}\n}\n`;
+  }
+
+  const pal = palette || {};
   const vars = [];
 
-  const bg = palette.background || '#1a1f25';
-  const text = palette.text || '#c9d1d9';
-  const accent = palette.accent || '#58a6ff';
-  const primary = palette.primary || '#0d1117';
+  const bg = pal.background || '#1a1f25';
+  const text = pal.text || '#c9d1d9';
+  const accent = pal.accent || '#58a6ff';
+  const primary = pal.primary || '#0d1117';
 
   vars.push(`  --bg: ${bg};`);
   vars.push(`  --text: ${text};`);

--- a/tools/publish/lib/timeline.js
+++ b/tools/publish/lib/timeline.js
@@ -4,15 +4,35 @@ function parseDate(value) {
   const s = String(value);
   const parts = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (parts) return new Date(Date.UTC(+parts[1], +parts[2] - 1, +parts[3]));
+
+  // Handle vague/seasonal dates like "Autumn 1813", "Late Spring 1813", "Summer 1813"
+  const yearMatch = s.match(/\b(\d{4})\b/);
+  if (yearMatch) {
+    const year = +yearMatch[1];
+    const lower = s.toLowerCase();
+    const seasonMap = { spring: 3, summer: 6, autumn: 9, fall: 9, winter: 0 };
+    let month = null;
+    for (const [season, baseMonth] of Object.entries(seasonMap)) {
+      if (lower.includes(season)) {
+        month = baseMonth;
+        if (lower.includes('early')) month = Math.max(0, month - 1);
+        if (lower.includes('late')) month = Math.min(11, month + 1);
+        break;
+      }
+    }
+    if (month === null) month = 5; // no season keyword — default to June
+    return new Date(Date.UTC(year, month, 1));
+  }
+
   return new Date(s);
 }
 
 function buildTimelineData(pages) {
   const events = pages
-    .filter(p => p.frontmatter.type === 'event' && p.frontmatter.date)
+    .filter(p => p.frontmatter.type === 'event' && (p.frontmatter.in_game_date || p.frontmatter.date))
     .map(p => ({
       title: p.displayTitle,
-      date: parseDate(p.frontmatter.date),
+      date: parseDate(p.frontmatter.in_game_date || p.frontmatter.date),
       type: 'event',
       outputPath: p.outputPath,
       outcome: p.frontmatter.outcome || '',

--- a/tools/publish/lib/timeline.js
+++ b/tools/publish/lib/timeline.js
@@ -1,12 +1,24 @@
 const { escapeHtml } = require('./processor');
 
+const MONTHS = { january:0, february:1, march:2, april:3, may:4, june:5,
+  july:6, august:7, september:8, october:9, november:10, december:11 };
+
 function parseDate(value) {
   const s = String(value);
-  const parts = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (parts) return new Date(Date.UTC(+parts[1], +parts[2] - 1, +parts[3]));
+  const iso = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (iso) return new Date(Date.UTC(+iso[1], +iso[2] - 1, +iso[3]));
 
-  // Handle vague/seasonal dates like "Autumn 1813", "Late Spring 1813", "Summer 1813"
+  // "August 11, 1814" or "11 August 1814" or "July 1814"
+  const monthName = s.match(/\b(january|february|march|april|may|june|july|august|september|october|november|december)\b/i);
   const yearMatch = s.match(/\b(\d{4})\b/);
+  if (monthName && yearMatch) {
+    const m = MONTHS[monthName[1].toLowerCase()];
+    const dayMatch = s.match(/\b(\d{1,2})\b/);
+    const day = dayMatch && +dayMatch[1] <= 31 ? +dayMatch[1] : 1;
+    return new Date(Date.UTC(+yearMatch[1], m, day));
+  }
+
+  // Vague/seasonal: "Autumn 1813", "Late Spring 1813"
   if (yearMatch) {
     const year = +yearMatch[1];
     const lower = s.toLowerCase();
@@ -20,7 +32,7 @@ function parseDate(value) {
         break;
       }
     }
-    if (month === null) month = 5; // no season keyword — default to June
+    if (month === null) month = 5;
     return new Date(Date.UTC(year, month, 1));
   }
 

--- a/tools/publish/test/fixtures/clean-schema/Events/Battle.md
+++ b/tools/publish/test/fixtures/clean-schema/Events/Battle.md
@@ -1,7 +1,7 @@
 ---
 type: event
 event_type: battle
-date: "June 15, 1943"
+in_game_date: "June 15, 1943"
 location: "[[City]]"
 participants:
   - "[[Hero]] (led the assault)"

--- a/tools/publish/test/fixtures/redesign-full/Events/Library_Break_In.md
+++ b/tools/publish/test/fixtures/redesign-full/Events/Library_Break_In.md
@@ -1,6 +1,6 @@
 ---
 type: event
-date: "1936-03-15"
+in_game_date: "1936-03-15"
 location: "[[Miskatonic_Library]]"
 outcome: "Several rare tomes stolen"
 participants:

--- a/tools/publish/test/fixtures/redesign-full/Sessions/Session_1.md
+++ b/tools/publish/test/fixtures/redesign-full/Sessions/Session_1.md
@@ -2,7 +2,7 @@
 type: session
 status: played
 session_number: 1
-actual_date: "2024-01-15"
+play_date: "2024-01-15"
 ---
 
 # Session 1: The Missing Books

--- a/tools/publish/test/fixtures/redesign-full/Sessions/Session_2.md
+++ b/tools/publish/test/fixtures/redesign-full/Sessions/Session_2.md
@@ -2,7 +2,7 @@
 type: session
 status: played
 session_number: 2
-actual_date: "2024-02-01"
+play_date: "2024-02-01"
 ---
 
 # Session 2: Following the Trail

--- a/tools/publish/test/fixtures/with-dashboard/Sessions/Session 1.md
+++ b/tools/publish/test/fixtures/with-dashboard/Sessions/Session 1.md
@@ -1,7 +1,7 @@
 ---
 type: session
 session_number: 1
-actual_date: "2026-01-15"
+play_date: "2026-01-15"
 status: played
 ---
 

--- a/tools/publish/test/fixtures/with-dashboard/Sessions/Session 2.md
+++ b/tools/publish/test/fixtures/with-dashboard/Sessions/Session 2.md
@@ -1,7 +1,7 @@
 ---
 type: session
 session_number: 2
-actual_date: "2026-04-12"
+play_date: "2026-04-12"
 status: played
 ---
 

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -5,9 +5,9 @@ const { getLatestSession, extractRecap, getInitials, getPCs, scoreNPCs, inferNPC
 describe('getLatestSession', () => {
   it('returns the most recent played session by session_number', () => {
     const pages = [
-      { frontmatter: { type: 'session', status: 'played', session_number: 1, actual_date: '2026-01-01' }, markdown: '# S1' },
-      { frontmatter: { type: 'session', status: 'played', session_number: 3, actual_date: '2026-03-01' }, markdown: '# S3' },
-      { frontmatter: { type: 'session', status: 'played', session_number: 2, actual_date: '2026-02-01' }, markdown: '# S2' },
+      { frontmatter: { type: 'session', status: 'played', session_number: 1, play_date: '2026-01-01' }, markdown: '# S1' },
+      { frontmatter: { type: 'session', status: 'played', session_number: 3, play_date: '2026-03-01' }, markdown: '# S3' },
+      { frontmatter: { type: 'session', status: 'played', session_number: 2, play_date: '2026-02-01' }, markdown: '# S2' },
       { frontmatter: { type: 'pc', status: 'alive' }, markdown: '# PC' },
     ];
     const result = getLatestSession(pages);
@@ -32,8 +32,8 @@ describe('getLatestSession', () => {
 
   it('returns a session with status reviewed', () => {
     const pages = [
-      { frontmatter: { type: 'session', status: 'reviewed', session_number: 5, actual_date: '2026-04-26' }, title: 'Session 5' },
-      { frontmatter: { type: 'session', status: 'played', session_number: 4, actual_date: '2026-04-19' }, title: 'Session 4' },
+      { frontmatter: { type: 'session', status: 'reviewed', session_number: 5, play_date: '2026-04-26' }, title: 'Session 5' },
+      { frontmatter: { type: 'session', status: 'played', session_number: 4, play_date: '2026-04-19' }, title: 'Session 4' },
     ];
     const result = getLatestSession(pages);
     assert.strictEqual(result.title, 'Session 5');
@@ -256,10 +256,10 @@ describe('scoreNPCs', () => {
 });
 
 describe('getRecentEvents', () => {
-  it('returns events sorted by date, most recent first', () => {
+  it('returns events sorted by in_game_date, most recent first', () => {
     const pages = [
-      { frontmatter: { type: 'event', date: '1936-01-01' }, displayTitle: 'Old' },
-      { frontmatter: { type: 'event', date: '1936-12-01' }, displayTitle: 'New' },
+      { frontmatter: { type: 'event', in_game_date: '1936-01-01' }, displayTitle: 'Old' },
+      { frontmatter: { type: 'event', in_game_date: '1936-12-01' }, displayTitle: 'New' },
       { frontmatter: { type: 'npc' }, displayTitle: 'Not event' },
     ];
     const result = getRecentEvents(pages, 10);
@@ -267,20 +267,30 @@ describe('getRecentEvents', () => {
     assert.strictEqual(result[0].displayTitle, 'New');
   });
 
+  it('falls back to date field for backward compat', () => {
+    const pages = [
+      { frontmatter: { type: 'event', date: '1936-01-01' }, displayTitle: 'Old (legacy)' },
+      { frontmatter: { type: 'event', date: '1936-12-01' }, displayTitle: 'New (legacy)' },
+    ];
+    const result = getRecentEvents(pages, 10);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].displayTitle, 'New (legacy)');
+  });
+
   it('respects max limit', () => {
     const pages = [
-      { frontmatter: { type: 'event', date: '1936-01-01' } },
-      { frontmatter: { type: 'event', date: '1936-02-01' } },
-      { frontmatter: { type: 'event', date: '1936-03-01' } },
+      { frontmatter: { type: 'event', in_game_date: '1936-01-01' } },
+      { frontmatter: { type: 'event', in_game_date: '1936-02-01' } },
+      { frontmatter: { type: 'event', in_game_date: '1936-03-01' } },
     ];
     const result = getRecentEvents(pages, 2);
     assert.strictEqual(result.length, 2);
   });
 
-  it('skips events without date', () => {
+  it('skips events without in_game_date or date', () => {
     const pages = [
       { frontmatter: { type: 'event' }, displayTitle: 'No date' },
-      { frontmatter: { type: 'event', date: '1936-01-01' }, displayTitle: 'Has date' },
+      { frontmatter: { type: 'event', in_game_date: '1936-01-01' }, displayTitle: 'Has date' },
     ];
     const result = getRecentEvents(pages, 10);
     assert.strictEqual(result.length, 1);


### PR DESCRIPTION
## Summary

- **Timeline fixes**: reads `in_game_date` (falling back to `date` for pre-migration vaults); parses vague seasonal dates like "Autumn 1813" to approximate months instead of defaulting to Jan 1
- **Chapter-session matching**: three-stage matcher (exact filename, filename with spaces, display title substring) so chapter pages correctly list their sessions
- **Genre preset override**: theme.css no longer stomps genre preset colors when no custom palette is provided
- **Stale npm detection**: publish-site routine updates now auto-detect and update outdated build tool dependencies
- **Date field standardization**: `date` → `in_game_date` on events, `planned_date`/`actual_date` → `play_date` on sessions, with migration entry (1.4.22) and deprecation warnings
- **Session wrap-up conventions**: standardized filename (`Session_NN_Wrap_Up.md`), type (`session_wrap`), and parseable date format guidance
- **All consuming code updated**: landing page, location pages, badges, event sorting use new fields with backward-compatible fallbacks
- **Tests and fixtures updated** to match new field names

## Test plan

- [x] Schema validation passes (`python3 scripts/validate_schema.py`)
- [x] Unit tests pass (`landing-data.test.js` — 38 tests including backward-compat coverage)
- [x] Both live campaign sites (Canticle, Special Forces) rebuilt and published successfully during testing
- [ ] CodeRabbit review
- [ ] Verify timeline renders all events with correct dates on both sites after migration