### PR TITLE
Add entity validation against world rules

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.2] — 2026-05-22
+
+### Added
+
+- **Entity validation against world rules** — campaign-organizer
+  checks NPCs, locations, and factions against `_World/` domain
+  rules during creation and updates
+- **Three-state flag prompts** — violations surface as advisory
+  prompts with canon/ignore/defer responses
+- **Ad-hoc bootstrap** — world infrastructure created on demand
+  when validation needs a domain file that doesn't exist yet
+
+---
+
 ## [1.6.1] — 2026-05-22
 
 ### Added
@@ -647,6 +661,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.3...v1.6.0
 [1.5.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.2...v1.5.3

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -251,6 +251,12 @@ tools used to read, write, and search differ.
    using that template as the structure. Fill in frontmatter per
    schema and embed `[[wiki-links]]`. Never pattern-match off
    existing entity files — the template is canonical.
+
+**World-rule validation:** After creating or updating an entity,
+if `_World/` exists, check the entity against active domain
+rules. Read `references/world-validation.md` for the full
+procedure. Surface violations as advisory prompts with
+three-state responses (canon / ignore / defer).
 5. **Link pass** — Find missed cross-references.
 6. **Graph audit** — Read `references/graph-hygiene.md` and
    run hygiene checks.
@@ -288,6 +294,10 @@ tools used to read, write, and search differ.
 4. **Propose** — Group by confidence: Explicit, Inferred, Possible.
 5. **Apply** — After confirmation, update frontmatter and links.
    Read `references/graph-hygiene.md` for link conventions.
+
+When adding relationships or updating entity fields, check
+new values against `_World/` rules (if `_World/` exists).
+Follow `references/world-validation.md`.
 6. **Update index** — Refresh `_meta/index.md`.
 7. **Graph audit** — Read `references/graph-hygiene.md` and
    run full hygiene check.
@@ -301,7 +311,11 @@ tools used to read, write, and search differ.
 2. **Semantic checks:** redundant edges, implied traversal edges,
    hub overload, generic type usage (`associated_with` etc.).
    Read `references/graph-hygiene.md` for anti-patterns.
-3. **Report** — Categorized findings with severity and fixes.
+3. **World-rule checks:** If `_World/` exists with active domain
+   files, check all entities against world rules. Report
+   violations as findings (not blocking). Follow
+   `references/world-validation.md` for check procedures.
+4. **Report** — Categorized findings with severity and fixes.
 
 ## Handling Ambiguity
 

--- a/skills/campaign-organizer/references/world-validation.md
+++ b/skills/campaign-organizer/references/world-validation.md
@@ -1,0 +1,67 @@
+# World-Rule Validation
+
+When creating or modifying entities, campaign-organizer checks
+the entity against active `_World/` rules. All validation is
+advisory — never blocking.
+
+## When to Validate
+
+- During entity creation (Organize, Dissect modes)
+- During entity updates (Weave mode)
+- Only when `_World/` exists and relevant domain files have
+  `status: active` with `rules` entries
+
+## Validation Procedure
+
+1. Read `_World/` domain files that could apply to this entity
+   type:
+   - NPCs/PCs → `heritages.md` (lifespan, heritage list)
+   - Locations → `geography-climate.md`
+   - Factions → `politics-governance.md`, `economics-trade.md`
+   - Any entity → `magic-technology.md` (tech era constraints)
+
+2. For each rule with a `check` object, evaluate:
+   - `field` — does this entity have this field?
+   - `max` / `min` — is the value within range?
+   - `allowed_values` — is the value in the list?
+   - `entity_type` — does this rule apply to this entity type?
+
+3. For each violation, surface the finding:
+   > "This NPC is 400 years old, but world rules say humans live
+   > 60-85 years. Intentional?"
+
+4. Present three-state prompt:
+   - **Canon** — the exception is intentional. Note it on the
+     entity (e.g., `age_note: "Unnaturally long-lived due to
+     Mythos exposure"`). Optionally update the world rule.
+   - **Ignore** — the violation doesn't matter. Add to
+     `_flags.md` ignored section to suppress future flags.
+   - **Defer** — not sure yet. Add to `_flags.md` deferred
+     section. Continue with entity creation.
+
+## Checks That Fire
+
+| Domain File | Entity Types | What's Checked |
+|-------------|-------------|----------------|
+| heritages.md | npc, pc | Age vs lifespan range, heritage vs allowed list |
+| geography-climate.md | location | Settlement rules (if defined) |
+| politics-governance.md | faction, organization | Hierarchy depth, required relationships |
+| economics-trade.md | faction, location | Economic base rules (if defined) |
+| magic-technology.md | any | Tech era constraints (if defined) |
+
+## Reading _flags.md
+
+Before surfacing a finding, check `_flags.md`:
+- If the topic is in **Ignored** → suppress silently
+- If the topic is in **Deferred** → note the existing deferral
+- If new → surface normally
+
+## Ad-Hoc Bootstrap
+
+If a validation finding requires a `_World/` file that doesn't
+exist (e.g., the GM confirms a heritage but `heritages.md`
+doesn't exist), create it:
+1. Create `_World/` if it doesn't exist (with world-index.md
+   and _flags.md stubs)
+2. Create the domain file as a stub with the new content
+3. Update world-index.md

--- a/tests/benchmark-questions/worldbuilding-validation.md
+++ b/tests/benchmark-questions/worldbuilding-validation.md
@@ -1,0 +1,44 @@
+# Benchmark Questions — Worldbuilding (Entity Validation)
+
+**Skill:** campaign-organizer (world validation)
+**Purpose:** Quality baseline for entity validation against world rules
+**Runs:** 5 per variant, report median + IQR
+**Campaign data:** `tests/benchmark-campaign/`
+
+## Questions
+
+### B4 — Entity validation at promotion
+
+I'm reviewing entities from Session 2 for promotion to
+AUTHORITATIVE. One of my NPCs, Professor Ashford, has
+`heritage: Human` and `age: 400`. My world rules in
+`_World/heritages.md` define human lifespan as max 85.
+Walk me through the reconcile process for this entity,
+including how the world-rule violation should be handled.
+
+### C3 — Campaign-organizer entity creation regression
+
+Create an NPC entity for my Ashford Case campaign: Margaret
+Chen, a 45-year-old Chinese-American librarian at Miskatonic
+University. She's a colleague of Professor Ashford. Use
+campaign-organizer's Organize mode.
+
+## Rubric
+
+### B4 (worldbuilding-specific rubric)
+
+| Dimension | 1 (poor) | 2 (adequate) | 3 (good) |
+|-----------|----------|--------------|----------|
+| Factual accuracy | Ignores the world rule violation | Notes the violation but doesn't explain options | Correctly identifies violation and presents all three response paths |
+| System specificity | Generic handling | Acknowledges CoC context | Uses CoC-appropriate framing (e.g., Mythos exposure as explanation) |
+| Second-order depth | Handles only the immediate violation | Considers what the exception means | Explores implications (e.g., if Ashford is 400, what does that mean for the campaign?) |
+| Internal consistency | Resolution would create contradictions | Resolution is clean | Resolution actively strengthens world coherence |
+| Actionability | Abstract advice | Workable but needs GM effort | Specific entity updates, flag entries, and domain file changes |
+
+### C3 (existing 5-dimension rubric)
+
+Standard entity creation rubric — entity should be correctly
+formatted, wiki-linked, relationship-connected, and filed.
+World-rule validation should fire (heritage check against
+`_World/heritages.md`) but should pass cleanly for a valid
+45-year-old human.


### PR DESCRIPTION
## Summary

- **World-rule validation reference** — campaign-organizer checks entities against `_World/` domain rules during creation/update, with three-state flag prompts (canon/ignore/defer)
- **Campaign-organizer mode updates** — validation integrated into Organize, Weave, and Validate modes
- **Ad-hoc bootstrap** — world infrastructure created on demand when validation needs a domain file that doesn't exist
- **Entity validation benchmarks** — B4 (promotion with world-rule violation) and C3 (entity creation regression)

SP3 of the worldbuilding system (depends on SP1 #46, independent of SP2 #47).

## Test plan

- [ ] Schema validation passes
- [ ] Markdown lint passes
- [ ] World-validation reference is well-formed and complete
- [ ] Campaign-organizer modes reference validation procedure correctly
- [ ] Benchmark questions cover both worldbuilding-specific and regression scenarios