### PR TITLE
SP1: Worldbuilding schema foundation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.0] — 2026-05-22
+
+### Added
+
+- **Heritage entity type** — first-class vault entity for species/ancestry
+  definitions with lifespan ranges, maturity age, notable traits, and
+  Second-Order Notes
+- **`_World/` vault layer** — 10 domain files for world rules (heritages,
+  geography, history, politics, economics, magic/technology, cosmology,
+  culture, ecology, language), each with machine-checkable rules
+- **Three-state flag system** — `_flags.md` tracks world facts as canon,
+  ignored, or deferred with accumulation and resurfacing
+- **Organization hierarchy** — `part_of` field on faction/organization
+  entities enables nested political, military, and religious structures
+- **Era field** — optional `era` universal field for temporal referencing
+  against world history eras
+- **World structural templates** — world-index, world-flags, world-domain,
+  heritage, and faction templates in `skills/shared/templates/`
+- **Schema validation** — `heritage`, `world_domain`, `world_flags` types
+  and `WORLD_DOMAIN_STATUS` enum in `validate_schema.py`
+- **Benchmark fixtures** — `_World/` and `Heritages/` test data in
+  benchmark campaign
+
+---
+
 ## [1.5.3] — 2026-05-16
 
 ### Added
@@ -602,6 +627,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.0]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.3...v1.6.0
 [1.5.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.0...v1.5.1

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -37,6 +37,7 @@ ADVENTURE_BRIEF_CONTINUATION = {
 ADVENTURE_BRIEF_SHAPE = {
     "linear", "branching", "hub-and-spoke", "open-node", "sandbox"
 }
+WORLD_DOMAIN_STATUS = {"active", "stub", "inactive"}
 
 # Required fields per entity type
 # All entities need: type, source_confidence
@@ -63,10 +64,13 @@ REQUIRED_FIELDS = {
     "timeline": ["type"],
     "player-characters": ["type"],
     "campaign_overview": ["type", "source_confidence"],
+    "heritage": ["type", "source_confidence"],
+    "world_domain": ["type", "domain", "status"],
+    "world_flags": ["type"],
 }
 
 # Optional fields that support portraits (for future validation)
-PORTRAIT_TYPES = {"npc", "pc", "location", "faction", "organization", "item", "creature", "campaign_overview"}
+PORTRAIT_TYPES = {"npc", "pc", "location", "faction", "organization", "item", "creature", "campaign_overview", "heritage"}
 
 # Valid optional fields per entity type (used for deprecation warnings)
 DEPRECATED_FIELDS: dict[str, list[tuple[str, str]]] = {
@@ -258,6 +262,17 @@ def validate_file(filepath: Path) -> list[str]:
                     f"Invalid scope '{value}' — "
                     f"must be one of: {', '.join(sorted(ADVENTURE_BRIEF_SCOPE))}"
                 )
+
+    # Validate world_domain status
+    if entity_type == "world_domain" and "status" in frontmatter:
+        value = frontmatter["status"]
+        if not isinstance(value, str):
+            errors.append("Field 'status' must be a string")
+        elif value not in WORLD_DOMAIN_STATUS:
+            errors.append(
+                f"Invalid status '{value}' — "
+                f"must be one of: {', '.join(sorted(WORLD_DOMAIN_STATUS))}"
+            )
 
     # Validate portrait field — only allowed for supported entity types
     portrait = frontmatter.get("portrait")

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -236,7 +236,16 @@ tools used to read, write, and search differ.
    contents. It is not part of the campaign vault structure.
 3. **Propose structure** — Present vault layout. Read
    `shared/vault-structure.md` for the default layout.
-   Adapt to content.
+   Adapt to content. During new vault setup, scaffold:
+   - `_World/` — create `world-index.md` and `_flags.md` from
+     `shared/templates/world-index.md` and
+     `shared/templates/world-flags.md`. Do not create individual
+     domain files — those are created on demand when content exists.
+   - `Heritages/` — entity folder for heritage entities. Add
+     `_Templates/_Template_Heritage.md` from
+     `shared/templates/heritage.md`.
+   - Add `_Templates/_Template_Faction.md` from
+     `shared/templates/faction.md` if not already present.
 4. **Extract and file** — For each entity, read
    `_Templates/_Template_{Type}.md` first, then create the note
    using that template as the structure. Fill in frontmatter per

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -87,6 +87,9 @@ narrative (abstract)
 ├── clue
 ├── adventure-brief
 └── campaign_overview
+
+world (abstract)
+└── heritage
 ```
 
 Abstract types cannot be assigned directly to entities but are
@@ -299,6 +302,16 @@ Extraction defaults:
 | chapters_planned | number | Chapters in current arc (or total if no arcs) |
 | portrait | string | Optional: path to campaign image under `_attachments/` |
 
+### Heritage
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| lifespan_range | array | [min, max] age range |
+| maturity_age | number | Age of adulthood |
+| average_height | string | Typical height range |
+| notable_traits | array | Distinguishing biological/cultural traits |
+| portrait | string | Optional: path to heritage illustration under `_attachments/` |
+
 ## Narrative Element Schemas
 
 **Chapter:**
@@ -485,6 +498,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | `creature` | `located_at` |
 | `faction` | `headquartered_at` |
 | `organization` | `headquartered_at` |
+| `heritage` | — (none required) |
 
 ## Default Folder Mapping
 
@@ -501,6 +515,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | clue | Clues/ |
 | adventure-brief | Adventures/{adventure-name}/ |
 | campaign_overview | _Campaign/ |
+| heritage | Heritages/ |
 
 ## Vault Configuration Fields
 

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -202,6 +202,7 @@ Extraction defaults:
 | recentActions | array | Last 1-3 sessions |
 | status | string | active / weakened / destroyed / allied / dormant |
 | portrait | string | Optional: path to logo or HQ image under `_attachments/` |
+| part_of | string | Optional: wiki-link to parent organization (`"[[Parent Org]]"`) |
 
 ### Clue
 
@@ -251,6 +252,7 @@ Extraction defaults:
 | resources | string | Available assets |
 | notable_members | array | Important people |
 | portrait | string | Optional: path to logo or HQ image under `_attachments/` |
+| part_of | string | Optional: wiki-link to parent organization (`"[[Parent Org]]"`) |
 
 ### Event
 

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -24,6 +24,7 @@ Apply to **every** entity type. Enable temporal queries
 | createdSession | string | Session when first introduced |
 | source | string | How it entered canon: "play", "prep", or "backstory" |
 | confidence | string | Canon confidence: DRAFT / AUTHORITATIVE / SUPERSEDED |
+| era | string | Optional: named era from `_World/history-timeline.md` (e.g., "Second Age"). Assumed campaign present if absent. |
 
 Always set `lastUpdated` and `asOfSession` to current session
 when filing or updating.
@@ -89,7 +90,9 @@ narrative (abstract)
 └── campaign_overview
 
 world (abstract)
-└── heritage
+├── heritage
+├── world_domain
+└── world_flags
 ```
 
 Abstract types cannot be assigned directly to entities but are
@@ -314,6 +317,35 @@ Extraction defaults:
 | notable_traits | array | Distinguishing biological/cultural traits |
 | portrait | string | Optional: path to heritage illustration under `_attachments/` |
 
+### World Domain
+
+Structural file defining world rules for one domain (e.g.,
+heritages, geography, economics). Lives in `_World/`. Not a
+knowledge-graph entity — a structural file like Campaign
+Overview.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| domain | string | Domain identifier (e.g., `heritages`, `geography-climate`) |
+| status | string | active / stub / inactive |
+| summary | string | One-line domain summary |
+| rules | array | Machine-checkable world rules (see below) |
+
+Each rule in the `rules` array has:
+- `id` — unique identifier for flag tracking
+- `rule` — human-readable description
+- `check` — structured object for validation (field comparisons,
+  allowed values, range checks)
+
+### World Flags
+
+Structural file tracking the three-state flag system. One per
+campaign at `_World/_flags.md`. Not a knowledge-graph entity.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| last_reviewed | string | Date of last flag review |
+
 ## Narrative Element Schemas
 
 **Chapter:**
@@ -518,6 +550,8 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | adventure-brief | Adventures/{adventure-name}/ |
 | campaign_overview | _Campaign/ |
 | heritage | Heritages/ |
+| world_domain | _World/ |
+| world_flags | _World/ |
 
 ## Vault Configuration Fields
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -177,3 +177,29 @@ Standardizes date field names across session and event entities.
   (`Adventures/{name}/{name}.md`). Existing briefs in flat
   `Adventures/` continue to work. No action needed for
   existing vaults.
+
+## Migration: 1.5.3 → 1.6.0
+
+### Structural
+
+- **New entity type:** `heritage` added to entity schema under
+  `world (abstract)`. Existing vaults continue to work without
+  modification.
+- **New structural types:** `world_domain` and `world_flags`
+  added to entity schema. These are structural files in `_World/`,
+  not knowledge-graph entities.
+- **New field:** `part_of` added to faction and organization
+  entity types. Optional — existing entities are unaffected.
+- **New universal field:** `era` added as optional field for
+  temporal referencing. Existing entities are unaffected.
+
+### Content
+
+- **New folder:** `_World/` added to vault structure with
+  `world-index.md` and `_flags.md` stubs. Created during vault
+  scaffolding. Individual domain files created on demand.
+- **New folder:** `Heritages/` added to entity folder structure
+  for heritage entities.
+- **New templates:** `heritage.md`, `faction.md`, `world-index.md`,
+  `world-flags.md`, `world-domain.md` added to
+  `skills/shared/templates/`.

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.5.1"
+current_version: "1.6.0"
 ---
 
 # Vault Migration Registry

--- a/skills/shared/templates/faction.md
+++ b/skills/shared/templates/faction.md
@@ -1,0 +1,41 @@
+---
+name: ""
+type: faction
+source_confidence: DRAFT
+source: ""
+createdSession: ""
+asOfSession: ""
+lastUpdated: ""
+aliases: []
+tags: []
+factionType: ""
+goals: []
+resources: ""
+leadership: ""
+territory: ""
+tier:
+currentPlan: ""
+planProgress: ""
+alliances: []
+recentActions: []
+status: active
+part_of: ""
+portrait: ""
+relationships:
+  - target: "[[]]"
+    type: headquartered_at
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+---
+
+## Overview
+
+## Goals & Methods
+
+## Resources
+
+## History
+
+## GM Notes

--- a/skills/shared/templates/heritage.md
+++ b/skills/shared/templates/heritage.md
@@ -1,0 +1,33 @@
+---
+name: ""
+type: heritage
+source_confidence: DRAFT
+source: ""
+createdSession: ""
+asOfSession: ""
+lastUpdated: ""
+aliases: []
+tags: [heritage]
+lifespan_range: []
+maturity_age:
+average_height: ""
+notable_traits: []
+portrait: ""
+relationships:
+  - target: "[[]]"
+    type: allied_with
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+---
+
+## Biology
+
+## Culture
+
+## History
+
+## Second-Order Notes
+
+## GM Notes

--- a/skills/shared/templates/world-domain.md
+++ b/skills/shared/templates/world-domain.md
@@ -1,0 +1,16 @@
+---
+type: world_domain
+domain: ""
+status: stub
+source_confidence: DRAFT
+last_updated: ""
+asOfSession: ""
+summary: ""
+rules: []
+---
+
+## Overview
+
+## Details
+
+## Cross-Domain Links

--- a/skills/shared/templates/world-domain.md
+++ b/skills/shared/templates/world-domain.md
@@ -3,7 +3,7 @@ type: world_domain
 domain: ""
 status: stub
 source_confidence: DRAFT
-last_updated: ""
+lastUpdated: ""
 asOfSession: ""
 summary: ""
 rules: []

--- a/skills/shared/templates/world-flags.md
+++ b/skills/shared/templates/world-flags.md
@@ -1,0 +1,10 @@
+---
+type: world_flags
+last_reviewed: ""
+---
+
+## Canon
+
+## Ignored
+
+## Deferred

--- a/skills/shared/templates/world-index.md
+++ b/skills/shared/templates/world-index.md
@@ -3,7 +3,7 @@ type: world_domain
 domain: index
 status: stub
 source_confidence: DRAFT
-last_updated: ""
+lastUpdated: ""
 asOfSession: ""
 summary: ""
 rules: []

--- a/skills/shared/templates/world-index.md
+++ b/skills/shared/templates/world-index.md
@@ -1,0 +1,14 @@
+---
+type: world_domain
+domain: index
+status: stub
+source_confidence: DRAFT
+last_updated: ""
+asOfSession: ""
+summary: ""
+rules: []
+---
+
+## Active Domains
+
+## World Summary

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -14,6 +14,9 @@ Written to `_meta/vault-config.md` on first setup.
 │   ├── events/      (scene art)
 │   └── documents/   (scans, letter images)
 ├── _midwife/        (adventure workspace — see below)
+├── _World/          (world rules and domain files)
+│   ├── world-index.md
+│   └── _flags.md
 ├── _Campaign/
 │   ├── Campaign Overview.md
 │   ├── Player Characters.md
@@ -34,6 +37,7 @@ Written to `_meta/vault-config.md` on first setup.
 ├── Factions & Organizations/
 ├── Items & Artifacts/
 ├── Creatures/
+├── Heritages/
 ├── Events/
 ├── Documents/
 └── Clues/
@@ -166,3 +170,33 @@ seed category. When starting a new adventure, the midwife
 scans seeds for relevant prior ideas.
 
 `campaign-qa` ignores `_midwife/` during audits.
+
+## World Layer
+
+The `_World/` folder stores world rules and domain definitions.
+Created on demand by any skill that needs to write world content.
+Domain files define machine-checkable rules; heritage entities in
+`Heritages/` are first-class vault entities.
+
+```text
+_World/
+├── world-index.md            (active domains, world summary)
+├── _flags.md                 (three-state flag tracker)
+├── heritages.md              (species/ancestry rules)
+├── geography-climate.md      (landforms, biomes, resources)
+├── history-timeline.md       (ages, eras, events)
+├── politics-governance.md    (power structures, borders)
+├── economics-trade.md        (resources, currency, trade)
+├── magic-technology.md       (systems, limits, access)
+├── cosmology-religion.md     (planes, gods, faiths)
+├── culture-daily-life.md     (customs, food, dress)
+├── ecology.md                (flora, fauna, food chains)
+└── language-communication.md (naming, scripts, barriers)
+```
+
+Individual domain files are created when content exists — not
+all 10 are required. `world-index.md` and `_flags.md` are
+created as stubs during vault scaffolding.
+
+`campaign-qa` audits `_World/` domain rules against entities.
+`campaign-organizer` creates `_World/` during vault setup.

--- a/tests/benchmark-campaign/Heritages/Human.md
+++ b/tests/benchmark-campaign/Heritages/Human.md
@@ -1,0 +1,36 @@
+---
+name: Human
+type: heritage
+source_confidence: AUTHORITATIVE
+source: play
+createdSession: "1"
+asOfSession: "2"
+lastUpdated: "2"
+aliases: []
+tags: [heritage]
+lifespan_range: [60, 85]
+maturity_age: 18
+average_height: "5'4\" - 6'0\""
+notable_traits: [adaptable, short-lived, culturally diverse]
+relationships: []
+---
+
+## Biology
+
+Standard human biology. No supernatural traits. Vulnerability
+to the Mythos is the defining characteristic — exposure to
+cosmic horror causes sanity loss.
+
+## Culture
+
+1920s American New England. Jazz age, prohibition, post-war
+optimism masking deep social stratification. Academic and
+maritime traditions dominate Kingsport.
+
+## Second-Order Notes
+
+- Short human lifespans mean institutional memory is fragile —
+  the Order of the Silver Twilight may know things lost to the
+  broader community
+- 1920s medicine means injuries are more consequential; no
+  antibiotics, limited surgery

--- a/tests/benchmark-campaign/_World/_flags.md
+++ b/tests/benchmark-campaign/_World/_flags.md
@@ -1,0 +1,22 @@
+---
+type: world_flags
+last_reviewed: "2026-04-15"
+---
+
+## Canon
+
+- **Humans** — only playable heritage, confirmed session 1
+  (2026-04-10). Created Heritages/Human.md
+
+## Ignored
+
+- **Giant rats** — mentioned session 2, GM confirmed flavor
+  only (2026-04-15)
+
+## Deferred
+
+- **The Silver Twilight's true purpose** (id: silver-twilight-purpose)
+  First seen: 2026-04-15 | Sessions: 2 | Mentions: 2
+  Context: Brother Ezra hinted at "deeper mysteries" within the
+  Order; Inspector Crane mentioned rumours of occult practices
+  Domains: cosmology-religion, politics-governance

--- a/tests/benchmark-campaign/_World/heritages.md
+++ b/tests/benchmark-campaign/_World/heritages.md
@@ -3,7 +3,7 @@ type: world_domain
 domain: heritages
 status: active
 source_confidence: AUTHORITATIVE
-last_updated: "2"
+lastUpdated: "2"
 asOfSession: "2"
 summary: "Human-only world; non-human entities are Mythos horrors"
 rules:

--- a/tests/benchmark-campaign/_World/heritages.md
+++ b/tests/benchmark-campaign/_World/heritages.md
@@ -1,0 +1,30 @@
+---
+type: world_domain
+domain: heritages
+status: active
+source_confidence: AUTHORITATIVE
+last_updated: "2"
+asOfSession: "2"
+summary: "Human-only world; non-human entities are Mythos horrors"
+rules:
+  - id: human-lifespan
+    rule: "Humans live 60-85 years (1920s life expectancy)"
+    check: { entity_type: [npc, pc], heritage: Human, field: age, max: 85 }
+  - id: heritage-list
+    rule: "Known heritages: Human"
+    check: { field: heritage, allowed_values: [Human] }
+---
+
+## Overview
+
+This is a human world. The horrors that lurk beneath Kingsport's
+streets are not alternative heritages — they are alien,
+incomprehensible, and fundamentally hostile to human existence.
+
+## Heritages
+
+### Human
+
+The only playable heritage. Investigators are ordinary people
+thrust into extraordinary circumstances. Their mortality and
+limited lifespan make the Mythos all the more terrifying.

--- a/tests/benchmark-campaign/_World/world-index.md
+++ b/tests/benchmark-campaign/_World/world-index.md
@@ -3,7 +3,7 @@ type: world_domain
 domain: index
 status: active
 source_confidence: AUTHORITATIVE
-last_updated: "2"
+lastUpdated: "2"
 asOfSession: "2"
 summary: "1920s New England — human world with whispered horrors"
 rules: []

--- a/tests/benchmark-campaign/_World/world-index.md
+++ b/tests/benchmark-campaign/_World/world-index.md
@@ -1,0 +1,22 @@
+---
+type: world_domain
+domain: index
+status: active
+source_confidence: AUTHORITATIVE
+last_updated: "2"
+asOfSession: "2"
+summary: "1920s New England — human world with whispered horrors"
+rules: []
+---
+
+## Active Domains
+
+- **Heritages** — Human-dominated world; non-human entities are
+  Mythos horrors, not playable heritages
+
+## World Summary
+
+Kingsport, Massachusetts, 1923. A world of jazz-age optimism
+layered over ancient cosmic dread. The surface world follows
+real-world 1920s conventions; beneath it, the Mythos operates
+by alien logic that defies human understanding.


### PR DESCRIPTION
## Summary

- Add **heritage** entity type under new `world (abstract)` parent in the type hierarchy, with lifespan ranges, maturity age, notable traits, and Second-Order Notes
- Add **`_World/` vault layer** with 10 domain file slots, machine-checkable world rules, and three-state flag system (`_flags.md` tracking canon/ignored/deferred)
- Add **`part_of`** field on faction/organization entities for nested hierarchies (political, military, religious)
- Add optional **`era`** universal field for temporal referencing against world history
- Add **5 shared templates**: heritage, faction, world-index, world-flags, world-domain
- Extend **`validate_schema.py`** with `heritage`, `world_domain`, `world_flags` types and `WORLD_DOMAIN_STATUS` enum
- Add **benchmark campaign fixtures** (`_World/` + `Heritages/Human.md`) — validation passes on 41 files
- Update **vault structure docs**, **campaign-organizer scaffolding**, and **migration entry** (1.5.3 → 1.6.0)

This is the schema foundation (SP1 of 6) for the worldbuilding system. SP2–SP6 add skill behavior on top of this schema — each depends on SP1 but is independent of the others.

## Test plan

- [x] `python3 scripts/validate_schema.py tests/benchmark-campaign` passes (41 files, 0 errors)
- [ ] CodeRabbit review passes
- [ ] CI checks pass