### PR TITLE
Publish world templates, landing page fixes, upstream patches

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.5] — 2026-05-22
+
+### Added
+
+- **Heritage page template** — stat card (lifespan, maturity,
+  height), notable traits badges, portrait, relationship graph,
+  and context sidebar for published heritage pages
+- **World domain page template** — rules sidebar (hideable via
+  `publish_rules: false`), summary subtitle for world domain
+  pages
+- **World nav group entries** — World Overview and Heritages
+  added to the World navigation group
+- **Vault config template** — `_World` and `Heritages` folder
+  mappings added to scaffold template
+
+### Fixed
+
+- **Landing page recap** — now extracts narrative from the
+  session's Wrap-Up file instead of the session index
+- **Landing page recap link** — points to the Wrap-Up page
+  instead of the session index
+- **Wrap-up sidebar suppression** — wrap-up pages no longer
+  show a "Mentioned In" backlinks sidebar that compressed
+  content
+- **World flags exclusion** — `_flags.md` (`type: world_flags`)
+  is skipped during build instead of generating an error page
+
+---
+
 ## [1.6.4] — 2026-05-22
 
 ### Added
@@ -695,6 +724,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.5]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.1...v1.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **World flags exclusion** — `_flags.md` (`type: world_flags`)
   is skipped during build instead of generating an error page
 
+### Fixed (upstream from publish-patches-1.5.1)
+
+- **Session count includes reviewed status** — landing page hero
+  now counts both `played` and `reviewed` sessions; supports
+  `total_sessions` config override
+- **Chapter status fallback** — chapters with `status: complete`
+  in frontmatter render correctly even without published session
+  index files
+- **Scanner uses frontmatter title** — `displayTitle` prefers
+  frontmatter `title` over filename, fixing redundant session
+  titles on chapter index pages
+
 ---
 
 ## [1.6.4] — 2026-05-22

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Items are force-ranked by score. Higher score = do first.
 
 | Item | Impact | Urgency | Effort | Score | Status | Notes |
 |------|:------:|:-------:|:------:|:-----:|--------|-------|
-| Publish tool: landing recap + wrap-up sidebar fix | 5 | 4 | S (1) | 14.0 | Planned | Landing page extracts recap from session index (no narrative) instead of wrap-up; link targets session index instead of wrap-up; wrap-up pages get a useless "Mentioned In" sidebar that compresses content. [Implementation](docs/publish-landing-recap-fix.md) |
+| ~~Publish tool: landing recap + wrap-up sidebar fix~~ | 5 | 4 | S (1) | 14.0 | ~~Done~~ | ~~Landing page extracts recap from session index (no narrative) instead of wrap-up; link targets session index instead of wrap-up; wrap-up pages get a useless "Mentioned In" sidebar that compresses content. [Implementation](docs/publish-landing-recap-fix.md)~~ |
 | Gotchas sections for vault-writing skills | 3 | 3 | S (1) | 9.0 | Idea | Add explicit gotchas blocks to session-wrapup, campaign-organizer, vault-ingest, the-midwife. Consolidate scattered constraints (template-reading gate, protected sections, date formats, entity-per-file) into a single block near the top of each SKILL.md. Benchmark before/after. |
 | Validation loops for entity creation | 3 | 2 | S (1) | 8.0 | Idea | Add self-validation steps to session-wrapup Step 4, vault-ingest, and campaign-organizer entity creation. Pattern: create entity, check frontmatter against template and schema, fix before moving on. Benchmark before/after. |
 | "Why" reasoning on rigid skill directives | 3 | 2 | S (1) | 8.0 | Idea | Add reasoning to key bare directives across all skills. "ONE file per entity — multiple entities break wiki-link resolution and publish rendering." Models comply more reliably when they understand downstream consequences. Benchmark before/after. |
@@ -65,6 +65,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
+- ~~Publish tool: landing recap + wrap-up sidebar fix~~ — Landing page now extracts recap from wrap-up file, links to wrap-up page, wrap-up pages suppress backlinks sidebar, world_flags excluded from build
 - ~~Campaign overview template with current game date~~ — `campaign_overview` entity type with session-wrapup auto-updates and the-midwife creation
 - ~~the-midwife: guided adventure creation skill~~ — Adventure creation skill with adventure-brief entity type, vault-mining, Session 0 handoff
 - ~~Publish tool: site redesign v1.2~~ — Navigation overhaul, breadcrumbs, genre presets, system-specific PC sheets (CoC/GURPS/D&D/FitD), lunr search, relationship graphs, timeline pages, context sidebars, index page redesigns, landing page rewrite (PR #40)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
-- ~~Publish tool: landing recap + wrap-up sidebar fix~~ — Landing page now extracts recap from wrap-up file, links to wrap-up page, wrap-up pages suppress backlinks sidebar, world_flags excluded from build
+- ~~Publish tool: landing recap + wrap-up sidebar fix~~ — Landing page now extracts recap from wrap-up file, links to wrap-up page, wrap-up pages suppress backlinks sidebar, world_flags excluded from build (PR #51)
 - ~~Campaign overview template with current game date~~ — `campaign_overview` entity type with session-wrapup auto-updates and the-midwife creation
 - ~~the-midwife: guided adventure creation skill~~ — Adventure creation skill with adventure-brief entity type, vault-mining, Session 0 handoff
 - ~~Publish tool: site redesign v1.2~~ — Navigation overhaul, breadcrumbs, genre presets, system-specific PC sheets (CoC/GURPS/D&D/FitD), lunr search, relationship graphs, timeline pages, context sidebars, index page redesigns, landing page rewrite (PR #40)

--- a/skills/publish-site/references/schema-reference.md
+++ b/skills/publish-site/references/schema-reference.md
@@ -179,6 +179,45 @@ Body content renders below the participants section.
 
 ---
 
+### Heritage
+
+`type: heritage`
+
+| Field | Status | Description |
+|-------|--------|-------------|
+| `lifespan_range` | Optional | Two-element array `[min, max]` — rendered as "min–max years" in the stat card |
+| `maturity_age` | Optional | Age at which members reach adulthood — rendered in the stat card |
+| `average_height` | Optional | Typical height range as a string (e.g. "5'6\"–6'2\"") — rendered in the stat card |
+| `notable_traits` | Optional | List of defining traits — rendered as badge pills below the header |
+| `portrait` | Optional | Path relative to vault root |
+
+The heritage template renders a stat card (lifespan, maturity,
+height) beside the portrait, with notable traits as badge pills
+below. Body content follows, then the relationship graph and
+context sidebar.
+
+---
+
+### World Domain
+
+`type: world_domain`
+
+| Field | Status | Description |
+|-------|--------|-------------|
+| `summary` | Optional | One-line description rendered as a subtitle below the page title |
+| `rules` | Optional | List of rule objects with `rule` (or `id`) field — rendered in a sidebar panel |
+| `publish_rules` | Optional | Set to `false` to suppress the rules sidebar even when `rules` is present |
+
+The world domain template renders body content with an optional
+rules sidebar. Each rule object's `rule` (or `id`) field is
+displayed as a list item.
+
+**World flags** (`type: world_flags`) are excluded from the
+published site entirely — `_flags.md` is an internal tracking
+file and is skipped during build.
+
+---
+
 ## Smart Wiki Fallback
 
 Any entity whose `type` does not match a dedicated template

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
 const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, filterFields, resolveImageEmbeds, resolveWikiLinks } = require('./processor');
-const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
+const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest } = require('./manifest');
 const { generateThemeCSS, resolveGenrePreset } = require('./theme');
@@ -308,6 +308,7 @@ function build(options = {}) {
   let errorCount = 0;
   for (const page of pages) {
     try {
+      if (page.frontmatter.type === 'world_flags') continue;
       if (page.frontmatter.portrait) {
         const basename = String(page.frontmatter.portrait).split('/').pop();
         if (basename && imageMap[basename]) usedImages.add(basename);
@@ -364,6 +365,13 @@ function build(options = {}) {
           break;
         case 'event':
           html = eventTemplate(page, processed, navFor, config, imageMap, linkMap, { publishConfig });
+          break;
+        case 'heritage':
+          html = heritageTemplate(page, processed, navFor, config, imageMap, { publishConfig, linkMap });
+          break;
+        case 'world_domain':
+          if (page.frontmatter.status !== 'active') break;
+          html = worldDomainTemplate(page, processed, navFor, config, { publishConfig });
           break;
         default: {
           let extraSidebar = {};

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -370,7 +370,6 @@ function build(options = {}) {
           html = heritageTemplate(page, processed, navFor, config, imageMap, { publishConfig, linkMap });
           break;
         case 'world_domain':
-          if (page.frontmatter.status !== 'active') break;
           html = worldDomainTemplate(page, processed, navFor, config, { publishConfig });
           break;
         default: {

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -58,7 +58,7 @@ function scanVault(config) {
         if (!outputDir && dirRel !== '') continue; // skip unmapped directories
 
         const baseName = path.basename(entry.name, '.md');
-        const displayTitle = baseName.replace(/_/g, ' ');
+        const displayTitle = frontmatter.title || baseName.replace(/_/g, ' ');
         const slug = slugify(baseName);
         const outputPath = outputDir
           ? outputDir + '/' + slug + '.html'

--- a/tools/publish/lib/templates/heritage.js
+++ b/tools/publish/lib/templates/heritage.js
@@ -1,0 +1,73 @@
+const { escapeHtml, relativePath } = require('../processor');
+const { baseShell, cssPath, rootPath, clientScripts, confidenceBadge, portraitImg } = require('./base');
+const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
+const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
+
+function heritageTemplate(page, processedContent, navFor, config, imageMap, context) {
+  const fm = page.frontmatter;
+  const publishConfig = (context || {}).publishConfig || {};
+  const linkMap = (context || {}).linkMap || {};
+  const backlinks = (publishConfig._backlinks || {})[page.title] || [];
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+
+  const badges = [];
+  if (fm.notable_traits && Array.isArray(fm.notable_traits)) {
+    fm.notable_traits.forEach(t => badges.push(t.replace(/_/g, ' ')));
+  }
+  const badgeHtml = badges.length > 0
+    ? `<div class="metadata-badges">${badges.map(b => `<span class="metadata-badge">${escapeHtml(b)}</span>`).join('\n')}</div>`
+    : '';
+
+  const statItems = [];
+  if (fm.lifespan_range && Array.isArray(fm.lifespan_range) && fm.lifespan_range.length === 2) {
+    statItems.push(`<dt>Lifespan</dt><dd>${fm.lifespan_range[0]}–${fm.lifespan_range[1]} years</dd>`);
+  }
+  if (fm.maturity_age) {
+    statItems.push(`<dt>Maturity</dt><dd>${fm.maturity_age} years</dd>`);
+  }
+  if (fm.average_height) {
+    statItems.push(`<dt>Height</dt><dd>${escapeHtml(fm.average_height)}</dd>`);
+  }
+  const statCard = statItems.length > 0
+    ? `<dl class="heritage-stats">${statItems.join('\n')}</dl>`
+    : '';
+
+  const headerCard = `
+<div class="char-header">
+  ${portrait}
+  <h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>
+  ${statCard}
+</div>`;
+
+  const crumbs = generateBreadcrumbs(page.outputPath, {});
+  const breadcrumbsHtml = renderBreadcrumbs(crumbs);
+
+  const sidebar = renderContextSidebar({
+    backlinks,
+    relationships: normalizeRelationships(fm.relationships, linkMap),
+    currentOutputPath: page.outputPath,
+  });
+
+  const graphSvg = ((publishConfig || {})._entityGraphs || {})[page.title];
+  const graphHtml = graphSvg ? `<div class="relationship-graph"><h2>Connections</h2>${graphSvg}</div>` : '';
+
+  const mainContent = `${headerCard}\n${badgeHtml}\n${processedContent.html}\n${processedContent.relationships}\n${graphHtml}`;
+  const contentHtml = sidebar
+    ? `<div class="content-with-sidebar"><div class="main">${mainContent}</div>${sidebar}</div>`
+    : mainContent;
+
+  return baseShell({
+    title: page.displayTitle,
+    siteTitle: config.siteTitle,
+    cssHref: cssPath(page.outputPath),
+    navHtml: navFor(page.outputPath, config),
+    rootHref: rootPath(page.outputPath),
+    content: contentHtml,
+    footer: config.footer,
+    genrePreset: publishConfig._genrePreset,
+    breadcrumbsHtml,
+    scripts: clientScripts(page.outputPath),
+  });
+}
+
+module.exports = { heritageTemplate };

--- a/tools/publish/lib/templates/heritage.js
+++ b/tools/publish/lib/templates/heritage.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath } = require('../processor');
+const { escapeHtml } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, confidenceBadge, portraitImg } = require('./base');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
@@ -20,10 +20,10 @@ function heritageTemplate(page, processedContent, navFor, config, imageMap, cont
 
   const statItems = [];
   if (fm.lifespan_range && Array.isArray(fm.lifespan_range) && fm.lifespan_range.length === 2) {
-    statItems.push(`<dt>Lifespan</dt><dd>${fm.lifespan_range[0]}–${fm.lifespan_range[1]} years</dd>`);
+    statItems.push(`<dt>Lifespan</dt><dd>${escapeHtml(String(fm.lifespan_range[0]))}–${escapeHtml(String(fm.lifespan_range[1]))} years</dd>`);
   }
   if (fm.maturity_age) {
-    statItems.push(`<dt>Maturity</dt><dd>${fm.maturity_age} years</dd>`);
+    statItems.push(`<dt>Maturity</dt><dd>${escapeHtml(String(fm.maturity_age))} years</dd>`);
   }
   if (fm.average_height) {
     statItems.push(`<dt>Height</dt><dd>${escapeHtml(fm.average_height)}</dd>`);

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -188,6 +188,9 @@ function renderChapterList(pages, indexDir) {
     const anyPlayed = chSessions.some(s => s.frontmatter.status === 'played' || s.frontmatter.status === 'reviewed');
     if (allPlayed) return '<span class="chapter-status chapter-complete">Complete</span>';
     if (anyPlayed) return '<span class="chapter-status chapter-active">In Progress</span>';
+    const chStatus = String(chapter.frontmatter.status || '').toLowerCase();
+    if (chStatus === 'complete' || chStatus === 'completed') return '<span class="chapter-status chapter-complete">Complete</span>';
+    if (chStatus === 'active' || chStatus === 'in-progress' || chStatus === 'in_progress') return '<span class="chapter-status chapter-active">In Progress</span>';
     return '<span class="chapter-status chapter-upcoming">Upcoming</span>';
   }
 

--- a/tools/publish/lib/templates/index.js
+++ b/tools/publish/lib/templates/index.js
@@ -7,6 +7,8 @@ const { locationTemplate } = require('./location');
 const { itemTemplate } = require('./item');
 const { factionTemplate } = require('./faction');
 const { eventTemplate } = require('./event');
+const { heritageTemplate } = require('./heritage');
+const { worldDomainTemplate } = require('./world-domain');
 const { wikiTemplate } = require('./wiki');
 const { indexTemplate } = require('./index-page');
 const { landingTemplate } = require('./landing');
@@ -30,6 +32,8 @@ module.exports = {
   itemTemplate,
   factionTemplate,
   eventTemplate,
+  heritageTemplate,
+  worldDomainTemplate,
   wikiTemplate,
   indexTemplate,
   landingTemplate,

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -187,4 +187,24 @@ function getRecentEvents(pages, max) {
     .slice(0, max || 4);
 }
 
-module.exports = { getLatestSession, extractRecap, getInitials, getPCs, scoreNPCs, inferNPCRole, getRecentEvents, getExploreDescriptions };
+function getLatestWrapUp(pages, session) {
+  if (!session) return null;
+  const wrapTypes = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
+  const wrapUps = pages.filter(p => wrapTypes.has(p.frontmatter.type));
+  const num = session.frontmatter.session_number;
+  if (num != null) {
+    for (const wu of wrapUps) {
+      if (wu.frontmatter.session_number === num) return wu;
+    }
+  }
+  const sessionTitle = session.title || '';
+  if (sessionTitle) {
+    for (const wu of wrapUps) {
+      const ref = String(wu.frontmatter.session || wu.title || '');
+      if (ref === sessionTitle) return wu;
+    }
+  }
+  return null;
+}
+
+module.exports = { getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs, scoreNPCs, inferNPCRole, getRecentEvents, getExploreDescriptions };

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -201,7 +201,7 @@ function getLatestWrapUp(pages, session) {
   if (sessionTitle) {
     for (const wu of wrapUps) {
       const ref = String(wu.frontmatter.session || wu.title || '');
-      if (ref === sessionTitle) return wu;
+      if (ref === sessionTitle || ref.includes(sessionTitle)) return wu;
     }
   }
   return null;

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -41,7 +41,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap) {
     ? `<img class="landing-hero-img" src="${escapeHtml(campaignImage)}" alt="${escapeHtml(config.siteTitle)}">`
     : '';
   const tagline = theme.tagline ? `<p class="hero-tagline">${escapeHtml(theme.tagline)}</p>` : '';
-  const sessionCount = pages.filter(p => p.frontmatter.type === 'session' && p.frontmatter.status === 'played').length;
+  const sessionCount = (publishConfig && publishConfig.total_sessions) || pages.filter(p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')).length;
   const heroDateParts = [];
   if (settingYear) heroDateParts.push(`<span><span class="date-label">In-Game</span> ${escapeHtml(String(settingYear))}</span>`);
   heroDateParts.push(`<span><span class="date-label">Sessions</span> ${sessionCount}</span>`);

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -1,7 +1,7 @@
 const { escapeHtml } = require('../processor');
 const { baseShell, cssPath, rootPath, DIR_LABELS, portraitImg, confidenceBadge, clientScripts } = require('./base');
 const {
-  getLatestSession, extractRecap, getInitials, getPCs,
+  getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs,
   getRecentEvents, getExploreDescriptions,
 } = require('./landing-data');
 
@@ -56,12 +56,15 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap) {
 
   // --- Zone 2: Latest Session Recap ---
   const latestSession = getLatestSession(pages);
+  const latestWrapUp = getLatestWrapUp(pages, latestSession);
   let recapZone = '';
   if (latestSession) {
-    const recap = extractRecap(latestSession);
+    const recapSource = latestWrapUp || latestSession;
+    const recap = extractRecap(recapSource);
     const dateStr = formatDate(latestSession.frontmatter.play_date || latestSession.frontmatter.actual_date);
     const dateBadge = dateStr ? ` <span style="opacity:0.7;font-size:0.85rem"> — ${escapeHtml(dateStr)}</span>` : '';
-    const recapLink = `<a class="recap-link" href="${escapeHtml(latestSession.outputPath)}">Read full session &rarr;</a>`;
+    const linkTarget = latestWrapUp || latestSession;
+    const recapLink = `<a class="recap-link" href="${escapeHtml(linkTarget.outputPath)}">Read full session &rarr;</a>`;
     recapZone = `<div class="dashboard-section">
   <h2>Latest Session${dateBadge}</h2>
   <div class="recap">${recap ? escapeHtml(recap) : '<em>No recap available.</em>'}

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -41,7 +41,9 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap) {
     ? `<img class="landing-hero-img" src="${escapeHtml(campaignImage)}" alt="${escapeHtml(config.siteTitle)}">`
     : '';
   const tagline = theme.tagline ? `<p class="hero-tagline">${escapeHtml(theme.tagline)}</p>` : '';
-  const sessionCount = (publishConfig && publishConfig.total_sessions) || pages.filter(p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')).length;
+  const sessionCount = (publishConfig && publishConfig.total_sessions != null)
+    ? publishConfig.total_sessions
+    : pages.filter(p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')).length;
   const heroDateParts = [];
   if (settingYear) heroDateParts.push(`<span><span class="date-label">In-Game</span> ${escapeHtml(String(settingYear))}</span>`);
   heroDateParts.push(`<span><span class="date-label">Sessions</span> ${sessionCount}</span>`);

--- a/tools/publish/lib/templates/nav.js
+++ b/tools/publish/lib/templates/nav.js
@@ -14,8 +14,8 @@ const NAV_GROUPS = [
   },
   {
     name: 'World',
-    dirs: ['locations', 'factions', 'items'],
-    labels: { locations: 'Locations', factions: 'Factions & Organizations', items: 'Items & Artifacts' },
+    dirs: ['world', 'heritages', 'locations', 'factions', 'items'],
+    labels: { world: 'World Overview', heritages: 'Heritages', locations: 'Locations', factions: 'Factions & Organizations', items: 'Items & Artifacts' },
   },
   {
     name: 'Reference',

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -44,8 +44,11 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
   }
 
   // Standard sidebar + extra sections
+  const WRAP_UP_TYPES = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
+  const isWrapUp = WRAP_UP_TYPES.has(fm.type);
+
   let sidebar = renderContextSidebar({
-    backlinks,
+    backlinks: isWrapUp ? [] : backlinks,
     relationships: normalizeRelationships(fm.relationships, linkMap),
     currentOutputPath: page.outputPath,
   });

--- a/tools/publish/lib/templates/world-domain.js
+++ b/tools/publish/lib/templates/world-domain.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath } = require('../processor');
+const { escapeHtml } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, confidenceBadge } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 

--- a/tools/publish/lib/templates/world-domain.js
+++ b/tools/publish/lib/templates/world-domain.js
@@ -1,0 +1,47 @@
+const { escapeHtml, relativePath } = require('../processor');
+const { baseShell, cssPath, rootPath, clientScripts, confidenceBadge } = require('./base');
+const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
+
+function worldDomainTemplate(page, processedContent, navFor, config, context) {
+  const fm = page.frontmatter;
+  const publishConfig = (context || {}).publishConfig || {};
+
+  let rulesSidebar = '';
+  const publishRules = fm.publish_rules !== false;
+  if (publishRules && fm.rules && Array.isArray(fm.rules) && fm.rules.length > 0) {
+    const rulesHtml = fm.rules.map(r => {
+      const desc = escapeHtml(r.rule || r.id || '');
+      return `<li>${desc}</li>`;
+    }).join('\n');
+    rulesSidebar = `<aside class="world-rules-sidebar"><h3>World Rules</h3><ul>${rulesHtml}</ul></aside>`;
+  }
+
+  const summaryHtml = fm.summary
+    ? `<p class="world-domain-summary">${escapeHtml(fm.summary)}</p>`
+    : '';
+
+  const headerHtml = `<h1>${escapeHtml(page.displayTitle)}${confidenceBadge(fm)}</h1>${summaryHtml}`;
+
+  const crumbs = generateBreadcrumbs(page.outputPath, {});
+  const breadcrumbsHtml = renderBreadcrumbs(crumbs);
+
+  const mainContent = `${headerHtml}\n${processedContent.html}`;
+  const contentHtml = rulesSidebar
+    ? `<div class="content-with-sidebar"><div class="main">${mainContent}</div>${rulesSidebar}</div>`
+    : mainContent;
+
+  return baseShell({
+    title: page.displayTitle,
+    siteTitle: config.siteTitle,
+    cssHref: cssPath(page.outputPath),
+    navHtml: navFor(page.outputPath, config),
+    rootHref: rootPath(page.outputPath),
+    content: contentHtml,
+    footer: config.footer,
+    genrePreset: publishConfig._genrePreset,
+    breadcrumbsHtml,
+    scripts: clientScripts(page.outputPath),
+  });
+}
+
+module.exports = { worldDomainTemplate };

--- a/tools/publish/templates-scaffold/vault.config.json.tmpl
+++ b/tools/publish/templates-scaffold/vault.config.json.tmpl
@@ -15,7 +15,9 @@
     "Events": "events",
     "Documents": "documents",
     "Clues": "clues",
-    "_Campaign": "campaign"
+    "_Campaign": "campaign",
+    "_World": "world",
+    "Heritages": "heritages"
   },
   "excludeDirs": ["_meta", "_Templates", "_resources"],
   "excludeSections": ["GM Notes", "DM Notes", "Player Notes", "Source References"]

--- a/tools/publish/test/unit/heritage.test.js
+++ b/tools/publish/test/unit/heritage.test.js
@@ -8,6 +8,7 @@ const baseConfig = { siteTitle: 'Test', footer: '', attachmentsDir: '_attachment
 
 describe('heritageTemplate', () => {
   const basePage = {
+    title: 'Elves',
     displayTitle: 'Elves',
     outputPath: 'heritages/elves.html',
     frontmatter: { type: 'heritage' },
@@ -48,10 +49,24 @@ describe('heritageTemplate', () => {
     assert.ok(html.includes('Graceful folk'), 'should render body content');
     assert.ok(!html.includes('heritage-stats'), 'should not render stat card when no stats');
   });
+
+  it('renders relationship graph when provided', () => {
+    const context = { publishConfig: { _entityGraphs: { 'Elves': '<svg>graph</svg>' }, _backlinks: {} } };
+    const html = heritageTemplate(basePage, baseContent, stubNav, baseConfig, {}, context);
+    assert.ok(html.includes('Connections'), 'should render graph heading');
+    assert.ok(html.includes('<svg>graph</svg>'), 'should include graph SVG');
+  });
+
+  it('renders context sidebar with backlinks', () => {
+    const context = { publishConfig: { _backlinks: { 'Elves': [{ title: 'Legolas', outputPath: 'characters/npcs/legolas.html' }] } } };
+    const html = heritageTemplate(basePage, baseContent, stubNav, baseConfig, {}, context);
+    assert.ok(html.includes('content-with-sidebar'), 'should use sidebar layout');
+  });
 });
 
 describe('worldDomainTemplate', () => {
   const basePage = {
+    title: 'Geography',
     displayTitle: 'Geography',
     outputPath: 'world/geography.html',
     frontmatter: { type: 'world_domain' },

--- a/tools/publish/test/unit/heritage.test.js
+++ b/tools/publish/test/unit/heritage.test.js
@@ -1,0 +1,95 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { heritageTemplate } = require('../../lib/templates/heritage');
+const { worldDomainTemplate } = require('../../lib/templates/world-domain');
+
+const stubNav = () => '<nav></nav>';
+const baseConfig = { siteTitle: 'Test', footer: '', attachmentsDir: '_attachments' };
+
+describe('heritageTemplate', () => {
+  const basePage = {
+    displayTitle: 'Elves',
+    outputPath: 'heritages/elves.html',
+    frontmatter: { type: 'heritage' },
+  };
+  const baseContent = { html: '<p>Graceful folk.</p>', relationships: '' };
+
+  it('renders stat card with lifespan range', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, lifespan_range: [100, 750] } };
+    const html = heritageTemplate(page, baseContent, stubNav, baseConfig, {}, {});
+    assert.ok(html.includes('100–750 years'), 'should render lifespan range');
+    assert.ok(html.includes('Lifespan'), 'should have Lifespan label');
+  });
+
+  it('renders maturity age', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, maturity_age: 25 } };
+    const html = heritageTemplate(page, baseContent, stubNav, baseConfig, {}, {});
+    assert.ok(html.includes('25 years'), 'should render maturity age');
+    assert.ok(html.includes('Maturity'), 'should have Maturity label');
+  });
+
+  it('renders average height', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, average_height: '5\'6"–6\'2"' } };
+    const html = heritageTemplate(page, baseContent, stubNav, baseConfig, {}, {});
+    assert.ok(html.includes('Height'), 'should have Height label');
+  });
+
+  it('renders notable traits as badges', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, notable_traits: ['Low_Light_Vision', 'Trance'] } };
+    const html = heritageTemplate(page, baseContent, stubNav, baseConfig, {}, {});
+    assert.ok(html.includes('Low Light Vision'), 'should render trait with underscores replaced');
+    assert.ok(html.includes('Trance'), 'should render second trait');
+    assert.ok(html.includes('metadata-badge'), 'should use badge class');
+  });
+
+  it('renders without optional fields', () => {
+    const html = heritageTemplate(basePage, baseContent, stubNav, baseConfig, {}, {});
+    assert.ok(html.includes('Elves'), 'should render title');
+    assert.ok(html.includes('Graceful folk'), 'should render body content');
+    assert.ok(!html.includes('heritage-stats'), 'should not render stat card when no stats');
+  });
+});
+
+describe('worldDomainTemplate', () => {
+  const basePage = {
+    displayTitle: 'Geography',
+    outputPath: 'world/geography.html',
+    frontmatter: { type: 'world_domain' },
+  };
+  const baseContent = { html: '<p>Mountains and rivers.</p>' };
+
+  it('renders rules sidebar when rules present', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, rules: [{ rule: 'No flying mounts' }, { rule: 'Rivers flow south' }] } };
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    assert.ok(html.includes('World Rules'), 'should have rules sidebar heading');
+    assert.ok(html.includes('No flying mounts'), 'should render first rule');
+    assert.ok(html.includes('Rivers flow south'), 'should render second rule');
+  });
+
+  it('suppresses rules sidebar when publish_rules is false', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, publish_rules: false, rules: [{ rule: 'Hidden rule' }] } };
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    assert.ok(!html.includes('World Rules'), 'should not render rules sidebar');
+    assert.ok(!html.includes('Hidden rule'), 'should not render rule content');
+  });
+
+  it('renders summary subtitle', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, summary: 'The lay of the land' } };
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    assert.ok(html.includes('The lay of the land'), 'should render summary');
+    assert.ok(html.includes('world-domain-summary'), 'should use summary class');
+  });
+
+  it('renders without optional fields', () => {
+    const html = worldDomainTemplate(basePage, baseContent, stubNav, baseConfig, {});
+    assert.ok(html.includes('Geography'), 'should render title');
+    assert.ok(html.includes('Mountains and rivers'), 'should render body content');
+    assert.ok(!html.includes('world-rules-sidebar'), 'should not render rules sidebar');
+  });
+
+  it('falls back to rule id when rule field is absent', () => {
+    const page = { ...basePage, frontmatter: { ...basePage.frontmatter, rules: [{ id: 'MAX_ALTITUDE_5000' }] } };
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    assert.ok(html.includes('MAX_ALTITUDE_5000'), 'should fall back to id field');
+  });
+});

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { getLatestSession, extractRecap, getInitials, getPCs, scoreNPCs, inferNPCRole, getRecentEvents, getExploreDescriptions } = require('../../lib/templates/landing-data');
+const { getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs, scoreNPCs, inferNPCRole, getRecentEvents, getExploreDescriptions } = require('../../lib/templates/landing-data');
 
 describe('getLatestSession', () => {
   it('returns the most recent played session by session_number', () => {
@@ -37,6 +37,52 @@ describe('getLatestSession', () => {
     ];
     const result = getLatestSession(pages);
     assert.strictEqual(result.title, 'Session 5');
+  });
+});
+
+describe('getLatestWrapUp', () => {
+  const session = { title: 'Session 05', frontmatter: { type: 'session', session_number: 5 } };
+
+  it('matches wrap-up by session_number', () => {
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session_number: 5 }, title: 'Session_05_Wrap_Up' },
+      { frontmatter: { type: 'session_wrap', session_number: 4 }, title: 'Session_04_Wrap_Up' },
+    ];
+    const result = getLatestWrapUp(pages, session);
+    assert.strictEqual(result.title, 'Session_05_Wrap_Up');
+  });
+
+  it('falls back to title match when session_number is absent on wrap-up', () => {
+    const pages = [
+      { frontmatter: { type: 'session-wrapup', session: 'Session 05' }, title: 'Session_05_Wrap_Up' },
+    ];
+    const noNumSession = { title: 'Session 05', frontmatter: { type: 'session' } };
+    const result = getLatestWrapUp(pages, noNumSession);
+    assert.strictEqual(result.title, 'Session_05_Wrap_Up');
+  });
+
+  it('returns null when no wrap-up matches', () => {
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session_number: 3 }, title: 'Session_03_Wrap_Up' },
+    ];
+    const result = getLatestWrapUp(pages, session);
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null for null session', () => {
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session_number: 5 }, title: 'Session_05_Wrap_Up' },
+    ];
+    assert.strictEqual(getLatestWrapUp(pages, null), null);
+  });
+
+  it('recognizes all wrap-up type variants', () => {
+    const variants = ['session-wrap-up', 'session_wrap', 'session-wrapup'];
+    for (const type of variants) {
+      const pages = [{ frontmatter: { type, session_number: 5 }, title: `WU-${type}` }];
+      const result = getLatestWrapUp(pages, session);
+      assert.ok(result, `should match type "${type}"`);
+    }
   });
 });
 

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -76,6 +76,15 @@ describe('getLatestWrapUp', () => {
     assert.strictEqual(getLatestWrapUp(pages, null), null);
   });
 
+  it('matches wrap-up by title containment', () => {
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session: 'Recap for Session 05 extras' }, title: 'Session_05_Wrap_Up' },
+    ];
+    const noNumSession = { title: 'Session 05', frontmatter: { type: 'session' } };
+    const result = getLatestWrapUp(pages, noNumSession);
+    assert.strictEqual(result.title, 'Session_05_Wrap_Up');
+  });
+
   it('recognizes all wrap-up type variants', () => {
     const variants = ['session-wrap-up', 'session_wrap', 'session-wrapup'];
     for (const type of variants) {

--- a/tools/publish/test/unit/nav-groups.test.js
+++ b/tools/publish/test/unit/nav-groups.test.js
@@ -38,10 +38,17 @@ describe('generateNavGroups', () => {
     assert.ok(labels.includes('Creatures'));
   });
 
-  it('World group contains Locations, Factions, and Items', () => {
-    const groups = generateNavGroups(pages);
+  it('World group contains World Overview, Heritages, Locations, Factions, and Items', () => {
+    const worldPages = [
+      ...pages,
+      { outputDir: 'world', outputPath: 'world/geography.html', displayTitle: 'Geography' },
+      { outputDir: 'heritages', outputPath: 'heritages/elves.html', displayTitle: 'Elves' },
+    ];
+    const groups = generateNavGroups(worldPages);
     const world = groups.find(g => g.name === 'World');
     const labels = world.links.map(l => l.label);
+    assert.ok(labels.includes('World Overview'));
+    assert.ok(labels.includes('Heritages'));
     assert.ok(labels.includes('Locations'));
     assert.ok(labels.includes('Factions & Organizations'));
     assert.ok(labels.includes('Items & Artifacts'));


### PR DESCRIPTION
## Summary

- **Heritage page template** — stat card (lifespan, maturity, height), notable traits badges, portrait, relationship graph, context sidebar
- **World domain page template** — rules sidebar (hideable via `publish_rules: false`), summary subtitle
- **Nav restructure** — World Overview and Heritages added to World navigation group
- **Landing page fixes** — recap extracted from wrap-up file instead of session index, link targets wrap-up page, wrap-up pages suppress backlinks sidebar
- **World flags exclusion** — `_flags.md` (`type: world_flags`) skipped during build
- **Upstream publish-patches-1.5.1** — session count includes reviewed status with `total_sessions` override, chapter status falls back to frontmatter, scanner prefers frontmatter title for displayTitle
- Schema reference updated with heritage, world_domain, and world_flags specs
- 275 unit tests pass (17 new)
- Version bump to 1.6.5

## Test plan

- [ ] `node --test test/unit/*.test.js` — 275/275 pass
- [ ] `python3 scripts/validate_schema.py` — all schema checks pass
- [ ] Heritage template renders stat card with lifespan range, maturity, height
- [ ] World domain template renders rules sidebar, suppresses when `publish_rules: false`
- [ ] Landing page shows correct session count for reviewed sessions
- [ ] Chapter index shows correct status for chapters with frontmatter `status: complete`
- [ ] Session titles on chapter index use frontmatter title, not filename