### PR TITLE
Add midwife worldbuilding mode and references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.1] — 2026-05-22
+
+### Added
+
+- **Midwife standalone worldbuilding mode** — why-chain
+  conversations for fleshing out world domains, with per-domain
+  question banks, cross-domain implication surfacing, and
+  Second-Order Notes
+- **Midwife woven worldbuilding** — one-question why-chain
+  prompts during adventure creation when world facts are implied
+- **Worldbuilding reference files** — question banks (10
+  domains), cross-domain implication matrix, spiral/iceberg
+  principles, pitfall avoidance
+- **TTRPG-expert worldbuilding advisory** — principles reference
+  with per-system notes and midwife handoff
+- **Worldbuilding benchmarks** — A1-A6 purposeful worldbuilding
+  and C2 adventure creation regression
+
+---
+
 ## [1.6.0] — 2026-05-22
 
 ### Added
@@ -627,6 +647,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.3...v1.6.0
 [1.5.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.1...v1.5.2

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -442,8 +442,8 @@ worldbuilding."
 
 ### Key Principles
 
-- Ask questions the world needs answered, not questions a
-  template needs filled
+- Ask questions the world needs to be answered, not questions a
+  template needs to be filled
 - Follow `references/worldbuilding-principles.md` — spiral
   method, iceberg principle, pitfall avoidance
 - Read `_World/_flags.md` for deferred items related to the

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -264,6 +264,25 @@ Write confirmed structure to topic files under
 to `adventures/`, etc. File unused ideas to
 `_midwife/seeds/`. Update the adventure index.
 
+### Woven Worldbuilding (Adventure Creation)
+
+During Discover → Shape → Structure → Scaffold, when the
+midwife encounters something that implies world facts, pause
+for one worldbuilding question per trigger:
+
+- Castle on a hill → "Why this hill? Strategic, economic,
+  historical?"
+- New faction → "What's their economic base?"
+- Unrecognized heritage → trigger three-state flag prompt
+  (canon / ignore / defer)
+
+**One question per trigger.** Don't interrogate — light touch.
+Accumulated world facts are written to `_World/` domain files
+during the Scaffold phase (Phase 4).
+
+Consult `references/cross-domain-implications.md` for which
+questions to ask based on the domain being touched.
+
 ## Phase 4: Scaffold & Handoff
 
 **Goal:** Adventure brief written, vault ready for Session 0.
@@ -391,6 +410,47 @@ source_document: ""
 "If They Do Nothing" is required. Open Questions are preserved
 — never invent answers for things the GM was undecided on.
 
+## Worldbuilding Mode
+
+Triggered when the GM asks to work on world-level content
+rather than an adventure: "help me flesh out my world's
+economics," "I want to define my heritages," "let's do some
+worldbuilding."
+
+### Standalone Worldbuilding Conversation
+
+1. **Read the target domain file** in `_World/` (or create a
+   stub from `shared/templates/world-domain.md` if none exists).
+   If `_World/` doesn't exist, create it with `world-index.md`
+   and `_flags.md` stubs first.
+2. **Read related domain files** for cross-domain context.
+   Consult `references/cross-domain-implications.md` to identify
+   which domains connect to the target.
+3. **Run a why-chain conversation.** Use questions from
+   `references/worldbuilding-questions.md` for the target domain.
+   One question at a time. Drill into causes and consequences
+   for 2-3 turns per thread before moving to the next question.
+4. **Update the domain file** — narrative body and any
+   machine-checkable rules that emerged from the conversation.
+   Rules use the `{ id, rule, check }` format.
+5. **Surface cross-domain implications.** After the
+   conversation, check `references/cross-domain-implications.md`
+   and offer to update related domain files.
+6. **Record Second-Order Notes** in relevant entity or domain
+   files under `## Second-Order Notes` — non-obvious insights
+   from why-chain conversations.
+
+### Key Principles
+
+- Ask questions the world needs answered, not questions a
+  template needs filled
+- Follow `references/worldbuilding-principles.md` — spiral
+  method, iceberg principle, pitfall avoidance
+- Read `_World/_flags.md` for deferred items related to the
+  target domain — offer to resolve them during the conversation
+- One question at a time. Wait for the GM's answer before
+  asking the next question.
+
 ## Companion Skills
 
 - **ttrpg-expert** — domain knowledge. All cross-routing for
@@ -401,3 +461,7 @@ source_document: ""
 - **session-prep** — Session 0 planning after handoff. Offered,
   never auto-invoked.
 - **campaign-qa** — optional post-scaffold health check.
+- **Worldbuilding references:**
+  `references/worldbuilding-questions.md` (per-domain question banks),
+  `references/cross-domain-implications.md` (implication matrix),
+  `references/worldbuilding-principles.md` (spiral, iceberg, pitfalls)

--- a/skills/the-midwife/references/cross-domain-implications.md
+++ b/skills/the-midwife/references/cross-domain-implications.md
@@ -1,0 +1,125 @@
+# Cross-Domain Implication Matrix
+
+When defining content in one domain, check this matrix for
+implications in other domains. These are questioning instincts,
+not checklists — use them to surface consequences the GM may
+not have considered.
+
+## How to Use
+
+When a GM establishes a fact in one domain, scan this table for
+the row matching that domain. Each column entry is a question
+to consider asking. Don't ask all of them — pick the one or two
+most relevant to what was just established.
+
+## The Matrix
+
+### Geography → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Economics | Resources determine trade; rivers and passes determine routes; coastline determines ports |
+| Politics | Natural barriers create borders; strategic positions create power; resources create conflict |
+| Ecology | Biomes constrain flora/fauna; climate determines agriculture; elevation determines settlement |
+| Culture | Diet follows agriculture; building materials follow geology; clothing follows climate |
+| History | Geography shapes invasion routes, siege locations, and expansion patterns |
+| Heritages | Environment shapes physical adaptation and settlement preference |
+
+### Economics → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Politics | Scarce resource control = power; trade dependencies create alliances or conflicts |
+| Culture | Wealth stratification shapes class systems; trade creates cosmopolitan mixing |
+| Geography | Settlements exist where resources are; trade routes follow geography |
+| History | Trade wars, economic booms/busts, resource exhaustion drive historical events |
+| Magic/Tech | Economic demand drives innovation; magic can obsolete entire industries |
+| Heritages | Lifespan affects wealth accumulation; different species have different economic roles |
+
+### Heritages → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Culture | Each heritage develops distinct customs, values, art forms |
+| Politics | Inter-heritage relations shape power structures; which heritage holds power? |
+| Economics | Lifespan → wealth accumulation patterns; biological traits → economic niches |
+| History | Migrations, diasporas, inter-heritage conflicts, founding myths |
+| Ecology | Different heritages adapt to different environments |
+| Language | Linguistic families track heritage groupings; loanwords track contact |
+
+### Magic/Technology → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Economics | What it replaces, who profits from it, what industries it creates or destroys |
+| Politics | Regulation, who controls it, power imbalance between magic-users and non-users |
+| Culture | Attitudes toward practitioners, magical education, social status of magic-users |
+| Ecology | Environmental impact of magic use, magical creatures, enchanted landscapes |
+| History | Discovery events, magical wars, tech revolutions, ages defined by magical advancement |
+| Cosmology | Divine vs arcane sources, magical cosmology, planar mechanics |
+
+### Politics → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Economics | Taxation, trade policy, sanctions, economic warfare |
+| History | How power was gained, succession crises, treaties that made today's borders |
+| Culture | Propaganda, national identity, suppressed cultures, state religion |
+| Heritages | Which heritage holds power, inter-heritage governance, minority rights |
+| Geography | Contested territories, buffer zones, strategic positions |
+| Magic/Tech | Regulation of magic/tech, state-controlled research, magical arms races |
+
+### History → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Politics | Current arrangements trace to past events; old grievances fuel new conflicts |
+| Culture | Traditions rooted in historical events; holidays commemorating victories/losses |
+| Geography | Ruins mark old borders; roads follow ancient paths; names preserve history |
+| Heritages | Migrations, diasporas, historical inter-heritage relations |
+| Economics | Old trade agreements, resource exhaustion, boom/bust cycles |
+| Cosmology | Mythologized history, religious interpretations of events |
+
+### Cosmology/Religion → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Culture | Rituals, taboos, holy days, dietary restrictions, art and architecture |
+| Politics | Theocracy vs secular rule, church/state tensions, religious justification for power |
+| Magic/Tech | Divine vs arcane magic, religious attitudes toward technology, blessed/cursed items |
+| History | Religious wars, reformations, revelations, prophetic events |
+| Heritages | Creation myths per heritage, afterlife beliefs, divine-heritage relationships |
+| Economics | Temple wealth, tithing, religious trade restrictions, pilgrimage economies |
+
+### Culture → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Economics | Customs that affect trade (gift economies, barter, usury prohibitions) |
+| Politics | Cultural identity → nationalism; cultural suppression → resistance movements |
+| Heritages | Cultural variation within a heritage; cultural exchange between heritages |
+| Ecology | Farming practices, land use attitudes, sacred vs exploitable nature |
+| Language | Cultural concepts encoded in language; untranslatable ideas |
+| History | Cultural memory, oral traditions, revisionist history |
+
+### Ecology → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Economics | What's harvestable, what's dangerous, resource scarcity, trade in exotic materials |
+| Geography | Biome constraints, natural hazards, habitable vs inhospitable zones |
+| Culture | Diet, building materials, fears and folklore, relationship to the wild |
+| Heritages | Adaptation to environment, preferred habitats, biological niches |
+| Magic/Tech | Magical flora/fauna, enchanted ecosystems, tech for taming wilderness |
+| History | Environmental catastrophes, resource wars, mass migrations from ecological collapse |
+
+### Language → Other Domains
+
+| Target Domain | Implication Pattern |
+|---------------|-------------------|
+| Culture | Concepts that exist in one language but not another; cultural values encoded in vocabulary |
+| Politics | Lingua franca = power; linguistic imperialism; minority language suppression |
+| Heritages | Linguistic families track heritage migrations; multilingualism patterns |
+| History | Language spread tracks conquest and trade; dead languages mark dead civilizations |
+| Economics | Trade pidgins, merchant lingua franca, written vs oral commerce |
+| Magic/Tech | Magical languages, sacred scripts, power words, naming magic |

--- a/skills/the-midwife/references/worldbuilding-principles.md
+++ b/skills/the-midwife/references/worldbuilding-principles.md
@@ -1,0 +1,102 @@
+# Worldbuilding Principles
+
+Guidance for how the midwife approaches worldbuilding — when to
+drill deeper, when to stop, and what to avoid.
+
+## The Spiral Method
+
+Don't front-load worldbuilding. Build outward from what the
+players will touch:
+
+1. **First pass:** Broad strokes for the whole world — tone,
+   major powers, the one or two facts that make this world
+   distinctive
+2. **Second pass:** Detail the region where play happens —
+   geography, factions, economy, culture of the immediate area
+3. **Third pass:** Deep detail for the next 1-2 sessions —
+   specific NPCs, locations, political dynamics, prices, weather
+4. **Future passes:** Detail outward only as play demands
+
+**"Think two horizons out":** Know the current adventure locale
+in detail. Sketch the one after that. Leave everything else
+loose enough that anything can fit.
+
+## Sanderson's Iceberg Principle
+
+You don't need answers to everything — you need enough to
+improvise coherently.
+
+- The goal is internal consistency, not completeness
+- If a detail won't surface through character interaction or
+  environment, it can stay undefined
+- A world that feels deep has consistent rules, not exhaustive
+  documentation
+- Help GMs sense when they have "enough" for a domain rather
+  than pushing for exhaustive coverage
+
+**Signs a domain has "enough":**
+- The GM can answer improvised questions consistently
+- Cross-domain implications don't create contradictions
+- Players can make meaningful choices based on what's defined
+- There's room for future surprises without retcons
+
+## Worldbuilding Pitfalls
+
+Patterns the midwife should actively steer GMs away from:
+
+### Planet of Hats
+
+Every culture reduced to one trait. "Dwarves are grumpy
+miners." "Elves are serene forest-dwellers."
+
+**Fix:** Ask about internal diversity, factions, dissidents,
+regional variation. "Not all dwarves — what's the equivalent
+of a dwarf who rejects the mines? What do urban dwarves look
+like?"
+
+### Medieval Stasis
+
+Thousands of years of history with no social, technological,
+or cultural change.
+
+**Fix:** Ask what drives or prevents innovation. "If dwarves
+live 300 years and accumulate expertise, why hasn't technology
+advanced? Is something suppressing innovation? Or has it
+advanced in ways humans don't recognize?"
+
+### Ignoring Second-Order Effects
+
+Adding healing magic without considering population growth.
+Adding teleportation without considering trade route collapse.
+Adding divination without considering privacy.
+
+**Fix:** The cross-domain implication matrix. Every new
+capability gets one "what does this break?" question.
+
+### Over-Detailing
+
+Building the full history of a continent before session 1.
+Defining 47 noble houses when the campaign starts in a tavern.
+
+**Fix:** Spiral method. "What do the players encounter in the
+next two sessions? Let's detail that. The rest can wait."
+
+### Worldbuilder's Disease
+
+Endless building, never playing. The world is never "ready."
+
+**Fix:** Recognize when a domain has "enough" and suggest
+moving on. "This is solid — you can answer questions about
+this domain consistently. Want to detail another area, or
+is this ready to play?"
+
+### Inconsistent Tone
+
+Grimdark politics with whimsical magic. Gritty survival with
+consequence-free resurrection.
+
+**Fix:** Ask about intended tone early. When new elements are
+added, flag when they clash with established tone. "This world
+has felt grounded and low-magic so far — adding easy
+teleportation would change that significantly. Is that
+intentional?"

--- a/skills/the-midwife/references/worldbuilding-questions.md
+++ b/skills/the-midwife/references/worldbuilding-questions.md
@@ -1,0 +1,126 @@
+# Worldbuilding Question Banks
+
+Per-domain starter questions for standalone and woven
+worldbuilding. These are not exhaustive questionnaires — they
+are the 5-10 most productive questions per domain that surface
+structure and causation.
+
+## How to Use
+
+- **Standalone mode:** Work through a domain's questions in
+  conversation, drilling deeper with why-chains on each answer
+- **Woven mode:** When adventure creation touches a domain,
+  pick the single most relevant question from that domain
+- Questions are starting points — follow the GM's answers,
+  don't march through the list mechanically
+
+## Heritages
+
+1. How long do they live? How does lifespan shape their
+   institutions and power structures?
+2. Where do they settle and why? What environments suit them?
+3. What's their relationship with other heritages? Trade
+   partners, rivals, indifferent?
+4. What do they value that others don't? What's taboo?
+5. How does their biology affect their culture? (e.g., long
+   lifespan → wealth accumulation, darkvision → underground
+   cities)
+
+## Geography & Climate
+
+1. What's the scarce resource? Who controls it?
+2. Where does water come from? Rivers, wells, rain, magic?
+3. What natural barriers exist? Mountains, deserts, oceans?
+4. Where do trade routes form and why? What makes a location
+   strategic?
+5. How does climate shape daily life? What can/can't grow here?
+
+## History & Timeline
+
+1. What was the founding event? How did this civilization begin?
+2. What's the most recent war and what caused it?
+3. What changed in living memory? What do elders remember that
+   youth don't?
+4. What do people believe happened vs what actually happened?
+5. What was the last major disruption? Plague, invasion,
+   magical catastrophe, succession crisis?
+
+## Politics & Governance
+
+1. Who holds power and by what right? Divine mandate, conquest,
+   election, wealth?
+2. What keeps them in power? Army, religion, economic control,
+   popular support?
+3. Who wants to take it? What's stopping them?
+4. What are the borders and why there? Natural barriers,
+   treaties, conquest lines?
+5. What laws affect daily life most? Taxation, movement
+   restrictions, religious law?
+
+## Economics & Trade
+
+1. What does each region produce? What do they lack?
+2. Who controls the scarce resource? How do they leverage it?
+3. What's the currency and why? Metal coins, trade goods,
+   letters of credit, magical tokens?
+4. What happens when trade is disrupted? Who suffers first?
+5. Where is wealth concentrated? Merchant class, nobility,
+   temples, guilds?
+
+## Magic/Technology
+
+1. Who can access it? Everyone, a trained elite, a bloodline?
+2. What does it cost? Physical exhaustion, material components,
+   sanity, years of training?
+3. Is it regulated? By whom? What are the penalties for
+   violation?
+4. What societal problem has it solved? Healing, communication,
+   food production, defense?
+5. What problem has it created? Power inequality, environmental
+   damage, dependency, weapons escalation?
+
+## Cosmology & Religion
+
+1. Are gods real and active? Do they intervene, observe, or
+   sleep?
+2. What happens when you die? Is the answer known or debated?
+3. How was the world made? Do different cultures agree?
+4. What's the relationship between divine and arcane magic?
+   Complementary, opposed, the same source?
+5. What religious conflict exists? Heresy, competing pantheons,
+   secular vs theocratic?
+
+## Culture & Daily Life
+
+1. What do people eat? How does diet vary by region and class?
+2. How are families structured? Nuclear, extended, clan-based,
+   communal?
+3. What's taboo? What gets you shunned or killed?
+4. What do they celebrate? Harvest festivals, religious holy
+   days, historical victories?
+5. How is status displayed? Clothing, titles, housing,
+   retainers, magical marks?
+
+## Ecology
+
+1. What's dangerous in the wild? Apex predators, magical
+   beasts, environmental hazards?
+2. What do people farm, hunt, or gather? What's the staple
+   crop?
+3. How does climate shape daily life? Seasons, storms,
+   drought cycles?
+4. What's the relationship between civilization and wilderness?
+   Expanding frontier, stable boundary, retreating?
+5. Are there domesticated magical/unusual creatures? What
+   roles do they fill?
+
+## Language & Communication
+
+1. Is there a common tongue? How did it spread? Trade,
+   conquest, divine gift?
+2. How do naming conventions signal heritage or region?
+3. What can't be translated between cultures? Concepts that
+   don't cross linguistic boundaries?
+4. How does long-distance communication work? Messengers,
+   signal fires, magic, birds?
+5. Are there forbidden or sacred languages? Who speaks them?

--- a/skills/ttrpg-expert/SKILL.md
+++ b/skills/ttrpg-expert/SKILL.md
@@ -123,6 +123,10 @@ Match user intent → go directly to the file. Skip clarification.
 **"What happened in session [N]?"** / **"campaign recap"**
 → `campaign-timeline.md` (vault root or campaign/).
 
+**"worldbuilding"** / **"world-design"** / **"second-order"**
+→ Read `worldbuilding-principles.md` for advisory guidance.
+For interactive worldbuilding sessions, hand off to the midwife.
+
 ## Modes
 
 **Analysis** — Validate, review, check, advise.

--- a/skills/ttrpg-expert/worldbuilding-principles.md
+++ b/skills/ttrpg-expert/worldbuilding-principles.md
@@ -1,0 +1,70 @@
+# Worldbuilding Principles
+
+Advisory reference for worldbuilding questions asked outside of
+a midwife session. For interactive worldbuilding conversations,
+hand off to the midwife.
+
+## Core Pattern: Second-Order Consequence Thinking
+
+Every world element exists in a web of cause and effect. When a
+GM asks about a world element, think one layer deeper:
+
+- **Geography** implies trade implies wealth implies politics
+  implies conflict
+- **Magic** implies societal consequences — healing magic
+  affects population, teleportation affects trade routes,
+  divination affects privacy
+- **Long lifespans** imply wealth accumulation, institutional
+  resistance to change, generational power dynamics
+- **Scarce resources** imply control, conflict, innovation,
+  and eventually war or trade
+
+## The Spiral Method
+
+Build outward from what players will touch. Detail the
+immediate area; sketch the next horizon; leave the rest
+loose. Think two horizons out, not ten.
+
+## Sanderson's Iceberg
+
+You need enough to improvise coherently, not enough to write
+an encyclopedia. If a detail won't surface through character
+interaction or environment, leave it undefined.
+
+## Common Pitfalls
+
+- **Planet of hats** — every culture as one trait. Ask about
+  internal diversity.
+- **Medieval stasis** — no change over centuries. Ask what
+  drives or prevents innovation.
+- **Ignoring second-order effects** — adding magic without
+  considering societal impact.
+- **Over-detailing** — building everything before playing.
+  Use the spiral method.
+- **Worldbuilder's disease** — never being "ready." Recognize
+  when a domain has enough.
+- **Inconsistent tone** — grimdark politics with whimsical
+  magic. Flag clashes early.
+
+## Per-System Worldbuilding Notes
+
+- **CoC** — Investigation-focused. Geography and history
+  matter more than economics. The "world" is mostly the real
+  world with hidden horrors underneath. Worldbuilding is about
+  what's wrong, not what's normal.
+- **D&D 5e** — Magic-heavy worlds need rigorous magic-system
+  rules, or second-order effects create plot holes. "Why
+  doesn't the king just use Sending?" needs an answer.
+- **GURPS 4e** — Point-build system needs heritage traits
+  defined precisely (racial templates with point costs).
+  Worldbuilding directly feeds mechanical character creation.
+- **FitD** — Faction-driven play means politics and economics
+  are central. Every faction needs goals, resources, and
+  obstacles. Worldbuilding IS faction-building.
+
+## Handoff
+
+If the GM wants to do interactive worldbuilding — drilling
+into a domain, running why-chains, creating domain files —
+hand off to the midwife: "This sounds like a worldbuilding
+session. Want me to switch to the midwife for that?"

--- a/tests/benchmark-questions/worldbuilding-midwife.md
+++ b/tests/benchmark-questions/worldbuilding-midwife.md
@@ -1,0 +1,72 @@
+# Benchmark Questions — Worldbuilding (Midwife)
+
+**Skill:** the-midwife (worldbuilding mode)
+**Purpose:** Quality baseline for worldbuilding conversations
+**Runs:** 5 per variant, report median + IQR
+**Campaign data:** `tests/benchmark-campaign/`
+
+## Questions
+
+### A1 — Cold-start worldbuilding
+
+I want to flesh out the heritages of my world. There are humans
+and I've mentioned dwarves in a few session notes but never
+defined them. Help me build this out.
+
+### A2 — Cross-domain implication
+
+I've established that the Northern Kingdom controls the only
+iron mines. What does that mean for the rest of the world?
+
+### A3 — Existing world extension
+
+I want to add a magic system to this world. Magic hasn't come
+up yet.
+
+### A4 — Pitfall avoidance
+
+Every dwarf is a grumpy miner and every elf is a serene
+forest-dweller.
+
+### A5 — Spiral discipline
+
+Tell me everything about the continent's 3,000-year history.
+
+### A6 — Political hierarchy
+
+There are five noble houses in the Eastern Provinces that owe
+fealty to the Archduke, who answers to the Emperor. Help me
+set this up.
+
+### C2 — Midwife adventure creation regression
+
+I want to create a new adventure for my Ashford Case campaign.
+Something involving the docks and the strange symbols the
+investigators found. Use the midwife's Discover phase to help
+me develop the concept.
+
+## Rubric
+
+### Categories A1-A6 (worldbuilding-specific rubric)
+
+| Dimension | 1 (poor) | 2 (adequate) | 3 (good) |
+|-----------|----------|--------------|----------|
+| Factual accuracy | Contradicts vault content or established world rules | Consistent with vault, minor gaps | Fully consistent, references specific vault entities |
+| System specificity | Generic fantasy, no system-native framing | Acknowledges the game system | Uses system-native concepts |
+| Second-order depth | States facts with no causal reasoning | Notes one implication | Traces cause → effect across 2+ domains |
+| Internal consistency | New content contradicts existing world rules | No contradictions but doesn't reinforce connections | Actively strengthens cross-domain coherence |
+| Actionability | Abstract lore with no play impact | Could inform play with GM rework | Directly usable — creates checkable rules, playable entities, or prompts |
+
+15 points max per question.
+
+### Category C2 (existing 5-dimension rubric)
+
+| Dimension | 1 (poor) | 2 (adequate) | 3 (good) |
+|-----------|----------|--------------|----------|
+| Factual accuracy | Contradicts vault content | Consistent with vault, minor gaps | Fully consistent, references specific vault entities |
+| System specificity | Generic, no system framing | Acknowledges game system | Uses system-native concepts |
+| Actionability | Abstract, needs heavy rework | Usable with some GM effort | Directly usable at the table |
+| Mechanical grounding | No mechanical basis | Mentions mechanics | Integrates system mechanics naturally |
+| Table-ready fiction | Flat, generic prose | Serviceable prose with some flavor | Vivid, evocative, campaign-specific |
+
+15 points max per question.


### PR DESCRIPTION
## Summary

- **Midwife standalone worldbuilding mode** — why-chain conversations for fleshing out world domains, with per-domain question banks (10 domains), cross-domain implication surfacing, and Second-Order Notes
- **Midwife woven worldbuilding** — one-question why-chain prompts during adventure creation when world facts are implied (Phase 3 integration)
- **Worldbuilding reference files** — question banks, 10×10 cross-domain implication matrix, spiral/iceberg principles, pitfall avoidance
- **TTRPG-expert worldbuilding advisory** — principles reference with per-system notes and midwife handoff routing
- **Worldbuilding benchmarks** — A1-A6 purposeful worldbuilding and C2 adventure creation regression

SP2 of the worldbuilding system (depends on SP1 merged in #46).

## Regression check

C2 (midwife adventure creation) benchmarked before/after — no regression, +1 on system specificity from richer vault context.

## Test plan

- [ ] Schema validation passes (`python3 scripts/validate_schema.py`)
- [ ] Markdown lint passes
- [ ] C2 regression benchmark shows no quality drop (done — 13/15 → 14/15)
- [ ] New reference files are well-formed markdown
- [ ] Midwife SKILL.md worldbuilding mode section routes correctly
- [ ] ttrpg-expert worldbuilding routing points to correct reference file