### PR TITLE
Integrate world-evolution into reconcile as step 5.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.6] — 2026-05-28
+
+### Added
+
+- **World evolution in reconcile** — reconcile step 5.5
+  offers faction turns, consequence surfacing, foreshadowing
+  review, and discovery state updates after session confidence
+  is promoted. Gated to most recent session only.
+- **`world-evolution` entity source** — entities created by
+  the world-evolution procedure are tagged with
+  `source: "world-evolution"` for provenance tracking
+- **`world_evolved` session field** — session index records
+  when world-evolution has run, preventing duplicate offers
+
+### Removed
+
+- **campaign-tracker.md references** — removed dead reference
+  from campaign-organizer. The file was never created; its
+  functionality is covered by the entity schema and session
+  document chain.
+- **Tracking templates** — replaced consequence tracker,
+  foreshadowing log, campaign tracker, and per-PC discovery
+  state templates in world-evolution.md with a pointer to the
+  entity schema where these are now tracked
+
+### Changed
+
+- **world-evolution.md** — Storage Checkpoint and timeline
+  entry marked standalone-only (reconcile skips both). Filing
+  protocol updated for reconcile handoff.
+
 ## [1.6.5] — 2026-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -767,6 +767,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.6.6]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.5...v1.6.6
 [1.6.5]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.2...v1.6.3

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -150,11 +150,6 @@ and clues, and thread entity fields, read
 entities.** Do not delete temporal tracking or world state
 fields during Organize or Weave passes.
 
-**campaign-tracker.md** may exist at the vault root with
-consequence logs, foreshadowing logs, world state snapshots,
-and rumour boards. Do not reorganise this file — it is
-updated by the world-evolution procedure.
-
 **Campaign-timeline.md** may exist at the vault root as an
 append-only session-by-session record of what happened. Do
 not reorganise or edit past entries — the timeline is the

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -22,7 +22,7 @@ Apply to **every** entity type. Enable temporal queries
 | lastUpdated | string | Session number or date of last modification |
 | asOfSession | string | Session when current state was confirmed accurate |
 | createdSession | string | Session when first introduced |
-| source | string | How it entered canon: "play", "prep", or "backstory" |
+| source | string | How it entered canon: "play", "prep", "backstory", or "world-evolution" |
 | confidence | string | Canon confidence: DRAFT / AUTHORITATIVE / SUPERSEDED |
 | era | string | Optional: named era from `_World/history-timeline.md` (e.g., "Second Age"). Assumed campaign present if absent. |
 

--- a/skills/shared/reconcile.md
+++ b/skills/shared/reconcile.md
@@ -42,7 +42,7 @@ On GM confirmation:
 - Set Wrap-Up `source_confidence` to `AUTHORITATIVE`
 - Promote all DRAFT entities from this session to AUTHORITATIVE
 - Update session index `status` to `reviewed`
-- Skip to step 6 (record decisions)
+- Skip to step 5.5 (world evolution offer)
 
 If any condition fails → proceed with the full 6-step procedure
 below.

--- a/skills/shared/reconcile.md
+++ b/skills/shared/reconcile.md
@@ -141,6 +141,41 @@ Do the bookkeeping immediately — don't leave a list for
 the GM. Hand off to campaign-organizer if entity filing
 is needed.
 
+### 5.5. World evolution (conditional)
+
+**Gate:** Only offer when reconciling the **most recent**
+session. Check the session index for a `world_evolved` field
+— if present and matching this session, skip.
+
+> "Session is settled. Want to evolve the world — faction
+> turns, consequence surfacing, foreshadowing review? This
+> updates how the world responds to what just happened. (y/n)"
+
+If the GM declines → skip to step 6.
+
+If the GM accepts → read and follow
+`ttrpg-expert/world-evolution.md`, skipping the Storage
+Checkpoint (already established). Run the 6-step procedure:
+thread state updates, faction turns, consequence surfacing,
+foreshadowing review, discovery state updates, world state
+changes. One item at a time, GM approves each — same
+conversational style as the rest of reconcile.
+
+**On completion:**
+- Set `world_evolved: "Session_NN"` on the session index
+  (current session reference)
+- Entity files created or updated use
+  `source: "world-evolution"`, with `lastUpdated` and
+  `asOfSession` set to the current session
+- Results feed into step 6's `## Reconciliation Context`
+  under `### World Evolution`, containing:
+  - Faction turn summaries (one line per faction: action,
+    impact level, what's visible to PCs)
+  - Surfaced consequences (trigger, manifestation)
+  - Foreshadowing changes (ripeness updates, new plants)
+  - Discovery state changes (per-PC knowledge shifts)
+  - World state changes (calendar, environment, politics)
+
 ### 6. Record decisions
 
 Write a `## Reconciliation Context` section capturing:
@@ -149,6 +184,10 @@ Write a `## Reconciliation Context` section capturing:
   play notes, no invention)
 - **Salvageable prep** — disposition of each unplayed item
 - **GM decisions** — each conflict resolution with rationale
+- **World evolution** — if step 5.5 ran, include a
+  `### World Evolution` sub-section with faction turn
+  summaries, surfaced consequences, foreshadowing and
+  discovery state changes, and world state updates
 
 This section provides cross-conversation continuity.
 Session-prep reads it to avoid re-gathering context.
@@ -178,3 +217,6 @@ file is the canonical location.
 - `shared/session-principles.md` — Shared session rules
 - `ttrpg-expert/canon-management.md` — Full conflict
   detection and resolution workflow
+- `ttrpg-expert/world-evolution.md` — Post-session world
+  evolution procedure (faction turns, consequences,
+  foreshadowing, discovery state)

--- a/skills/shared/session-document-chain.md
+++ b/skills/shared/session-document-chain.md
@@ -25,6 +25,7 @@ documents:
   wrap_up: "[[Session_NN_Wrap_Up]]"
 scenes:
   - "[[Scene Title]]"
+world_evolved: null
 tags: []
 ---
 ```
@@ -46,6 +47,12 @@ metadata.
 | played | Play Notes file exists |
 | wrap-up | Wrap-Up file exists |
 | reviewed | GM has reviewed and confirmed the Wrap-Up |
+
+**`world_evolved`:** Set by reconcile step 5.5 after the
+world-evolution procedure completes. Value is the session
+reference (e.g., `"Session_07"`). Null until world-evolution
+runs. Prevents reconcile from re-offering world-evolution
+for the same session.
 
 ### 2. Session Plan (`Session {NN} - {Title} - Plan.md`)
 

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -111,7 +111,10 @@ Set `source: "world-evolution"`, `createdSession`, `lastUpdated`,
 **Changed entities:** update changed fields only. Set
 `lastUpdated` and `asOfSession`.
 
-**Timeline entry** — append to `campaign-timeline.md`:
+**Timeline entry (standalone only)** — when invoked outside
+reconcile, append to `campaign-timeline.md`. Skip when
+invoked from reconcile — session-wrapup already wrote the
+session's timeline entry.
 
 ```markdown
 ## Session [N] — [date]

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -4,6 +4,11 @@ The world does not wait for the PCs. Between sessions, factions
 advance plans, consequences ripen, rumours spread, and the
 calendar turns. Run this procedure after every session.
 
+**Invocation:** This procedure normally runs as reconcile
+step 5.5 — offered to the GM after session confidence is
+promoted. It can also be invoked standalone via ttrpg-expert
+("update the world" / "post-session update").
+
 > "Every antagonist faction has a plan that advances whether
 > the PCs act or not. The PCs don't start the story — they
 > *interrupt* it."
@@ -28,9 +33,12 @@ visible to the GM before it becomes canon.
 - **Match system tone.** CoC: creeping dread. FitD: noir crime.
   D&D: living political/adventure landscape.
 
-## Storage Checkpoint
+## Storage Checkpoint (standalone only)
 
-Before the first update, determine where campaign state lives:
+Skip this step when invoked from reconcile — the vault
+location is already established.
+
+When invoked standalone, determine where campaign state lives:
 
 1. **campaign-organizer** (recommended if vault exists)
 2. **Set up campaign-organizer now** — pause, configure, return
@@ -97,7 +105,7 @@ or rejects each. Then execute the filing protocol.
 ### Filing Protocol
 
 **New entities:** create file per `shared/entity-schema.md` schema.
-Set `source: "play"`, `createdSession`, `lastUpdated`,
+Set `source: "world-evolution"`, `createdSession`, `lastUpdated`,
 `asOfSession` to current session.
 
 **Changed entities:** update changed fields only. Set
@@ -123,6 +131,11 @@ Set `source: "play"`, `createdSession`, `lastUpdated`,
 
 After filing: "Updates filed. Run campaign-qa to validate,
 or proceed to session prep?"
+
+**When invoked from reconcile:** skip this prompt — results
+flow into reconcile step 6's `## Reconciliation Context`
+under `### World Evolution`. Set `world_evolved` on the
+session index to the current session reference.
 
 ## Universal Faction Turn
 

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -62,7 +62,7 @@ System-specific modules override when available:
 
 ### Step 3: Consequence Surfacing
 
-Review the Consequence Tracker. For each deferred consequence:
+Review carry-forward items and active threads. For each deferred consequence:
 has enough time passed? Does the current situation make surfacing
 natural? Manifests as event, NPC reaction, environmental change,
 or rumour?
@@ -145,54 +145,18 @@ Five questions per active faction:
 5. **What becomes visible to PCs?** Directly, through allies,
    through rumour, or not at all.
 
-## Tracking Templates
+## Tracking State
 
-### Consequence Tracker
+Consequences, foreshadowing, and discovery state are tracked
+via the entity schema — not standalone files. See
+`shared/entity-schema.md` for:
 
-```markdown
-| # | Action | Deferred Consequence | Surfaces In | Manifests As | Status |
-|---|--------|---------------------|-------------|-------------|--------|
-```
+- **Thread entities** with `threadType: "Foreshadowing"`,
+  `plantedDetail`, `intendedPayoff`, `ripeness`
+- **Clue entities** with `discoveryState` (per-PC knowledge
+  levels: Unknown → Rumoured → Observed → Investigated →
+  Understood)
 
-Status: Pending → Surfaced → Spent. Also: Banked (available
-when narratively useful).
-
-### Foreshadowing Log
-
-```markdown
-| # | Planted | Element | Noticed By | Intended Payoff | Ripeness | Pay Off By |
-|---|---------|---------|------------|-----------------|----------|------------|
-```
-
-Ripeness 1/5 (barely hinted) to 5/5 (payoff imminent). At 5/5,
-deliver next session or impact fades.
-
-### Campaign Tracker
-
-```markdown
-## Campaign Tracker
-**Campaign:**  **System:**  **Session Count:**
-**Current In-World Date:**
-
-### World State Snapshot
-[2-3 sentence current state as PCs know it]
-
-### Active Consequences
-[Pending/Banked entries with expected surface session]
-
-### Active Foreshadowing
-[Entries not yet paid off, with ripeness and target]
-
-### Rumour Board
-[Current rumours — mark True, Partially True, or False]
-```
-
-### Per-PC Discovery State
-
-```markdown
-## Discovery State: [Clue/Secret Name]
-| PC | Level | Changed | How |
-|----|-------|---------|-----|
-```
-
-Levels: Unknown, Rumoured, Observed, Investigated, Understood.
+Consequences surface through session-wrapup's carry-forward
+section and session-prep's thread review. World state snapshots
+are maintained in the Wrap-Up → Plan handoff chain.


### PR DESCRIPTION
## Summary

- Adds reconcile step 5.5: after session confidence is promoted, offer the GM faction turns, consequence surfacing, foreshadowing review, and discovery state updates
- Gated to most recent session only (vault-ingest and old-session reviews skip it). Tracks completion via `world_evolved` field on session index
- Removes dead `campaign-tracker.md` references — the file was never created; its functionality is covered by the entity schema and session document chain
- Adds `"world-evolution"` as a valid entity `source` value for provenance tracking

## Changes

| File | What |
|------|------|
| `shared/reconcile.md` | New step 5.5 with gate logic, fast-path routes through it |
| `ttrpg-expert/world-evolution.md` | Invocation context note, Storage Checkpoint and timeline entry marked standalone-only, source field updated, reconcile handoff |
| `shared/entity-schema.md` | `"world-evolution"` added to source field |
| `shared/session-document-chain.md` | `world_evolved` field added to session index schema |
| `campaign-organizer/SKILL.md` | Removed dead campaign-tracker.md paragraph |
| `.claude-plugin/plugin.json` | v1.6.6 |
| `CHANGELOG.md` | v1.6.6 entry |

## Test plan

- [x] `python3 scripts/validate_schema.py` — 41 files, all passed
- [x] `markdownlint-cli2` — 0 errors on all changed files
- [x] Relative path validation — no broken references
- [x] Cross-reference check — all files referenced by reconcile and world-evolution exist
- [x] Field consistency — `source: "world-evolution"` and `world_evolved` consistent across files
- [x] `build-skill-zips.sh` — 9 valid zips produced