### PR TITLE
Add the-midwife adventure creation skill (v1.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
-  "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, and vault ingestion of old campaign materials",
-  "version": "1.5.0",
+  "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
+  "version": "1.5.1",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -139,8 +139,8 @@ jobs:
         run: |
           ./scripts/build-skill-zips.sh
           ZIP_COUNT=$(ls dist/*.zip 2>/dev/null | wc -l | xargs)
-          if [ "$ZIP_COUNT" -ne 8 ]; then
-            echo "::error::Expected 8 skill zips, got $ZIP_COUNT"
+          if [ "$ZIP_COUNT" -ne 9 ]; then
+            echo "::error::Expected 9 skill zips, got $ZIP_COUNT"
             exit 1
           fi
           for z in dist/*.zip; do

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -149,4 +149,4 @@ jobs:
               exit 1
             fi
           done
-          echo "All 8 skill zips valid"
+          echo "All $ZIP_COUNT skill zips valid"

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -71,7 +71,8 @@ project's skill files with attribution to their creators:
 - **Return of the Lazy Dungeon Master** and the Lazy DM
   prep method by Mike Shea (Sly Flourish,
   https://slyflourish.com/)
-- **Five Room Dungeon** by Johnn Four (Roleplaying Tips,
+- **Five Room Dungeon** and **Campaign Seed Recipe** by
+  Johnn Four (Roleplaying Tips,
   https://roleplayingtips.com/)
 - **Action-Oriented Monsters** by Matthew Colville (MCDM,
   https://mcdm.gg/)
@@ -81,6 +82,14 @@ project's skill files with attribution to their creators:
 - **Fronts** from Apocalypse World by D. Vincent Baker
 - **Progress Clocks** from Blades in the Dark by John Harper
   (CC-BY 3.0, see above)
+- **Adventure Shapes** and **Momentous & Inertial Adventure
+  Design** by Scott Rehm (The Angry GM,
+  https://theangrygm.com/)
+- **CATS Method** (Concept/Aim/Tone/Subject) by Patrick
+  O'Leary
+- **Petersen's Onion Layer** by Sandy Petersen
+- **Story-to-Campaign Adaptation** by Mythcreants
+  (https://mythcreants.com/)
 
 ## Lovecraft Mythos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.1] — 2026-05-09
+
+### Added
+
+- **the-midwife skill** — guided adventure creation through
+  creative conversation. Handles greenfield campaigns and
+  existing vault continuations (new chapters, arcs, prequels,
+  time jumps). Produces an adventure brief and scaffolds the
+  vault for Session 0 handoff.
+- **adventure-brief entity type** — new entity under
+  `narrative (abstract)` for structured adventure design
+  documents with scope, shape, and continuation metadata.
+- **Adventure Shapes framework** — structural skeleton
+  taxonomy (linear, branching, hub-and-spoke, open-node,
+  sandbox) in scenario-writing reference.
+- **CATS pitch method** — Concept/Aim/Tone/Subject session 0
+  pitch framework in gm-session-patterns reference.
+- **One-shot and few-shot structural guidance** — conception-
+  phase constraints and principles in scenario-writing
+  reference.
+- **Victory-state antagonist design** — reverse-engineering
+  villain plans from victory state in scenario-writing
+  reference.
+- **Playability stress test** — checklist for testing RPG
+  viability of adventure concepts.
+
 ## [1.5.0] — 2026-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,6 +550,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.5.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.22...v1.5.0
 [1.4.22]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.21...v1.4.22
 [1.4.19]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.18...v1.4.19
 [1.4.18]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.17...v1.4.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference.
 - **Playability stress test** — checklist for testing RPG
   viability of adventure concepts.
+- **Midwife workspace** — per-adventure working directories
+  with automatic topic splitting, shared seed bank, and
+  context-aware reading. Replaces monolithic
+  `_midwife-notes.md`. Supports multiple adventures in
+  parallel.
+- **Adventures/ subfolder convention** — adventure briefs
+  now live in `Adventures/{adventure-name}/` subdirectories.
+- **`_midwife/` vault folder** — creative workspace added
+  to vault structure for midwife working files.
 
 ## [1.5.0] — 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ generation to campaign management and session lifecycle support.
 | | session-wrapup | Post-session processing | Turns raw play notes into canon. Creates/updates entities, events, timeline. Feeds session-prep. |
 | **Content ingestion** | vault-ingest | Old materials to structured vault | Adapter — classifies, interviews GM, synthesizes. Hands off to campaign-organizer and session-wrapup. |
 | **Content publication** | publish-site | Vault to static website | Reads vault, generates HTML. No vault writes. |
-| **Adventure creation** | the-midwife *(planned)* | Idea to starting adventure + vault | Creative midwife — draws ideas out of the GM, shapes them into a playable starting point. |
+| **Adventure creation** | the-midwife | Idea to starting adventure + vault | Creative guide — draws ideas out of the GM through conversation, shapes them into a playable starting point with adventure brief and vault scaffold. |
 
 ## Supported Game Systems
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,7 @@ Items are force-ranked by score. Higher score = do first.
 
 | Item | Impact | Urgency | Effort | Score | Status | Notes |
 |------|:------:|:-------:|:------:|:-----:|--------|-------|
+| Campaign overview template with current game date | 5 | 3 | M (2) | 6.5 | Idea | Create a campaign overview template (none exists today). Include a `current_game_date` frontmatter field that session-wrapup updates after every wrap-up. Keeps the campaign front page authoritative on where the story clock sits. |
 | ~~the-midwife: guided adventure creation skill~~ | 4 | 2 | M (2) | 5.0 | ~~Done~~ | ~~Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots.~~ |
 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
 | Publish tool: thematic cause-of-death icons for The Fallen | 2 | 1 | S (1) | 5.0 | Idea | New optional PC frontmatter field `cause_of_death` (combat, madness, eldritch, disease, etc.) with thematic SVG icons on Fallen cards |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Items are force-ranked by score. Higher score = do first.
 
 | Item | Impact | Urgency | Effort | Score | Status | Notes |
 |------|:------:|:-------:|:------:|:-----:|--------|-------|
-| the-midwife: guided adventure creation skill | 4 | 2 | M (2) | 5.0 | Idea | Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots. |
+| ~~the-midwife: guided adventure creation skill~~ | 4 | 2 | M (2) | 5.0 | ~~Done~~ | ~~Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots.~~ |
 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
 | Publish tool: thematic cause-of-death icons for The Fallen | 2 | 1 | S (1) | 5.0 | Idea | New optional PC frontmatter field `cause_of_death` (combat, madness, eldritch, disease, etc.) with thematic SVG icons on Fallen cards |
 | Publish tool: per-page header banner | 2 | 1 | S (1) | 5.0 | Idea | Custom banner image per page via frontmatter |
@@ -60,6 +60,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
+- ~~the-midwife: guided adventure creation skill~~ — Adventure creation skill with adventure-brief entity type, vault-mining, Session 0 handoff
 - ~~Publish tool: site redesign v1.2~~ — Navigation overhaul, breadcrumbs, genre presets, system-specific PC sheets (CoC/GURPS/D&D/FitD), lunr search, relationship graphs, timeline pages, context sidebars, index page redesigns, landing page rewrite (PR #40)
 - ~~Publish tool: GURPS PC sheet — single alphabetized skills list~~ — Inline comments enforcing single alphabetized tables for Skills and Spells (PR #32)
 - ~~Publish tool: mobile HTML fixes~~ — Accordion table horizontal scroll, back-to-top button with scroll-triggered fade (PR #32)

--- a/docs/personal-reference-files.md
+++ b/docs/personal-reference-files.md
@@ -30,7 +30,7 @@ host it publicly, or circumvent publisher licensing terms.
 
 ## Where Personal Files Live
 
-```
+```text
 skills/ttrpg-expert/systems/
   fitd/
     personal/           <-- your FitD setting content

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -26,6 +26,14 @@ SCENE_TYPES = {
     "transition", "horror", "downtime", "other"
 }
 NPC_STATUS = {"alive", "dead", "missing", "unknown"}
+ADVENTURE_BRIEF_SCOPE = {"campaign", "one-shot", "few-shot"}
+ADVENTURE_BRIEF_CONTINUATION = {
+    "new", "new-chapter", "new-arc", "time-jump",
+    "prequel", "parallel", "new-pcs"
+}
+ADVENTURE_BRIEF_SHAPE = {
+    "linear", "branching", "hub-and-spoke", "open-node", "sandbox"
+}
 
 # Required fields per entity type
 # All entities need: type, source_confidence
@@ -40,6 +48,7 @@ REQUIRED_FIELDS = {
     "clue": ["type", "source_confidence"],
     "event": ["type", "source_confidence"],
     "document": ["type", "source_confidence"],
+    "adventure-brief": ["type", "source_confidence", "scope"],
     "session": ["type", "session_number", "status", "documents"],
     "session-plan": ["type", "source_confidence", "session"],
     "session-play-notes": ["type", "source_confidence", "session"],
@@ -194,6 +203,36 @@ def validate_file(filepath: Path) -> list[str]:
                 f"Invalid status '{value}' — "
                 f"must be one of: {', '.join(sorted(NPC_STATUS))}"
             )
+
+    # Validate adventure-brief fields
+    if entity_type == "adventure-brief":
+        if "scope" in frontmatter:
+            value = frontmatter["scope"]
+            if not isinstance(value, str):
+                errors.append("Field 'scope' must be a string")
+            elif value not in ADVENTURE_BRIEF_SCOPE:
+                errors.append(
+                    f"Invalid scope '{value}' — "
+                    f"must be one of: {', '.join(sorted(ADVENTURE_BRIEF_SCOPE))}"
+                )
+        if "continuation_type" in frontmatter:
+            value = frontmatter["continuation_type"]
+            if not isinstance(value, str):
+                errors.append("Field 'continuation_type' must be a string")
+            elif value not in ADVENTURE_BRIEF_CONTINUATION:
+                errors.append(
+                    f"Invalid continuation_type '{value}' — "
+                    f"must be one of: {', '.join(sorted(ADVENTURE_BRIEF_CONTINUATION))}"
+                )
+        if "adventure_shape" in frontmatter:
+            value = frontmatter["adventure_shape"]
+            if not isinstance(value, str):
+                errors.append("Field 'adventure_shape' must be a string")
+            elif value not in ADVENTURE_BRIEF_SHAPE:
+                errors.append(
+                    f"Invalid adventure_shape '{value}' — "
+                    f"must be one of: {', '.join(sorted(ADVENTURE_BRIEF_SHAPE))}"
+                )
 
     # Validate portrait field — only allowed for supported entity types
     portrait = frontmatter.get("portrait")

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -84,6 +84,9 @@ to your environment's tools per `shared/filesystem-mode.md`.
 - `_inbox/` — Staging area for vault-ingest. **Ignore during
   all audit modes.** Do not flag files here as orphans or
   structural issues.
+- `_midwife/` — Midwife creative workspace. **Ignore during
+  all audit modes.** Entity sketches here are drafts, not
+  vault entities.
 
 **Shared references** (read as needed for schema definitions):
 - `shared/canon-confidence.md` — DRAFT/AUTHORITATIVE/SUPERSEDED

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -84,7 +84,8 @@ narrative (abstract)
 │   ├── discovery
 │   ├── betrayal_event
 │   └── celebration
-└── clue
+├── clue
+└── adventure-brief
 ```
 
 Abstract types cannot be assigned directly to entities but are
@@ -266,6 +267,16 @@ Extraction defaults:
 | date | string | When written |
 | content | string | The text |
 | condition | string | Physical state |
+
+### Adventure Brief
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| scope | string | campaign / one-shot / few-shot |
+| sessions_estimated | string | Number or range (e.g. "3-5") |
+| continuation_type | string | new / new-chapter / new-arc / time-jump / prequel / parallel / new-pcs |
+| adventure_shape | string | linear / branching / hub-and-spoke / open-node / sandbox |
+| system | string | Game system identifier or "undecided" |
 
 ## Narrative Element Schemas
 
@@ -457,6 +468,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | event (all subtypes) | Events/ |
 | document (all subtypes) | Documents/ |
 | clue | Clues/ |
+| adventure-brief | Adventures/ |
 
 ## Vault Configuration Fields
 

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -402,6 +402,11 @@ etc.), `goals`, `leadership` (wiki-link), `territory` (wiki-link),
 **Clue:** `clue_type` (physical, testimonial, documentary),
 `found_at` (wiki-link), `found_by`, `leads_to`, `reliability`
 
+**Adventure Brief:** `scope` (campaign/one-shot/few-shot),
+`sessions_estimated`, `continuation_type` (new/new-chapter/new-arc/time-jump/prequel/parallel/new-pcs),
+`adventure_shape` (linear/branching/hub-and-spoke/open-node/sandbox),
+`system`
+
 **Creature:** `creature_type` (beast, undead, aberration, etc.),
 `location` (wiki-link), `abilities`, `weaknesses`, `portrait` (optional)
 

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -468,7 +468,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | event (all subtypes) | Events/ |
 | document (all subtypes) | Documents/ |
 | clue | Clues/ |
-| adventure-brief | Adventures/ |
+| adventure-brief | Adventures/{adventure-name}/ |
 
 ## Vault Configuration Fields
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.4.22"
+current_version: "1.5.1"
 ---
 
 # Vault Migration Registry

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -166,3 +166,14 @@ Standardizes date field names across session and event entities.
   for `adventure-brief` entities. Created automatically when the
   midwife writes its first adventure brief. No action needed for
   existing vaults.
+
+- **New workspace folder:** `_midwife/` added to vault
+  structure for midwife working files. Created automatically
+  on first midwife invocation. No action needed for existing
+  vaults.
+
+- **Adventures/ subfolder convention:** Adventure briefs
+  now use per-adventure subdirectories
+  (`Adventures/{name}/{name}.md`). Existing briefs in flat
+  `Adventures/` continue to work. No action needed for
+  existing vaults.

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -150,3 +150,19 @@ Standardizes date field names across session and event entities.
 - **Session wrap-up files**: standardize `type:` to `session_wrap`
   (from any of: `session-wrap-up`, `session_wrap_up`, `session_note`).
   Opt-in per file — review before applying.
+
+## Migration: 1.4.22 → 1.5.1
+
+### Structural
+
+- **New entity type:** `adventure-brief` added to entity schema
+  under `narrative (abstract)`. No vault changes required — the
+  type is available for new files immediately. Existing vaults
+  continue to work without modification.
+
+### Content
+
+- **New folder:** `Adventures/` added to default folder mapping
+  for `adventure-brief` entities. Created automatically when the
+  midwife writes its first adventure brief. No action needed for
+  existing vaults.

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -117,7 +117,7 @@ Adventures/
     └── {Adventure Name}.md    (adventure brief)
 ```
 
-The adventure brief is the folder's index file. Entity files
+The adventure brief is the folder's primary file. Entity files
 referenced by the brief live in their normal type folders
 (Characters/, Locations/, etc.), not under Adventures/.
 

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -150,6 +150,10 @@ _midwife/
     └── session-0/       (CATS pitch, safety, handouts)
 ```
 
+Additional topic files (weather, cover stories, social events,
+romance threads) are created on demand. See the-midwife
+SKILL.md for the full list.
+
 Each adventure is an independent working directory. The
 midwife can work on multiple adventures in parallel.
 Adventures stay here until explicitly ingested into the vault

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -13,6 +13,7 @@ Written to `_meta/vault-config.md` on first setup.
 │   ├── creatures/   (creature art)
 │   ├── events/      (scene art)
 │   └── documents/   (scans, letter images)
+├── _midwife/        (adventure workspace — see below)
 ├── _Campaign/
 │   ├── Campaign Overview.md
 │   ├── Player Characters.md
@@ -20,6 +21,9 @@ Written to `_meta/vault-config.md` on first setup.
 ├── _Templates/      (one per type)
 ├── _inbox/          (staging area for vault-ingest)
 │   └── _processed/  (completed imports, date-stamped)
+├── Adventures/
+│   └── {Adventure Name}/
+│       └── {Adventure Name}.md
 ├── Chapters/
 │   └── Chapter N - {Title}/
 │       ├── Chapter N Overview.md
@@ -100,3 +104,61 @@ ingestion, files move to `_inbox/_processed/` with a date stamp.
 `campaign-qa` ignores `_inbox/` during audits.
 `campaign-organizer` creates it during vault setup but does
 not process its contents.
+
+## Adventures
+
+The `Adventures/` folder stores adventure briefs — structured
+design documents produced by the midwife skill. Each adventure
+gets its own subfolder:
+
+```text
+Adventures/
+└── {Adventure Name}/
+    └── {Adventure Name}.md    (adventure brief)
+```
+
+The adventure brief is the folder's index file. Entity files
+referenced by the brief live in their normal type folders
+(Characters/, Locations/, etc.), not under Adventures/.
+
+## Midwife Workspace
+
+The `_midwife/` folder is the midwife skill's creative
+workspace. It stores working notes, seed ideas, entity
+sketches, and other artifacts produced during adventure
+brainstorming. Created automatically on first midwife
+invocation.
+
+```text
+_midwife/
+├── index.md             (master manifest — all adventures)
+├── seeds/               (shared idea bank across adventures)
+│   ├── premises/        (adventure concepts, genre combos)
+│   ├── npcs/            (NPC ideas that didn't fit)
+│   ├── locations/       (place concepts)
+│   ├── hooks/           (plot hooks, inciting events)
+│   ├── tone/            (tone/genre/atmosphere ideas)
+│   └── mechanics/       (system-specific ideas)
+└── {adventure-name}/    (per-adventure working directory)
+    ├── index.md         (adventure TOC, status, open Qs)
+    ├── discoveries.md
+    ├── chapter-shape.md
+    ├── adventures/      (confirmed sub-adventures)
+    ├── npcs/            (confirmed NPC profiles)
+    ├── entity-sketches/ (draft entities for promotion)
+    ├── image-prompts/   (visual concept descriptions)
+    └── session-0/       (CATS pitch, safety, handouts)
+```
+
+Each adventure is an independent working directory. The
+midwife can work on multiple adventures in parallel.
+Adventures stay here until explicitly ingested into the vault
+via `Adventures/`. They may never be ingested — parked
+adventures remain as creative archives.
+
+The `seeds/` folder is shared across all adventures. When an
+idea is generated but not used, it goes to the appropriate
+seed category. When starting a new adventure, the midwife
+scans seeds for relevant prior ideas.
+
+`campaign-qa` ignores `_midwife/` during audits.

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -55,16 +55,86 @@ hand off to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`).
 Skip if no `_meta/`.
 
-## Progressive Notes
+## Content Management
 
-From Phase 1 onward, write working notes to
-`_midwife-notes.md` (vault root or CWD). Every decision,
-idea, and parked concept goes on disk immediately — nothing
-lives only in conversation context.
+The Midwife maintains a workspace at `_midwife/` (vault root
+or CWD). Every decision, idea, and parked concept goes on
+disk immediately — nothing lives only in conversation context.
 
-- Created at first discovery, append-only during Phases 1-3
-- Consumed and synthesized into adventure brief in Phase 4
-- Kept alongside the brief (GM may revisit parked ideas)
+### Workspace Setup
+
+On first invocation, create `_midwife/index.md` (master
+manifest) and `_midwife/seeds/` (empty seed categories:
+`premises/`, `npcs/`, `locations/`, `hooks/`, `tone/`,
+`mechanics/`). If `_midwife/` already exists, read the
+master index to discover existing adventures and seeds.
+
+When the GM names the adventure (or at first discovery),
+create `_midwife/{adventure-name}/index.md`.
+
+### Master Index
+
+`_midwife/index.md` — always read on start. Lists all
+adventures with status (Active / Parked / Complete /
+Ingested) and seed bank summary. Keep under 100 lines.
+
+### Adventure Index
+
+`_midwife/{adventure}/index.md` — read when working on a
+specific adventure. Contains:
+
+- Status and current phase
+- File manifest with one-line summary per topic file
+- Open Questions (parked GM decisions)
+- Active thread (what the conversation is working on)
+
+Keep under 150 lines.
+
+### Reading Pattern
+
+1. Always read `_midwife/index.md` (~50-100 lines)
+2. Read `_midwife/{adventure}/index.md` (~100-150 lines)
+3. Read only topic files relevant to the current conversation
+4. Never bulk-read all files — load on demand
+
+### Topic Files
+
+Not all files are created upfront. Create on demand as
+content emerges. Only `index.md` is guaranteed.
+
+Possible topic files per adventure:
+
+- `discoveries.md` — Phase 1 vault mining, constraints
+- `chapter-shape.md` — structure, shape, climax plan
+- `weather-atmosphere.md` — setting colour by location
+- `adventures/{name}.md` — confirmed sub-adventures
+- `npcs/{name}.md` — confirmed NPC profiles or groups
+- `cover-stories.md` — PC covers, obligations
+- `social-events.md` — set pieces, social calendar
+- `romance-threads.md` — PC relationship threads
+- `entity-sketches/{name}.md` — draft entities
+- `image-prompts/{name}.md` — visual concepts
+- `session-0/{name}.md` — CATS pitch, safety, handouts
+
+### Automatic Filing
+
+When content is confirmed ("done", "let's move on", GM
+approval), write it to the appropriate topic file, update
+the adventure index, and mention it briefly. The GM never
+manages files.
+
+When an idea is rejected or parked for later, write it to
+a file in the appropriate `seeds/` subfolder with a title
+and a paragraph capturing the concept. Seeds accumulate
+across all adventures and are never deleted.
+
+### Splitting
+
+When any topic file exceeds ~400 lines, split it by
+subtopic (e.g., `indian-allies.md` → per-ally files under
+`npcs/`). Update the adventure index. Adventures always
+get their own file under `adventures/` once confirmed,
+regardless of size.
 
 ## Phase 1: Discover
 
@@ -98,7 +168,12 @@ for genre patterns. Ask which seed wants to grow.
 Adapt to what the GM gives. Full concept → validate, move to
 Shape. Single image → explore it. One question at a time.
 
-Write discoveries to notes file as they emerge.
+**Seed bank:** On new adventures, scan `_midwife/seeds/`
+for relevant prior ideas. Surface any seeds that connect
+to the GM's interests alongside fresh brainstorming.
+
+Write discoveries to `_midwife/{adventure}/discoveries.md`
+as they emerge. Update the adventure index.
 
 ## Phase 2: Shape
 
@@ -140,7 +215,9 @@ connections the GM might not have seen.
 - `ttrpg-expert/gm-session-patterns.md` — session 0
 - `ttrpg-expert/arc-spotlight-reference.md` — long-term arcs
 
-Update notes file.
+Write confirmed shape decisions to
+`_midwife/{adventure}/chapter-shape.md`. File rejected
+concepts to `_midwife/seeds/`. Update the adventure index.
 
 ## Phase 3: Structure
 
@@ -175,7 +252,10 @@ structure.
 Three strong NPCs beat six sketches. Two vivid locations beat
 five names on a map.
 
-Update notes file.
+Write confirmed structure to topic files under
+`_midwife/{adventure}/` — NPCs to `npcs/`, sub-adventures
+to `adventures/`, etc. File unused ideas to
+`_midwife/seeds/`. Update the adventure index.
 
 ## Phase 4: Scaffold & Handoff
 
@@ -184,20 +264,45 @@ Update notes file.
 ### Step 1: Synthesize Adventure Brief
 
 Read `shared/entity-schema.md` for adventure-brief type.
-Synthesize notes into the brief using the template below.
+Synthesize the adventure index and topic files into the
+brief using the template below.
 
-- **Existing vault:** Write to vault under `Adventures/`.
+- **Existing vault:** Write to
+  `Adventures/{adventure-name}/{adventure-name}.md`.
   Use `[[wiki-links]]` for existing entities. Flag entity
   updates the adventure implies.
-- **Greenfield:** Write to CWD.
+- **Greenfield:** Write to CWD. The adventure brief is
+  written to `Adventures/{adventure-name}/{adventure-name}.md`
+  relative to CWD — campaign-organizer will wrap the vault
+  around it.
 
-### Step 2: Vault Scaffold (greenfield only)
+### Step 2: Entity Promotion
+
+List all entity sketches from
+`_midwife/{adventure}/entity-sketches/` and ask which
+to promote to real vault entities:
+
+"These entities emerged during design:
+[Name] ([type]), [Name] ([type]), ...
+Which should I create as vault entities?"
+
+Approved entities are filed by campaign-organizer to the
+correct vault folders with proper frontmatter. Do not
+auto-promote — the GM chooses.
+
+### Step 3: Vault Scaffold (greenfield only)
 
 Ask: "Ready to set up the vault for this campaign?"
 If yes, hand off to campaign-organizer with the adventure
-brief as context.
+brief as context. campaign-organizer builds the vault
+around the existing `Adventures/` folder.
 
-### Step 3: Session 0 Handoff
+### Step 4: Update Status
+
+Mark the adventure as "Ingested" in `_midwife/index.md`.
+The working directory stays as creative archive.
+
+### Step 5: Session 0 Handoff
 
 Read `ttrpg-expert/gm-session-patterns.md`, Session Zero and
 CATS sections.

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -4,7 +4,7 @@ description: "Guided adventure creation through creative conversation. Helps GMs
 ---
 
 **On start, print:**
-```
+```text
 \033[1;42;37m  THE MIDWIFE  \033[0m
 ```
 

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: the-midwife
+description: "Guided adventure creation through creative conversation. Helps GMs develop campaign concepts, one-shots, and adventure arcs from a vague idea or from nothing at all. Detects existing vaults to build on continuing campaigns. Produces a polished adventure brief and scaffolds the vault for Session 0 handoff. Trigger on: 'new campaign', 'new adventure', 'I want to run a game', 'help me create', 'adventure idea', 'campaign concept', 'one-shot idea', 'what should I run', 'I have an idea for a game', 'new chapter', 'brainstorm a campaign', 'help me plan an adventure'."
+---
+
+**On start, print:**
+```
+\033[1;42;37m  THE MIDWIFE  \033[0m
+```
+
+Creative guide for adventure conception. You draw ideas out of
+the GM through conversation — you spark, shape, and refine, but
+never decide for them. Warm, encouraging, generatively curious.
+Offer possibilities as seeds, not prescriptions. Write nothing
+to the vault until the GM confirms.
+
+Build worlds in motion — factions act, clocks tick, consequences
+accumulate whether PCs engage or not. Ensure multiple entry
+points into every problem. Every concept needs a "what if they
+do nothing?" answer. Help the GM focus: three strong ideas beat
+six half-formed ones.
+
+**Shared references:** Read `shared/session-principles.md` on
+first invocation.
+
+## Environment Detection
+
+On start, before any creative conversation:
+
+1. Check CWD for `_meta/vault-config.md`
+   - **Found:** Existing vault. Read vault-config for system,
+     campaign name, and current state. Announce:
+     "I can see your [campaign name] vault ([system]).
+     Are we adding a new adventure to this campaign,
+     or starting something fresh?"
+   - **Not found:** Ask:
+     "I don't see a campaign vault here. Is this for an
+     existing campaign (point me to the vault) or are we
+     starting something completely new?"
+     If existing: GM provides path, read vault-config,
+     proceed as existing vault case. If new: greenfield.
+
+2. If existing vault, also read:
+   - `_meta/entity-registry.md` (if present)
+   - Most recent session index
+
+3. **System:** Existing vault → inherit, confirm with GM.
+   Greenfield → let system emerge. If GM is undecided,
+   cross-route to ttrpg-expert system files for guidance.
+
+**Version check:** Read `gm_apprentice_version` from
+`_meta/vault-config.md` and `current_version` from
+`shared/migrations.md`. If vault version is lower or absent,
+hand off to campaign-organizer's migration workflow
+(`campaign-organizer/references/migration-procedure.md`).
+Skip if no `_meta/`.
+
+## Progressive Notes
+
+From Phase 1 onward, write working notes to
+`_midwife-notes.md` (vault root or CWD). Every decision,
+idea, and parked concept goes on disk immediately — nothing
+lives only in conversation context.
+
+- Created at first discovery, append-only during Phases 1-3
+- Consumed and synthesized into adventure brief in Phase 4
+- Kept alongside the brief (GM may revisit parked ideas)
+
+## Phase 1: Discover
+
+**Goal:** Understand what the GM has.
+
+**Existing vault:** Mine the vault before asking questions.
+Surface creative opportunities:
+
+- Unresolved threads and dormant factions
+- PC arcs needing attention — read
+  `ttrpg-expert/arc-spotlight-reference.md`
+- Chekhov elements planted but unfired — read
+  `ttrpg-expert/continuity-engine.md`
+- NPCs with unfinished business
+- Parked or abandoned plot hooks
+- World state changes creating new pressure
+
+Present 2-3 vault-informed seeds alongside fresh ideas.
+
+Ask continuation type: new chapter? New arc, same PCs? Time
+jump? New PCs, same world? Prequel? Parallel story?
+
+**Greenfield:** "What's pulling at you? A genre, a scene
+you've imagined, a feeling you want at the table, a system
+you've been wanting to try — or nothing at all?"
+
+**If nothing:** Generate three seeds — genre/tone combos,
+one sentence each. Read `ttrpg-expert/scenario-writing.md`
+for genre patterns. Ask which seed wants to grow.
+
+Adapt to what the GM gives. Full concept → validate, move to
+Shape. Single image → explore it. One question at a time.
+
+Write discoveries to notes file as they emerge.
+
+## Phase 2: Shape
+
+**Goal:** Concept has enough form to name.
+
+Refine into:
+
+- **Premise:** one paragraph — what and why
+- **Tone:** feel at the table
+- **Core tension:** central conflict or mystery
+- **Driving forces:** who or what is in motion, and why
+
+**Adventure shape:** Read `ttrpg-expert/scenario-writing.md`,
+Adventure Shapes section. Help the GM choose: linear,
+branching, hub-and-spoke, open-node, or sandbox. Don't let
+shape emerge by accident.
+
+**Scope:** Don't ask "campaign or one-shot?" — reflect what's
+emerging. Greenfield: let scope emerge. Existing vault:
+inherit scope.
+
+- **Campaign:** arcs, long-term factions, PC growth
+- **One-shot:** read scenario-writing.md, One-Shot Constraints.
+  Single inciting event, contained space, closed resolution.
+  Flag if concept is too sprawling.
+- **Few-shot (2-8 sessions):** read scenario-writing.md,
+  Few-Shot Guidance. Help GM define session count, single arc,
+  built-in ending.
+
+**Playability stress test:** Read scenario-writing.md,
+Playability Stress Test. Can it branch? Does it have agency?
+Adapting from fiction? Test and reshape if needed.
+
+**Existing vault:** Check new concept against canon. Surface
+connections the GM might not have seen.
+
+**Anti-patterns:** Read:
+- `ttrpg-expert/scenario-writing.md` — anti-patterns table
+- `ttrpg-expert/gm-session-patterns.md` — session 0
+- `ttrpg-expert/arc-spotlight-reference.md` — long-term arcs
+
+Update notes file.
+
+## Phase 3: Structure
+
+**Goal:** Concept has bones.
+
+- **Key NPCs:** Read `ttrpg-expert/npc-generation.md`. Who,
+  what they want, how they connect to PCs.
+- **Factions:** Read `ttrpg-expert/world-evolution.md`.
+  Agendas, timelines if PCs don't intervene.
+- **Antagonist architecture:** Read
+  `ttrpg-expert/scenario-writing.md`, Proactive NPCs +
+  Victory-state design. Start from villain's victory state,
+  work backwards. Steps become the pressure spine.
+- **Locations:** Read `ttrpg-expert/content-generation.md`.
+  What makes each place interesting.
+- **Relationships:** Read
+  `ttrpg-expert/relationship-patterns.md`. How NPCs,
+  factions, locations connect.
+- **Architecture:** Fill in the adventure shape from Phase 2.
+  Entry points, escalation, "what if they do nothing?"
+  Multiple paths through every problem.
+
+**Existing vault:** Suggest reusing established NPCs,
+factions, locations. Check relationship graph for organic
+tie-ins. New content should feel like continuation, not a
+bolted-on module.
+
+**System-specific:** When system is known, read
+`systems/{system}/session-procedures.md` for system-flavored
+structure.
+
+Three strong NPCs beat six sketches. Two vivid locations beat
+five names on a map.
+
+Update notes file.
+
+## Phase 4: Scaffold & Handoff
+
+**Goal:** Adventure brief written, vault ready for Session 0.
+
+### Step 1: Synthesize Adventure Brief
+
+Read `shared/entity-schema.md` for adventure-brief type.
+Synthesize notes into the brief using the template below.
+
+- **Existing vault:** Write to vault under `Adventures/`.
+  Use `[[wiki-links]]` for existing entities. Flag entity
+  updates the adventure implies.
+- **Greenfield:** Write to CWD.
+
+### Step 2: Vault Scaffold (greenfield only)
+
+Ask: "Ready to set up the vault for this campaign?"
+If yes, hand off to campaign-organizer with the adventure
+brief as context.
+
+### Step 3: Session 0 Handoff
+
+Read `ttrpg-expert/gm-session-patterns.md`, Session Zero and
+CATS sections.
+
+"You've got enough to run Session 0. When you're ready,
+session-prep can help you plan it — or if you'd like to stop
+here and marinate on the concept, that's good too."
+
+Do not auto-invoke session-prep. Offer it.
+
+## Adventure Brief Template
+
+```yaml
+---
+type: adventure-brief
+source_confidence: DRAFT
+title: "[title]"
+system: "[system or undecided]"
+scope: "[campaign | one-shot | few-shot]"
+sessions_estimated: "[number or range]"
+campaign: "[name, if existing vault]"
+continuation_type: "[new | new-chapter | new-arc | time-jump | prequel | parallel | new-pcs]"
+adventure_shape: "[linear | branching | hub-and-spoke | open-node | sandbox]"
+tags: []
+aliases: []
+source_document: ""
+---
+```
+
+### Required Sections
+
+| Section | Content |
+|---------|---------|
+| Premise | One paragraph elevator pitch |
+| Tone & Genre | Sensory and emotional descriptors |
+| Adventure Shape | Structure type and rationale |
+| Core Tension | Central conflict or mystery |
+| Driving Forces | Per-faction: goal, victory state, plan, timeline, resources |
+| Key NPCs | Per-NPC: role, motivation, connection, first appearance |
+| Locations | Per-location: atmosphere, significance, connections |
+| Entry Points | ≥3 hooks (Three Clue Rule at adventure scale) |
+| Escalation | How pressure increases |
+| If They Do Nothing | Antagonist plan runs to completion |
+| Open Questions | Things the GM still needs to decide |
+| CATS Pitch | Concept/Aim/Tone/Subject for Session 0 |
+| Session 0 Agenda | Checklist items for player buy-in |
+| Vault Notes | Existing entities, updates implied (vault only) |
+
+"If They Do Nothing" is required. Open Questions are preserved
+— never invent answers for things the GM was undecided on.
+
+## Companion Skills
+
+- **ttrpg-expert** — domain knowledge. All cross-routing for
+  genre patterns, NPC frameworks, anti-patterns, arc models,
+  and system-specific content.
+- **campaign-organizer** — vault scaffold on greenfield handoff.
+  Entity filing, folder structure, knowledge graph.
+- **session-prep** — Session 0 planning after handoff. Offered,
+  never auto-invoked.
+- **campaign-qa** — optional post-scaffold health check.

--- a/skills/ttrpg-expert/gm-session-patterns.md
+++ b/skills/ttrpg-expert/gm-session-patterns.md
@@ -98,6 +98,23 @@ Establish expectations before campaign starts:
 6. House rules and system choices
 7. Player expectations and goals
 
+### CATS Pitch (Patrick O'Leary)
+
+Pitch the adventure to players before character creation.
+Four components:
+
+- **Concept:** What kind of story is this? (one sentence)
+- **Aim:** What will players be doing? (investigate, heist,
+  survive, explore, build)
+- **Tone:** What's the emotional register? (dread, swashbuckling,
+  gritty noir, cosmic horror, heroic fantasy)
+- **Subject matter:** What themes appear? Flag anything that
+  needs Lines/Veils discussion.
+
+CATS ensures player buy-in before anyone builds a character.
+A player who hears "gritty survival horror" and builds a
+wisecracking swashbuckler wasn't given the CATS pitch.
+
 ## Scene Framing
 
 **Open:** Cut to the Chase (mid-action), In Media Res
@@ -187,7 +204,8 @@ Bargains prepared.
 
 Sly Flourish (Lazy DM); The Alexandrian (Three Clue Rule);
 Vincent Baker (Fronts, Apocalypse World); John Harper
-(Progress Clocks, BitD); Johnn Four (Five Room Dungeon).
+(Progress Clocks, BitD); Johnn Four (Five Room Dungeon);
+Patrick O'Leary (CATS Method).
 
 ## External References
 

--- a/skills/ttrpg-expert/scenario-writing.md
+++ b/skills/ttrpg-expert/scenario-writing.md
@@ -72,6 +72,23 @@ The Alexandrian: prepare situations (locations, NPCs,
 motivations, resources, threats), not sequences. The scenario
 defines what exists; PCs determine what happens.
 
+### Adventure Shapes
+
+Choose the structural skeleton before building content. The
+shape constrains what content to develop and how PCs navigate.
+
+| Shape | Description | Best For |
+|-------|-------------|----------|
+| Linear | A → B → C. Fixed sequence. | One-shots, tutorials, tightly paced horror |
+| Branching | Forks with distinct paths. Paths may reconverge. | Mystery with multiple suspect lines, moral dilemmas |
+| Hub-and-spoke | Central base, radiating locations/missions. Return between. | Sandbox investigation, heist prep, faction play |
+| Open-node | Interconnected nodes, any order. Each node self-contained. | Hexcrawl, pointcrawl, exploration campaigns |
+| Sandbox | No predetermined structure. World reacts to PC actions. | Living-world campaigns, emergent play, FitD |
+
+Linear is not inherently bad — a tightly paced one-shot benefits
+from it. But flag when a concept needs branching and the GM is
+building linear.
+
 ## NPC Approach Patterns
 
 ### Proactive NPCs
@@ -80,6 +97,12 @@ Five components per significant NPC: Goal, Plan, Timeline,
 Reaction, Escalation. When PCs ignore an NPC, their plan
 advances along the timeline; consequences eventually reach
 the PCs.
+
+**Victory-state design:** Start from what the world looks like
+if the villain succeeds. Work backwards through 3-5 logistical
+steps to reach that state. Each step becomes a pressure point
+PCs can discover, disrupt, or accelerate. This prevents villain-
+goal drift and naturally generates hooks at each stage.
 
 ### Proactive Clues (when players stall)
 
@@ -140,6 +163,46 @@ engagement visibly.
 - **Scripted dialogue:** constrains GM, feels stilted. Provide
   personality + motivation + key info instead.
 
+### One-Shot Structural Constraints
+
+One-shots need hard constraints at conception — there is no
+next session to recover from loose threads:
+
+- Single inciting event that cannot be ignored
+- Contained location or social space (one building, one
+  neighbourhood, one ship)
+- Pre-generated or pre-tied PCs (no time for organic bonds)
+- Resolution that closes within session (3-4 hours)
+- No more than 3 key NPCs, 2 locations, 1 faction
+
+### Few-Shot Guidance (2-8 Sessions)
+
+Few-shots need campaign depth with one-shot closure. No
+established framework exists — build from these principles:
+
+- Single arc with a built-in ending (the ritual date, the
+  ship's departure, the election)
+- Session count should be explicit at conception ("this is
+  a 4-session arc")
+- Escalation tied to the timeline, not PC actions — the
+  clock ticks whether they engage or not
+- Final session must be satisfying even if PCs haven't
+  resolved everything — the world moves on
+
+### Playability Stress Test
+
+Before committing to a concept, test it for RPG viability:
+
+- Can the premise branch? If there's only one path through,
+  it's a story, not an adventure.
+- Does it have player agency? If the PCs are audience to
+  events rather than participants, restructure.
+- Does adapting from fiction require removing the fixed
+  narrative? If yes, extract the setting and discard the
+  plot.
+- Can a session end mid-adventure without losing momentum?
+  If not, it might need to be a one-shot.
+
 ## System-Specific Conventions
 
 ### CoC 7e
@@ -177,4 +240,7 @@ The Alexandrian (Three Clue Rule, Don't Prep Plots, Node-
 Based Design); Sly Flourish (Lazy DM); Sandy Petersen (Onion
 Layer); Chaosium (CoC Style Guide); Robin Laws / Pelgrane
 (GUMSHOE, core clue design); John Harper (BitD SRD); WotC
-(2024 DMG).
+(2024 DMG); Scott Rehm / The Angry GM (Adventure Shapes,
+Momentous & Inertial Design); Johnn Four / Roleplaying Tips
+(Campaign Seed Recipe); Mythcreants (Story-to-Campaign
+Adaptation).

--- a/tests/benchmark-campaign/Adventures/The Darkened Pier.md
+++ b/tests/benchmark-campaign/Adventures/The Darkened Pier.md
@@ -1,0 +1,170 @@
+---
+type: adventure-brief
+source_confidence: DRAFT
+title: "The Darkened Pier"
+system: coc-7e
+scope: few-shot
+sessions_estimated: "3-4"
+campaign: "The Haunting of Briarwood"
+continuation_type: new-chapter
+adventure_shape: branching
+tags:
+  - horror
+  - investigation
+  - maritime
+aliases: []
+source_document: ""
+---
+
+# The Darkened Pier
+
+## Premise
+
+A series of disappearances along the waterfront leads investigators
+to an abandoned pier where fishermen once made offerings to ensure
+safe passage. The old customs have been revived — but the entity
+receiving the offerings is no longer content with fish and wine.
+
+## Tone & Genre
+
+Maritime horror with investigation. Fog, salt-rotted timber, the
+sound of water lapping against pilings in darkness. Dread builds
+through absence — the missing are never found, only their belongings
+wash ashore.
+
+## Adventure Shape
+
+Branching — investigators can approach through the waterfront
+community, the harbour master's records, or the historical society.
+Each branch reveals different facets of the threat and converges
+at the pier.
+
+## Core Tension
+
+The disappearances are accelerating. Whatever lives beneath the pier
+is growing bolder, and the next offering is due at the new moon —
+three days away.
+
+## Driving Forces
+
+### The Esoteric Order of the Tidewaters
+
+- **Goal:** Complete the binding ritual that will give them control
+  over the entity beneath the pier
+- **Victory state:** The entity is bound and the Order uses it to
+  eliminate their rivals in the fishing trade
+- **Plan:** Continue offerings to keep the entity placated while
+  they prepare the binding circle; acquire the final component
+  (a willing sacrifice) from among the desperate dock workers
+- **Timeline:** Binding ritual at the new moon (3 days). If PCs
+  don't intervene, two more dock workers vanish and the ritual
+  succeeds — the Order gains a terrifying weapon
+- **Resources:** Six members, access to the pier, a partial copy
+  of the binding text, one corrupted harbour official
+
+## Key NPCs
+
+### [[Martha Hale]]
+
+- **Role:** Ally — grieving widow of a disappeared fisherman
+- **Motivation:** Wants answers about her husband's fate
+- **Connection:** Her husband was the most recent disappearance;
+  she found his boots washed up with strange markings
+- **First appearance:** Approaches investigators at the dockside
+  pub after hearing they're asking questions
+
+### [[Silas Marsh]]
+
+- **Role:** Antagonist — leader of the Order
+- **Motivation:** Believes controlling the entity will restore his
+  family's former prominence in the fishing trade
+- **Connection:** Owns the pier through a shell company; his
+  family name appears in historical society records
+- **First appearance:** Encountered as a "concerned local
+  businessman" offering to help the investigation
+
+## Locations
+
+### The Darkened Pier
+
+- **Atmosphere:** Creaking timber, perpetual fog, the smell of
+  brine and something older. Lanterns won't stay lit past the
+  halfway point.
+- **Significance:** Site of the offerings and the planned binding
+  ritual. The entity dwells in the water beneath.
+- **Connections:** Order meets here at night; historical records
+  show it was built on an older stone foundation
+
+### The Harbour Master's Office
+
+- **Atmosphere:** Cramped, paper-stuffed, smells of pipe tobacco
+  and damp wool. Ledgers going back decades.
+- **Significance:** Records show a pattern — disappearances
+  cluster around new moons, going back forty years
+- **Connections:** The harbour master is compromised by the Order
+
+## Entry Points
+
+1. **Personal:** Martha Hale seeks out anyone who might listen —
+   the police won't help, she's desperate
+2. **Professional:** The harbour master quietly contacts an
+   investigator he trusts — he's afraid but can't go to the police
+   because he's complicit
+3. **Circumstantial:** Strange markings appear on the boarding house
+   wall near the investigators' lodgings — they match the ones on
+   the washed-up boots
+
+## Escalation
+
+- **Day 1:** Another dock worker goes missing. Martha Hale's
+  boarding house is searched by unknown intruders.
+- **Day 2:** The harbour master is found dead — apparent drowning,
+  but in his locked office. His records have been partially
+  destroyed.
+- **Day 3 (new moon):** The Order attempts the binding ritual at
+  midnight. If investigators haven't found the pier by now,
+  the ritual succeeds.
+
+## If They Do Nothing
+
+Silas Marsh completes the binding ritual. The entity is bound to
+the Order's will. Disappearances stop — replaced by targeted
+killings of rival fishing operations. Within a month, the Marsh
+family controls the waterfront. Within a year, the entity breaks
+free of its binding and the real horror begins.
+
+## Open Questions
+
+- What exactly is the entity? (Keeper's choice — Deep One hybrid,
+  bound servitor, or something older)
+- Can the entity be destroyed, or only re-sealed?
+- Is Silas Marsh a true believer or a desperate pragmatist?
+
+## CATS Pitch
+
+- **Concept:** Maritime investigation — something under the pier
+  is taking people, and a secret society is trying to control it
+- **Aim:** Investigate disappearances, uncover the Order, stop the
+  binding ritual before the new moon
+- **Tone:** Creeping dread, maritime horror, race against time
+- **Subject matter:** Disappearances, drowning, cult activity,
+  body horror (the entity's victims). Lines/Veils discussion
+  recommended for body horror specifics.
+
+## Session 0 Agenda
+
+- [ ] Present premise and get buy-in
+- [ ] Tone and safety tools (Lines/Veils for body horror)
+- [ ] Character creation — investigators need reason to be near
+      the waterfront
+- [ ] PC connections to each other and to the adventure hooks
+- [ ] Scheduling — 3-4 sessions, weekly preferred for momentum
+
+## Vault Notes
+
+- References existing entity [[Martha Hale]] — needs creation if
+  not present
+- [[Silas Marsh]] connects to existing Marsh family lore if
+  campaign has established it
+- Harbour master is a new NPC — create during session-prep
+- The Darkened Pier location should be filed under Locations/

--- a/tools/publish/package-lock.json
+++ b/tools/publish/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gm-apprentice-publish",
-      "version": "1.1.1",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

- **New skill: the-midwife** — guided adventure creation through creative conversation. Handles greenfield campaigns and existing vault continuations (new chapters, arcs, prequels, time jumps, new PCs). Produces an adventure brief and scaffolds the vault for Session 0 handoff.
- **New entity type: adventure-brief** — under `narrative (abstract)` with scope, shape, continuation metadata, schema validation, and `Adventures/` folder mapping.
- **Enriched scenario-writing.md** — Adventure Shapes taxonomy (linear/branching/hub-and-spoke/open-node/sandbox), one-shot structural constraints, few-shot guidance, playability stress test, victory-state antagonist design.
- **Added CATS pitch** (Concept/Aim/Tone/Subject) to Session Zero in gm-session-patterns.md.
- **Attribution, migration, metadata** — new framework attributions, migration entry 1.4.22 → 1.5.1, plugin version bump.

## Test Plan

- [x] Schema validation passes (37 files including new adventure-brief)
- [x] 9 skill zips build (the-midwife.zip present with SKILL.md + shared files)
- [x] All 11 cross-routing targets exist
- [x] 5 new attributions verified in ATTRIBUTION.md
- [ ] CodeRabbit review