### PR TITLE
Add deferred flag surfacing and world consistency audits

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.4] — 2026-05-22
+
+### Added
+
+- **Session-prep deferred flag surfacing** — world threads
+  gaining traction are surfaced during prep (awareness only,
+  no prompts)
+- **Campaign-QA world consistency audits** — heritage
+  consistency, geographic plausibility, economic coherence,
+  timeline contradictions, and deferred flag review
+- **World audit criteria reference** — hard checks vs soft
+  checks, scoping rules, output format
+
+---
+
 ## [1.6.3] — 2026-05-22
 
 ### Added
@@ -680,6 +695,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.4]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.0...v1.6.1

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -244,15 +244,41 @@ for the full procedure.
   `asOfSession` is more than 1 session behind the latest
   wrap-up
 
+### World Consistency
+
+**Use when:** Checking entities against `_World/` domain rules.
+**Trigger phrases:** "world check", "world consistency",
+"heritage audit", "world rules"
+
+If `_World/` exists with active domain files, run world-rule
+audits against all entities. Read
+`references/world-audit-criteria.md` for check procedures.
+
+**What it checks:**
+- Heritage consistency — NPC/PC ages vs heritage lifespan
+  rules, heritage values vs allowed list
+- Geographic plausibility — locations vs geography domain
+  rules (if defined)
+- Economic coherence — factions/settlements with no economic
+  base (soft check)
+- Timeline contradictions — entity dates vs history-timeline
+  events and era ordering
+- Deferred flag review — all deferred items with mention
+  counts and session references
+
+Only checks domains with `status: active` and `rules`
+entries. Skip undefined domains — no false positives.
+
 ### Full Audit
 
 **Use when:** Running all checks in sequence.
 **Trigger phrases:** "full QA", "audit everything",
 "full check", "campaign health check"
 
-Runs all five modes in order: Canon Audit → Timeline
+Runs all six modes in order: Canon Audit → Timeline
 Validation → Name Similarity → Clue Redundancy → Graph
-Health. Deduplicates findings that appear in multiple checks.
+Health → World Consistency (if `_World/` exists).
+Deduplicates findings that appear in multiple checks.
 Produces a unified report.
 
 For full audits, present findings grouped by severity

--- a/skills/campaign-qa/references/world-audit-criteria.md
+++ b/skills/campaign-qa/references/world-audit-criteria.md
@@ -1,0 +1,46 @@
+# World Audit Criteria
+
+Audit checks for world consistency. Only fire when `_World/`
+exists with active domain files containing rules.
+
+## Hard Checks (clear right/wrong)
+
+| Check | Domain Source | Entity Types | What's Flagged |
+|-------|-------------|-------------|----------------|
+| Age exceeds heritage lifespan | heritages.md | npc, pc | NPC age > max lifespan for their heritage |
+| Unknown heritage | heritages.md | npc, pc | Heritage value not in allowed_values list |
+| Timeline contradiction | history-timeline.md | event, any with era | Event date contradicts era ordering |
+| Tech-level violation | magic-technology.md | item, location | Item or feature from wrong tech era |
+| Climate inconsistency | geography-climate.md | location | Location claims climate inconsistent with defined geography |
+
+**Output format:** "Inconsistency found — review needed."
+Reference the specific world rule being violated.
+
+## Soft Checks (questions, not errors)
+
+| Check | What's Flagged |
+|-------|----------------|
+| No economic base | Faction with no described revenue source or economic activity |
+| No water source | Settlement with no apparent water source or trade justification |
+| No heritage culture | Heritage entity with no described culture or societal structure |
+| Long-lived no-impact | Long-lived NPC with no explanation for how they've affected history |
+| Monoculture | Neighboring regions with identical cultures (planet-of-hats signal) |
+| Stasis signal | Historical period with no recorded change (medieval stasis signal) |
+
+**Output format:** "Question — worth considering." These are
+suggestions, not errors.
+
+## Deferred Flag Review
+
+Report all deferred items from `_flags.md` with mention counts
+and session references. Group by domain. Highlight items that
+meet resurfacing criteria (3+ sessions or 3+ mentions).
+
+## Scoping
+
+- Only run checks for domains with `status: active` files
+  containing `rules` entries
+- No false positives from undefined domains — if
+  `geography-climate.md` doesn't exist, skip geographic checks
+- Cross-reference each finding with `_flags.md` — if the topic
+  is already ignored, suppress the finding

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -116,6 +116,26 @@ those flagged in carry-forward or threads.
 Date, location, threats, factions, clocks.
 → Write `## World State` to Plan file.
 
+#### Step 10b: World threads
+
+If `_World/_flags.md` exists, read the **Deferred** section.
+Surface items gaining traction:
+
+> **World threads gaining traction:**
+> - "The Old Empire" — mentioned 3 times across sessions 3-5,
+>   still no detail. Worth a midwife worldbuilding session?
+> - "River spirits" — mentioned twice, possibly related to the
+>   Thornwood arc
+
+**Resurfacing criteria:**
+- Referenced in 3+ distinct sessions
+- 3+ mentions within a single session
+- Related to the upcoming adventure's themes or locations
+
+**Awareness only** — no three-state prompt. The GM decides
+whether to act. If they want to resolve, suggest a midwife
+worldbuilding conversation.
+
 If Reconcile ran, steps 7-10 read `## Reconciliation Context` and skip
 what's already established.
 

--- a/tests/benchmark-questions/worldbuilding-qa.md
+++ b/tests/benchmark-questions/worldbuilding-qa.md
@@ -13,7 +13,9 @@ Run session-prep for Session 3 of the Ashford Case campaign.
 The campaign has `_World/_flags.md` with one deferred item
 ("The Silver Twilight's true purpose" — 2 mentions across
 sessions 1-2). A Plan file exists for Session 3 referencing
-the docks investigation.
+the docks investigation. The deferred item is thematically
+relevant to the upcoming session, meeting the "related to
+upcoming adventure's themes" surfacing criterion.
 
 Verify the prep output includes the deferred flag awareness
 section without it dominating the prep. Existing prep quality

--- a/tests/benchmark-questions/worldbuilding-qa.md
+++ b/tests/benchmark-questions/worldbuilding-qa.md
@@ -1,0 +1,43 @@
+# Benchmark Questions — Worldbuilding (Prep + QA)
+
+**Skill:** session-prep, campaign-qa
+**Purpose:** Regression testing for prep and QA with world content
+**Runs:** 5 per variant, report median + IQR
+**Campaign data:** `tests/benchmark-campaign/`
+
+## Questions
+
+### C4 — Session-prep with deferred flags
+
+Run session-prep for Session 3 of the Ashford Case campaign.
+The campaign has `_World/_flags.md` with one deferred item
+("The Silver Twilight's true purpose" — 2 mentions across
+sessions 1-2). A Plan file exists for Session 3 referencing
+the docks investigation.
+
+Verify the prep output includes the deferred flag awareness
+section without it dominating the prep. Existing prep quality
+(threat assessment, NPC readiness, scene proposals) must be
+preserved.
+
+### C5 — Campaign-qa with world audits
+
+Run a Full Audit on the Ashford Case campaign at
+`tests/benchmark-campaign/`. The campaign has `_World/` with
+active `heritages.md` (human lifespan max 85) and `_flags.md`
+with one deferred and one ignored item.
+
+Verify that:
+- World consistency findings appear alongside existing audit
+  types (canon, timeline, graph health)
+- No false positives from undefined domains (only heritages
+  domain has rules)
+- Existing audit quality is unchanged
+- The ignored item is not flagged
+
+## Rubric (existing 5-dimensional rubric)
+
+Standard rubric for each skill. C4 tests that session-prep
+adds world-thread awareness without degrading prep quality.
+C5 tests that campaign-qa adds world audits without false
+positives or quality regression.


### PR DESCRIPTION
## Summary

- **Session-prep deferred flag surfacing** — Step 10b reads `_flags.md` deferred section and surfaces world threads gaining traction (3+ sessions or 3+ mentions) as awareness-only notes
- **Campaign-QA world consistency mode** — new sixth audit mode checking entities against `_World/` domain rules (heritage, geographic, economic, timeline checks)
- **World audit criteria reference** — hard checks vs soft checks, scoping rules, deferred flag review
- **Prep/QA benchmarks** — C4 (session-prep regression) and C5 (campaign-qa regression)

SP5 of the worldbuilding system (depends on SP1 #46, independent of SP2-SP4).

## Regression check

C4 (session-prep with deferred flags) benchmarked before/after — no regression, +1 on table-ready fiction. Deferred flag surfaced correctly as awareness-only.

## Test plan

- [ ] Schema validation passes
- [ ] Markdown lint passes
- [ ] C4 regression benchmark shows no quality drop (done — 14/15 → 15/15)
- [ ] Session-prep Step 10b inserts cleanly after Step 10
- [ ] Campaign-QA Full Audit updated from 5 to 6 modes
- [ ] World audit criteria scoping prevents false positives