### PR TITLE
Add world fact detection to session-wrapup and reconcile

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.3] — 2026-05-22
+
+### Added
+
+- **Session-wrapup world fact detection** — scans session notes
+  for unrecognized heritages, place names, cultural practices,
+  deity names, and other world facts; stages findings for
+  reconcile review
+- **Reconcile step 2.5** — world fact review with three-state
+  prompts (canon/ignore/defer) during post-session reconciliation
+- **Reconcile step 5 world-rule validation** — checks entities
+  against `_World/` rules during promotion to AUTHORITATIVE
+- **Deferred flag accumulation** — mention counting and
+  resurfacing for deferred world facts
+- **World fact detection heuristics** — signal/noise distinction
+  reference for session-wrapup scanning
+
+---
+
 ## [1.6.2] — 2026-05-22
 
 ### Added
@@ -661,6 +680,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.5.3...v1.6.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,7 @@ Items are force-ranked by score. Higher score = do first.
 
 | Item | Impact | Urgency | Effort | Score | Status | Notes |
 |------|:------:|:-------:|:------:|:-----:|--------|-------|
+| Publish tool: landing recap + wrap-up sidebar fix | 5 | 4 | S (1) | 14.0 | Planned | Landing page extracts recap from session index (no narrative) instead of wrap-up; link targets session index instead of wrap-up; wrap-up pages get a useless "Mentioned In" sidebar that compresses content. [Implementation](docs/publish-landing-recap-fix.md) |
 | Gotchas sections for vault-writing skills | 3 | 3 | S (1) | 9.0 | Idea | Add explicit gotchas blocks to session-wrapup, campaign-organizer, vault-ingest, the-midwife. Consolidate scattered constraints (template-reading gate, protected sections, date formats, entity-per-file) into a single block near the top of each SKILL.md. Benchmark before/after. |
 | Validation loops for entity creation | 3 | 2 | S (1) | 8.0 | Idea | Add self-validation steps to session-wrapup Step 4, vault-ingest, and campaign-organizer entity creation. Pattern: create entity, check frontmatter against template and schema, fix before moving on. Benchmark before/after. |
 | "Why" reasoning on rigid skill directives | 3 | 2 | S (1) | 8.0 | Idea | Add reasoning to key bare directives across all skills. "ONE file per entity — multiple entities break wiki-link resolution and publish rendering." Models comply more reliably when they understand downstream consequences. Benchmark before/after. |

--- a/docs/publish-landing-recap-fix.md
+++ b/docs/publish-landing-recap-fix.md
@@ -1,0 +1,83 @@
+# Publish Tool: Landing Page Recap + Wrap-Up Sidebar Fix
+
+Three related bugs in the publish tool's handling of session
+wrap-up pages.
+
+## Bug 1: Landing page shows no recap text
+
+`landing.js` calls `extractRecap(latestSession)` on the session
+index page, which has no `## Narrative Recap` heading. The recap
+lives in the wrap-up file, not the session index.
+
+## Bug 2: "Read full session" links to session index
+
+The landing page links to `latestSession.outputPath` (the session
+index), not the wrap-up page where the actual narrative lives.
+
+## Bug 3: Wrap-up page compressed by "Mentioned In" sidebar
+
+`wiki.js` unconditionally passes backlinks to
+`renderContextSidebar()` for all page types. On wrap-up pages,
+this produces a "Mentioned In" sidebar that compresses the main
+content to ~60% width with no useful information.
+
+---
+
+## Implementation
+
+### File 1: `tools/publish/lib/templates/landing-data.js`
+
+Add `getLatestWrapUp` function and export it.
+
+```javascript
+function getLatestWrapUp(pages, session) {
+  if (!session) return null;
+  const wrapTypes = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
+  const wrapUps = pages.filter(p => wrapTypes.has(p.frontmatter.type));
+  const sessionTitle = session.title || '';
+  for (const wu of wrapUps) {
+    const ref = String(wu.frontmatter.session || '');
+    if (ref.includes(sessionTitle)) return wu;
+  }
+  const num = session.frontmatter.session_number;
+  if (num != null) {
+    for (const wu of wrapUps) {
+      if (wu.frontmatter.session_number === num) return wu;
+    }
+  }
+  return null;
+}
+
+module.exports = { getLatestSession, getLatestWrapUp, extractRecap, ... };
+```
+
+### File 2: `tools/publish/lib/templates/landing.js`
+
+Import `getLatestWrapUp`. In Zone 2, find the wrap-up and use
+it as both the recap source and the link target:
+
+```javascript
+const latestSession = getLatestSession(pages);
+const latestWrapUp = getLatestWrapUp(pages, latestSession);
+let recapZone = '';
+if (latestSession) {
+  const recapSource = latestWrapUp || latestSession;
+  const recap = extractRecap(recapSource);
+  const linkTarget = latestWrapUp || latestSession;
+  const recapLink = `<a class="recap-link" href="${escapeHtml(linkTarget.outputPath)}">Read full session &rarr;</a>`;
+```
+
+### File 3: `tools/publish/lib/templates/wiki.js`
+
+Suppress backlinks for wrap-up page types:
+
+```javascript
+const WRAP_UP_TYPES = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
+const isWrapUp = WRAP_UP_TYPES.has(fm.type);
+
+let sidebar = renderContextSidebar({
+  backlinks: isWrapUp ? [] : backlinks,
+  relationships: normalizeRelationships(fm.relationships, linkMap),
+  currentOutputPath: page.outputPath,
+});
+```

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -215,9 +215,11 @@ facts (heritage references, deity names, new place names):
 
 1. Scan session notes using heuristics from
    `references/world-fact-detection.md`
-2. Check each finding against `_World/_flags.md` for
-   deduplication (ignored → suppress, deferred → increment,
-   canon → suppress)
+2. Deduplicate each finding against `_World/_flags.md`
+   (ignored → suppress, deferred → increment, canon →
+   suppress), `_World/` domain files (already encoded →
+   suppress), and existing entity files (already exists →
+   suppress)
 3. Stage findings in the Wrap-Up file under
    `## World Fact Findings`
 

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -208,6 +208,26 @@ can update manually later.
 `current_chapter`, `chapters_planned`, `status`, or any body
 sections. These are narrative decisions the GM makes explicitly.
 
+### 4c. World Fact Scan
+
+If `_World/` exists OR session notes contain potential world
+facts (heritage references, deity names, new place names):
+
+1. Scan session notes using heuristics from
+   `references/world-fact-detection.md`
+2. Check each finding against `_World/_flags.md` for
+   deduplication (ignored → suppress, deferred → increment,
+   canon → suppress)
+3. Stage findings in the Wrap-Up file under
+   `## World Fact Findings`
+
+**Do not present three-state prompts.** Findings are staged
+for the reconcile procedure (step 2.5) to present during
+review. Session-wrapup detects; reconcile decides.
+
+If `_World/` doesn't exist and no findings are detected, skip
+this step entirely — no empty section.
+
 ### 5. What Carries Forward
 
 Write into Wrap-Up file:
@@ -256,6 +276,7 @@ Wrap-up **must** produce all sections so prep reads one file:
 | What Carries Forward | Yes | Wrap-Up file |
 | World State | Yes | Wrap-Up file |
 | Keeper Checklist | Yes | Wrap-Up file |
+| World Fact Findings | If findings exist | Wrap-Up file |
 
 Entity files and timeline are updated separately (Step 4).
 Character story files are updated separately (Step 3b).

--- a/skills/session-wrapup/references/world-fact-detection.md
+++ b/skills/session-wrapup/references/world-fact-detection.md
@@ -38,7 +38,8 @@ Before staging a finding:
 1. Check `_World/_flags.md` — is this already tracked?
    - **Ignored** → suppress silently, do not stage
    - **Deferred** → increment mention count, note session
-     number, stage for reconcile if accumulation threshold met
+     number. Stage for reconcile when the topic has been
+     mentioned in 3 or more sessions.
    - **Canon** → suppress, it's already resolved
 2. Check `_World/` domain files — is this fact already encoded?
    If so, suppress.

--- a/skills/session-wrapup/references/world-fact-detection.md
+++ b/skills/session-wrapup/references/world-fact-detection.md
@@ -1,0 +1,69 @@
+# World Fact Detection
+
+Heuristics for scanning session content and identifying
+potential world facts during the Wrap-Up generation pass.
+
+## What to Scan For
+
+| Category | Examples | Signal Strength |
+|----------|---------|----------------|
+| Heritage/species names | "Torga, a dwarf merchant" | High — proper noun used as identity |
+| New place names | "the village of Brackenmoor" | High — named and described |
+| Cultural practices | "the harvest festival of Moonrise" | Medium — depends on detail level |
+| Religious references | "she prayed to Shar" | High — deity name |
+| Technology/magic | "he drew a flintlock pistol" | Medium — depends on world rules |
+| Historical events | "since the fall of the Empire" | Medium — could be flavor or lore |
+| Economic details | "gold crowns" (currency), "silk trade" | Low-medium — often flavor |
+| Ecological details | "the dire wolves of the Frost Waste" | Medium — creature + location |
+
+## Signal vs Noise
+
+**Likely significant (flag it):**
+- Named AND described — a proper noun with enough context to
+  create an entity or rule
+- Used by multiple NPCs or in multiple scenes — gaining weight
+- Contradicts an existing world rule — always flag
+- Consistent with existing rules but extends them — flag as
+  potential addition
+
+**Likely flavor (don't flag):**
+- Mentioned once in passing with no description
+- Generic reference with no proper noun ("some old ruins")
+- Atmospheric detail that doesn't imply a world rule ("it was
+  raining heavily")
+
+## Deduplication
+
+Before staging a finding:
+1. Check `_World/_flags.md` — is this already tracked?
+   - **Ignored** → suppress silently, do not stage
+   - **Deferred** → increment mention count, note session
+     number, stage for reconcile if accumulation threshold met
+   - **Canon** → suppress, it's already resolved
+2. Check `_World/` domain files — is this fact already encoded?
+   If so, suppress.
+3. Check entity files — does a matching entity already exist?
+   If so, suppress.
+
+## Output Format
+
+Stage findings in the Wrap-Up file under
+`## World Fact Findings`:
+
+```markdown
+## World Fact Findings
+
+- **Dwarf heritage** — Torga described as "a dwarf merchant"
+  (first mention). No heritage definition exists.
+  Domains: heritages
+- **Brackenmoor** — new settlement mentioned by two NPCs.
+  No vault entry.
+  Domains: geography-climate
+- **The Old Empire** — referenced again (deferred, 3 prior
+  mentions, threshold reached). Sessions: 3, 4, 5, 7.
+  Recommend resurfacing.
+  Domains: history-timeline, politics-governance
+```
+
+Each finding includes: the fact, evidence from session notes,
+which domains it touches, and whether it's new or accumulated.

--- a/skills/shared/reconcile.md
+++ b/skills/shared/reconcile.md
@@ -66,6 +66,32 @@ Surface everything that needs GM attention:
 
 Present as a short inventory, not a wall of text.
 
+### 2.5. World fact review
+
+If the Wrap-Up file contains a `## World Fact Findings` section
+(staged by session-wrapup), review each finding with the GM.
+
+For each finding, present the three-state prompt:
+
+- **Canon** → create or update the relevant `_World/` domain
+  file and entities. Example: new heritage confirmed → create
+  `Heritages/{Name}.md` from `shared/templates/heritage.md`,
+  add entry to `_World/heritages.md`, record in `_flags.md`
+  canon section.
+  If `_World/` doesn't exist, create it first (world-index.md
+  + _flags.md stubs from shared/templates/).
+- **Ignore** → add to `_flags.md` ignored section with date
+  and context. Future flags on this topic are suppressed.
+- **Defer** → add to `_flags.md` deferred section with session
+  number and context. If the item was being re-surfaced
+  (accumulated mentions), present the accumulated context:
+  "The Old Empire has come up in 3 sessions now — should we
+  flesh this out?"
+
+One finding at a time. Wait for GM decision before continuing.
+Record each resolution in the `## Reconciliation Context`
+section (step 6).
+
 ### 3. Walk through conflicts
 
 One conflict at a time. For each:
@@ -99,6 +125,15 @@ On GM approval:
 2. Update session index `status` to `reviewed`
 3. Promote related entity `source_confidence` from DRAFT
    to AUTHORITATIVE where GM confirmed content
+   3b. Before finalizing each entity promotion, check the entity
+       against active `_World/` rules (if `_World/` exists).
+       If a world rule is violated:
+       - Surface: "This NPC is 400 years old, but world rules
+         say humans live 60-85 years. Is that intentional?"
+       - **Yes, intentional** → promote with a note explaining
+         the exception
+       - **Correct it** → update the entity before promotion
+       - **Defer** → promote but tag `needs_review: true`
 4. Mark any contradicted content as `SUPERSEDED` with
    `superseded_by` reference
 

--- a/tests/benchmark-questions/worldbuilding-wrapup.md
+++ b/tests/benchmark-questions/worldbuilding-wrapup.md
@@ -1,0 +1,87 @@
+# Benchmark Questions — Worldbuilding (Wrapup + Reconcile)
+
+**Skill:** session-wrapup, reconcile procedure
+**Purpose:** Quality baseline for world fact detection and reconcile integration
+**Runs:** 5 per variant, report median + IQR
+**Campaign data:** `tests/benchmark-campaign/`
+
+## Questions
+
+### B1 — Heritage detection
+
+Process these session notes as a Wrap-Up for Session 3 of the
+Ashford Case campaign:
+
+"The investigators visited the Kingsport Docks where they met
+Torga, a dwarf merchant selling exotic spices from the Eastern
+Continent. Torga warned them about 'deep things' in the
+harbor. Later, Inspector Crane confirmed Torga has been a
+regular at the docks for decades."
+
+Focus on the world-fact scan — what should be staged in
+## World Fact Findings?
+
+### B2 — Deferred accumulation
+
+Process these session notes as a Wrap-Up for Session 5. The
+campaign's `_flags.md` already has "The Old Empire" deferred
+with 2 prior mentions from sessions 3 and 4. Session 5 notes:
+
+"Father Blackwood mentioned that the church was built on ruins
+from 'the old empire' and that the crypt predates the town
+itself. Mrs Whitmore's diary references 'imperial road markers'
+along the coast road."
+
+What happens to the deferred flag for "The Old Empire"?
+
+### B3 — Ignored suppression
+
+Process these session notes as a Wrap-Up for Session 4. The
+campaign's `_flags.md` has "giant rats" in the ignored section.
+Session 4 notes mention "giant rats skittering in the
+warehouse basement."
+
+Verify that no world-fact finding is staged for giant rats.
+
+### B5 — Domain bootstrap from ad-hoc
+
+During reconcile of Session 3, the GM confirms that "the
+harvest festival of Moonrise" is canon. No
+`_World/culture-daily-life.md` file exists.
+
+Walk through what should happen: what files are created, what
+content goes where, and what gets recorded in _flags.md.
+
+### C1 — Session-wrapup without _World/
+
+Process these session notes as a standard Wrap-Up for Session 1
+of a brand-new campaign (no `_World/` folder exists):
+
+"Dr. Eleanor Voss arrived in Kingsport by train. She met
+Professor Ashford at Miskatonic University, who showed her the
+strange symbol carved into his study door. That evening, she
+visited St. Anselm's Church where Father Blackwood seemed
+nervous about recent disturbances."
+
+Produce a complete Wrap-Up. Verify the output is clean standard
+wrapup with no errors or empty world sections.
+
+## Rubric
+
+### B1-B3, B5 (worldbuilding-specific rubric)
+
+| Dimension | 1 (poor) | 2 (adequate) | 3 (good) |
+|-----------|----------|--------------|----------|
+| Factual accuracy | Misidentifies facts or ignores _flags.md state | Correct detection, minor gaps in context | Complete and accurate, references specific _flags.md entries |
+| System specificity | Generic handling | Acknowledges CoC context | Uses CoC-appropriate framing |
+| Second-order depth | Only detects surface facts | Notes domain connections | Identifies cross-domain implications of detected facts |
+| Internal consistency | Creates contradictions with existing world state | Clean but minimal | Actively reinforces existing world coherence |
+| Actionability | Vague findings | Workable findings needing GM effort | Specific, staged findings ready for reconcile review |
+
+### C1 (existing 5-dimension rubric)
+
+Standard session-wrapup quality — complete recap, entity
+updates, timeline entries, carry-forward. No world-fact section
+should appear since `_World/` doesn't exist and the notes
+contain no strong world-fact signals for a CoC campaign (all
+entities are human, all locations are real-world).

--- a/tests/benchmark-questions/worldbuilding-wrapup.md
+++ b/tests/benchmark-questions/worldbuilding-wrapup.md
@@ -78,7 +78,7 @@ wrapup with no errors or empty world sections.
 | Internal consistency | Creates contradictions with existing world state | Clean but minimal | Actively reinforces existing world coherence |
 | Actionability | Vague findings | Workable findings needing GM effort | Specific, staged findings ready for reconcile review |
 
-### C1 (existing 5-dimension rubric)
+### C1 (existing 5-dimensional rubric)
 
 Standard session-wrapup quality — complete recap, entity
 updates, timeline entries, carry-forward. No world-fact section


### PR DESCRIPTION
## Summary

- **World fact detection** — session-wrapup scans session notes for heritage references, place names, cultural practices, deity names, and other world facts using signal/noise heuristics
- **Reconcile step 2.5** — world fact review with three-state prompts (canon/ignore/defer) during post-session reconciliation
- **Reconcile step 5 world-rule validation** — checks entities against `_World/` rules during promotion to AUTHORITATIVE
- **Deferred flag accumulation** — mention counting and resurfacing for deferred world facts
- **Wrapup/reconcile benchmarks** — B1-B3, B5, C1 covering detection, accumulation, suppression, bootstrap, and regression

SP4 of the worldbuilding system (depends on SP1 #46, independent of SP2-SP3).

Also includes a roadmap entry and bug doc from another session (publish tool landing recap fix).

## Test plan

- [ ] Schema validation passes
- [ ] Markdown lint passes
- [ ] Session-wrapup 4c section integrates cleanly after 4b
- [ ] Reconcile step 2.5 sits correctly between steps 2 and 3
- [ ] Reconcile step 5 item 3b follows item 3
- [ ] Benchmark questions cover all five test scenarios