### PR TITLE
Add campaign overview template (v1.5.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.5.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.22...v1.5.0
 [1.4.22]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.4.21...v1.4.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.2] — 2026-05-12
+
+### Added
+
+- **Campaign overview template** — new `campaign_overview` entity type
+  with frontmatter for game date, session tracking, and narrative
+  position (arc/chapter progress).
+- **Session-wrapup auto-updates** — campaign overview mechanical fields
+  (game date, session count, last session, last play date) updated
+  after each wrap-up with GM confirmation.
+- **The-midwife integration** — creates campaign overview during vault
+  scaffolding, populated from the adventure brief conversation.
+- **Publish tool rendering** — campaign landing page shows new sections
+  (Premise, Setting, Key Themes, Key Factions) with game date and
+  current arc param cards.
+
+### Changed
+
+- Publish tool landing page replaces Known Threats / Key Organizations
+  / Key Individuals sections with Setting and Key Factions.
+
+---
+
 ## [1.5.1] — 2026-05-09
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Items are force-ranked by score. Higher score = do first.
 
 | Item | Impact | Urgency | Effort | Score | Status | Notes |
 |------|:------:|:-------:|:------:|:-----:|--------|-------|
-| Campaign overview template with current game date | 5 | 3 | M (2) | 6.5 | Idea | Create a campaign overview template (none exists today). Include a `current_game_date` frontmatter field that session-wrapup updates after every wrap-up. Keeps the campaign front page authoritative on where the story clock sits. |
+| ~~Campaign overview template with current game date~~ | 5 | 3 | M (2) | 6.5 | ~~Done~~ | ~~Create a campaign overview template (none exists today). Include a `current_game_date` frontmatter field that session-wrapup updates after every wrap-up. Keeps the campaign front page authoritative on where the story clock sits.~~ |
 | ~~the-midwife: guided adventure creation skill~~ | 4 | 2 | M (2) | 5.0 | ~~Done~~ | ~~Creative midwife persona — draws ideas out of the GM through guided conversation, shapes them into a playable starting point with a vault/folder. Supports campaigns, one-shots, few-shots.~~ |
 | Handout document type with image creation prompts | 4 | 2 | M (2) | 5.0 | Idea | Session-prep scene artifact: handout markdown + frontmatter linking to scene/session + auto-generated image prompt for DALL-E/Midjourney |
 | Publish tool: thematic cause-of-death icons for The Fallen | 2 | 1 | S (1) | 5.0 | Idea | New optional PC frontmatter field `cause_of_death` (combat, madness, eldritch, disease, etc.) with thematic SVG icons on Fallen cards |
@@ -61,6 +61,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
+- ~~Campaign overview template with current game date~~ — `campaign_overview` entity type with session-wrapup auto-updates and the-midwife creation
 - ~~the-midwife: guided adventure creation skill~~ — Adventure creation skill with adventure-brief entity type, vault-mining, Session 0 handoff
 - ~~Publish tool: site redesign v1.2~~ — Navigation overhaul, breadcrumbs, genre presets, system-specific PC sheets (CoC/GURPS/D&D/FitD), lunr search, relationship graphs, timeline pages, context sidebars, index page redesigns, landing page rewrite (PR #40)
 - ~~Publish tool: GURPS PC sheet — single alphabetized skills list~~ — Inline comments enforcing single alphabetized tables for Skills and Spells (PR #32)

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -30,7 +30,6 @@ ADVENTURE_BRIEF_SCOPE = {"campaign", "one-shot", "few-shot"}
 CAMPAIGN_OVERVIEW_STATUS = {
     "not_started", "in_progress", "paused", "completed", "abandoned"
 }
-CAMPAIGN_OVERVIEW_SCOPE = {"campaign", "one-shot", "few-shot"}
 ADVENTURE_BRIEF_CONTINUATION = {
     "new", "new-chapter", "new-arc", "time-jump",
     "prequel", "parallel", "new-pcs"
@@ -254,10 +253,10 @@ def validate_file(filepath: Path) -> list[str]:
             value = frontmatter["scope"]
             if not isinstance(value, str):
                 errors.append("Field 'scope' must be a string")
-            elif value not in CAMPAIGN_OVERVIEW_SCOPE:
+            elif value not in ADVENTURE_BRIEF_SCOPE:
                 errors.append(
                     f"Invalid scope '{value}' — "
-                    f"must be one of: {', '.join(sorted(CAMPAIGN_OVERVIEW_SCOPE))}"
+                    f"must be one of: {', '.join(sorted(ADVENTURE_BRIEF_SCOPE))}"
                 )
 
     # Validate portrait field — only allowed for supported entity types

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -27,6 +27,10 @@ SCENE_TYPES = {
 }
 NPC_STATUS = {"alive", "dead", "missing", "unknown"}
 ADVENTURE_BRIEF_SCOPE = {"campaign", "one-shot", "few-shot"}
+CAMPAIGN_OVERVIEW_STATUS = {
+    "not_started", "in_progress", "paused", "completed", "abandoned"
+}
+CAMPAIGN_OVERVIEW_SCOPE = {"campaign", "one-shot", "few-shot"}
 ADVENTURE_BRIEF_CONTINUATION = {
     "new", "new-chapter", "new-arc", "time-jump",
     "prequel", "parallel", "new-pcs"
@@ -59,10 +63,11 @@ REQUIRED_FIELDS = {
     "meta": ["type"],
     "timeline": ["type"],
     "player-characters": ["type"],
+    "campaign_overview": ["type", "source_confidence"],
 }
 
 # Optional fields that support portraits (for future validation)
-PORTRAIT_TYPES = {"npc", "pc", "location", "faction", "organization", "item", "creature"}
+PORTRAIT_TYPES = {"npc", "pc", "location", "faction", "organization", "item", "creature", "campaign_overview"}
 
 # Valid optional fields per entity type (used for deprecation warnings)
 DEPRECATED_FIELDS: dict[str, list[tuple[str, str]]] = {
@@ -232,6 +237,27 @@ def validate_file(filepath: Path) -> list[str]:
                 errors.append(
                     f"Invalid adventure_shape '{value}' — "
                     f"must be one of: {', '.join(sorted(ADVENTURE_BRIEF_SHAPE))}"
+                )
+
+    # Validate campaign_overview fields
+    if entity_type == "campaign_overview":
+        if "status" in frontmatter:
+            value = frontmatter["status"]
+            if not isinstance(value, str):
+                errors.append("Field 'status' must be a string")
+            elif value not in CAMPAIGN_OVERVIEW_STATUS:
+                errors.append(
+                    f"Invalid status '{value}' — "
+                    f"must be one of: {', '.join(sorted(CAMPAIGN_OVERVIEW_STATUS))}"
+                )
+        if "scope" in frontmatter:
+            value = frontmatter["scope"]
+            if not isinstance(value, str):
+                errors.append("Field 'scope' must be a string")
+            elif value not in CAMPAIGN_OVERVIEW_SCOPE:
+                errors.append(
+                    f"Invalid scope '{value}' — "
+                    f"must be one of: {', '.join(sorted(CAMPAIGN_OVERVIEW_SCOPE))}"
                 )
 
     # Validate portrait field — only allowed for supported entity types

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -174,6 +174,40 @@ entities via wiki-links only.
 
 Every entity reference: `[[wiki-link]]`.
 
+### 4b. Update Campaign Overview
+
+If `_Campaign/Campaign Overview.md` exists, update its mechanical
+frontmatter fields. Read the file first, then present proposed
+changes to the GM for confirmation.
+
+**Auto-updated fields:**
+
+| Field | Source | Logic |
+|-------|--------|-------|
+| `current_game_date` | In-game date at session end (from World State or GM) | Overwrite |
+| `sessions_played` | Current value + 1 | Increment |
+| `last_session` | Wiki-link to this session's index file | Overwrite |
+| `last_play_date` | This session's `play_date` | Overwrite |
+| `lastUpdated` | Current session reference | Overwrite |
+| `asOfSession` | Current session reference | Overwrite |
+
+**Confirmation prompt:**
+
+"Campaign overview updates:
+  current_game_date: "{old}" → "{new}"
+  sessions_played: {old} → {new}
+  last_session: [[{session title}]]
+  last_play_date: {date}
+
+Apply these updates?"
+
+On yes: write the updated frontmatter. On no: skip — the GM
+can update manually later.
+
+**Do not update:** `current_arc`, `arcs_planned`,
+`current_chapter`, `chapters_planned`, `status`, or any body
+sections. These are narrative decisions the GM makes explicitly.
+
 ### 5. What Carries Forward
 
 Write into Wrap-Up file:

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -85,7 +85,8 @@ narrative (abstract)
 │   ├── betrayal_event
 │   └── celebration
 ├── clue
-└── adventure-brief
+├── adventure-brief
+└── campaign_overview
 ```
 
 Abstract types cannot be assigned directly to entities but are
@@ -278,6 +279,26 @@ Extraction defaults:
 | adventure_shape | string | linear / branching / hub-and-spoke / open-node / sandbox |
 | system | string | Game system identifier or "undecided" |
 
+### Campaign Overview
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| campaign | string | Campaign name |
+| game_system | string | Game system identifier |
+| setting_year | string | In-game era or year |
+| current_game_date | string | Current in-game date (auto-updated by session-wrapup) |
+| genre_tags | array | Genre descriptors |
+| scope | string | campaign / one-shot / few-shot |
+| status | string | not_started / in_progress / paused / completed / abandoned |
+| sessions_played | number | Total sessions played (auto-updated by session-wrapup) |
+| last_session | string | Wiki-link to most recent session file (auto-updated) |
+| last_play_date | string | Real-world ISO date of last session (auto-updated) |
+| current_arc | string | Name of the active story arc |
+| arcs_planned | number | Total arcs outlined (0 for sandbox) |
+| current_chapter | string | Wiki-link to active chapter |
+| chapters_planned | number | Chapters in current arc (or total if no arcs) |
+| portrait | string | Optional: path to campaign image under `_attachments/` |
+
 ## Narrative Element Schemas
 
 **Chapter:**
@@ -407,6 +428,11 @@ etc.), `goals`, `leadership` (wiki-link), `territory` (wiki-link),
 `adventure_shape` (linear/branching/hub-and-spoke/open-node/sandbox),
 `system`
 
+**Campaign Overview:** `campaign`, `game_system`, `setting_year`,
+`current_game_date`, `genre_tags`, `scope`, `status`, `sessions_played`,
+`last_session`, `last_play_date`, `current_arc`, `arcs_planned`,
+`current_chapter`, `chapters_planned`, `portrait` (optional)
+
 **Creature:** `creature_type` (beast, undead, aberration, etc.),
 `location` (wiki-link), `abilities`, `weaknesses`, `portrait` (optional)
 
@@ -474,6 +500,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | document (all subtypes) | Documents/ |
 | clue | Clues/ |
 | adventure-brief | Adventures/{adventure-name}/ |
+| campaign_overview | _Campaign/ |
 
 ## Vault Configuration Fields
 

--- a/skills/shared/templates/campaign-overview.md
+++ b/skills/shared/templates/campaign-overview.md
@@ -1,0 +1,60 @@
+---
+type: campaign_overview
+campaign: ""
+game_system: ""
+setting_year: ""
+current_game_date: ""
+genre_tags: []
+scope: ""
+status: "not_started"
+sessions_played: 0
+last_session: ""
+last_play_date: ""
+current_arc: ""
+arcs_planned: 0
+current_chapter: ""
+chapters_planned: 0
+source_confidence: AUTHORITATIVE
+aliases: []
+tags: []
+portrait: ""
+lastUpdated: ""
+asOfSession: ""
+---
+
+# {Campaign Name}
+
+## Premise
+
+One paragraph elevator pitch. What's this campaign about, why does it
+matter, what's the hook that pulls players in?
+
+## Setting
+
+The world in broad strokes — era, geography, atmosphere, tone. Not
+exhaustive worldbuilding, just enough to orient someone picking this
+up cold.
+
+## Key Themes
+
+- Theme 1
+- Theme 2
+- Theme 3
+
+## Current Arc
+
+What's happening right now in the story? Where did the last session
+leave things? What's the active tension? This is the section the GM
+reads first when sitting down to prep.
+
+## Key Factions
+
+The power structures that shape the world — cults, governments,
+criminal networks, rival adventuring parties. Brief description and
+current posture toward the PCs.
+
+## GM Notes
+
+> [!info] Keeper Only
+> Campaign-level secrets, long-term plans, deferred decisions,
+> threads the players haven't discovered yet.

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -293,9 +293,30 @@ auto-promote — the GM chooses.
 ### Step 3: Vault Scaffold (greenfield only)
 
 Ask: "Ready to set up the vault for this campaign?"
-If yes, hand off to campaign-organizer with the adventure
-brief as context. campaign-organizer builds the vault
-around the existing `Adventures/` folder.
+If yes:
+
+1. **Create Campaign Overview** at
+   `_Campaign/Campaign Overview.md` using the template from
+   `shared/templates/campaign-overview.md`. Populate from the
+   adventure brief conversation:
+   - `campaign`: adventure/campaign name
+   - `game_system`: system chosen (or empty if undecided)
+   - `setting_year`: era discussed (or empty)
+   - `current_game_date`: same as `setting_year` if known
+   - `genre_tags`: from tone/genre discussion
+   - `scope`: from adventure brief scope
+   - `status`: `not_started`
+   - `sessions_played`: 0
+   - Premise section: from the adventure brief premise
+   - Setting section: from worldbuilding discussion
+   - Key Themes section: from tone and genre conversation
+   - Key Factions section: from driving forces in the brief
+   - Current Arc section: "Not yet begun."
+   - GM Notes section: empty
+
+2. **Hand off** to campaign-organizer with the adventure
+   brief as context. campaign-organizer builds the vault
+   around the existing `Adventures/` and `_Campaign/` folders.
 
 ### Step 4: Update Status
 

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -424,12 +424,25 @@ function renderCampaignDeepDive(pages, indexDir, publishConfig) {
   const system = fm.game_system || '';
   const year = fm.setting_year || '';
   const points = fm.point_total || '';
+  const gameDate = fm.current_game_date || '';
+  const lastPlayed = fm.last_play_date || '';
   const genres = Array.isArray(fm.genre_tags) ? fm.genre_tags : [];
 
   const paramCards = [];
   if (system) paramCards.push(`<div class="cdd-param"><span class="cdd-param-label">System</span><span class="cdd-param-value">${escapeHtml(String(system))}</span></div>`);
   if (year) paramCards.push(`<div class="cdd-param"><span class="cdd-param-label">Setting Year</span><span class="cdd-param-value">${escapeHtml(String(year))}</span></div>`);
+  if (gameDate) paramCards.push(`<div class="cdd-param"><span class="cdd-param-label">Game Date</span><span class="cdd-param-value">${escapeHtml(String(gameDate))}</span></div>`);
   if (points) paramCards.push(`<div class="cdd-param"><span class="cdd-param-label">Point Total</span><span class="cdd-param-value">${escapeHtml(String(points))}</span></div>`);
+  if (lastPlayed) paramCards.push(`<div class="cdd-param"><span class="cdd-param-label">Last Played</span><span class="cdd-param-value">${escapeHtml(String(lastPlayed))}</span></div>`);
+
+  const arcsPlanned = parseInt(fm.arcs_planned, 10) || 0;
+  if (fm.current_arc) {
+    const arcValue = arcsPlanned > 0
+      ? `${escapeHtml(String(fm.current_arc))} (of ${arcsPlanned})`
+      : escapeHtml(String(fm.current_arc));
+    paramCards.push(`<div class="cdd-param"><span class="cdd-param-label">Current Arc</span><span class="cdd-param-value">${arcValue}</span></div>`);
+  }
+
   const paramsHtml = paramCards.length > 0
     ? `<div class="cdd-params">${paramCards.join('\n')}</div>`
     : '';
@@ -443,24 +456,19 @@ function renderCampaignDeepDive(pages, indexDir, publishConfig) {
     ? `<section class="cdd-section"><h2 class="cdd-section-title">Premise</h2><div class="cdd-prose">${mdRenderer.render(premiseMd)}</div></section>`
     : '';
 
+  const settingMd = sections['Setting'] || '';
+  const settingHtml = settingMd
+    ? `<section class="cdd-section"><h2 class="cdd-section-title">Setting</h2><div class="cdd-prose">${mdRenderer.render(settingMd)}</div></section>`
+    : '';
+
   const themesMd = sections['Key Themes'] || '';
   const themesHtml = themesMd
     ? `<section class="cdd-section"><h2 class="cdd-section-title">Key Themes</h2><div class="cdd-themes">${mdRenderer.render(themesMd)}</div></section>`
     : '';
 
-  const threatsMd = sections['Known Fragment-Empowered Individuals'] || sections['Known Threats'] || '';
-  const threatsHtml = threatsMd
-    ? `<section class="cdd-section"><h2 class="cdd-section-title">Known Threats</h2><div class="cdd-threats">${mdRenderer.render(threatsMd)}</div></section>`
-    : '';
-
-  const orgsMd = sections['Key Organizations'] || '';
-  const orgsHtml = orgsMd
-    ? `<section class="cdd-section"><h2 class="cdd-section-title">Key Organizations</h2><div class="cdd-prose">${mdRenderer.render(orgsMd)}</div></section>`
-    : '';
-
-  const individualsMd = sections['Key Individuals'] || '';
-  const individualsHtml = individualsMd
-    ? `<section class="cdd-section"><h2 class="cdd-section-title">Key Individuals</h2><div class="cdd-prose">${mdRenderer.render(individualsMd)}</div></section>`
+  const factionsMd = sections['Key Factions'] || '';
+  const factionsHtml = factionsMd
+    ? `<section class="cdd-section"><h2 class="cdd-section-title">Key Factions</h2><div class="cdd-prose">${mdRenderer.render(factionsMd)}</div></section>`
     : '';
 
   const overviewHref = relHref(overview, indexDir);
@@ -471,10 +479,9 @@ function renderCampaignDeepDive(pages, indexDir, publishConfig) {
     ${genreHtml}
   </div>
   ${premiseHtml}
+  ${settingHtml}
   ${themesHtml}
-  ${threatsHtml}
-  ${orgsHtml}
-  ${individualsHtml}
+  ${factionsHtml}
   <div class="cdd-full-link"><a href="${escapeHtml(overviewHref)}">Read full campaign overview &rarr;</a></div>
 </div>`;
 }

--- a/tools/publish/test/fixtures/clean-schema/_Campaign/Campaign Overview.md
+++ b/tools/publish/test/fixtures/clean-schema/_Campaign/Campaign Overview.md
@@ -1,7 +1,65 @@
 ---
-type: campaign
+type: campaign_overview
+campaign: "The Haunting of Harrowstone"
+game_system: "CoC 7e"
+setting_year: "1928"
+current_game_date: "1928-03-15"
+genre_tags: ["Horror", "Mystery"]
+scope: "campaign"
+status: "in_progress"
+sessions_played: 5
+last_session: "[[Session 05 — The Locked Room]]"
+last_play_date: "2026-05-03"
+current_arc: "The Whisperer in the Walls"
+arcs_planned: 3
+current_chapter: "[[Chapter 2 — The Inner Circle]]"
+chapters_planned: 4
+source_confidence: AUTHORITATIVE
+aliases: []
+tags: []
+portrait: ""
+lastUpdated: "Session 5"
+asOfSession: "Session 5"
 ---
 
-# Campaign Overview
+# The Haunting of Harrowstone
 
-The campaign overview.
+## Premise
+
+A group of investigators in 1920s New England uncover a conspiracy
+linking a series of disappearances to an ancient cult operating
+beneath the streets of Arkham.
+
+## Setting
+
+Prohibition-era New England, 1928. Fog-shrouded coastal towns,
+crumbling colonial mansions, and the ivy-covered halls of Miskatonic
+University. The veneer of Jazz Age modernity barely conceals older,
+darker truths.
+
+## Key Themes
+
+- The cost of forbidden knowledge
+- Trust and paranoia among allies
+- The thin line between sanity and understanding
+
+## Current Arc
+
+The investigators have traced the disappearances to a network of
+tunnels beneath the old Harrowstone estate. [[Dr. Whitmore]] has
+gone missing after a late-night visit to the university archives.
+
+## Key Factions
+
+- **[[The Esoteric Order]]** — A secret society with ties to the
+  university faculty. Currently consolidating power after a schism.
+- **[[Arkham Police Department]]** — Overworked and dismissive of
+  the supernatural. Detective [[Walsh]] is a reluctant ally.
+- **[[The Silver Twilight Lodge]]** — Respectable front for darker
+  dealings. Watching the investigators with interest.
+
+## GM Notes
+
+> [!info] Keeper Only
+> The Esoteric Order is a front for a Nyarlathotep cult. Dr. Whitmore
+> discovered this and was taken to prevent exposure.

--- a/tools/publish/test/fixtures/minimal/_Campaign/Campaign Overview.md
+++ b/tools/publish/test/fixtures/minimal/_Campaign/Campaign Overview.md
@@ -1,7 +1,11 @@
 ---
-type: campaign
+type: campaign_overview
+campaign: "Test Campaign"
+source_confidence: DRAFT
 ---
 
-# Campaign Overview
+# Test Campaign
 
-Test campaign.
+## Premise
+
+A minimal test campaign.


### PR DESCRIPTION
## Summary

- Adds `campaign_overview` entity type with shared template, entity schema registration, and schema validation
- Session-wrapup auto-updates mechanical fields (game date, session count, last session, last play date) with GM confirmation after each wrap-up
- The-midwife creates the campaign overview during vault scaffolding, populated from the adventure brief conversation
- Publish tool renders new landing page sections (Premise, Setting, Key Themes, Key Factions) with game date, last played, and current arc param cards
- Replaces old landing page sections (Known Threats, Key Organizations, Key Individuals)

## Test plan

- [x] Schema validation passes (`python3 scripts/validate_schema.py`)
- [x] Publish tool tests pass (374/374)
- [x] Clean-schema and minimal test fixtures updated to `campaign_overview` type
- [ ] Visual check of published landing page with new sections and param cards
- [ ] End-to-end: run the-midwife for a new campaign, verify overview is created
- [ ] End-to-end: run session-wrapup, verify overview fields are updated with confirmation