### PR TITLE
Add narrative planning layer to vault

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.7.0] — 2026-05-30
+
+### Added
+
+- **Plan entity type** — new `plan` entity under `narrative`
+  hierarchy with `plan_type` discriminator (arc, scene,
+  investigation, timeline). Plans live in `Planning/` under
+  their chapter directory, capturing the GM's narrative
+  planning content (scene designs, arc structures,
+  investigation flows, timelines) as first-class vault entities.
+- **Plan template** — `skills/shared/templates/plan.md` added
+  as canonical template for plan entities
+- **Midwife plan promotion** — Phase 4 handoff now promotes
+  narrative planning content from `_midwife/` to vault
+  `Planning/` folder alongside existing entity promotion
+- **Session prep plan surfacing** — context gathering reads
+  `Planning/` and surfaces relevant scene plans for the
+  upcoming session
+- **Session play plan lookup** — scene plans accessible via
+  mid-game routing table
+- **Campaign QA plan validation** — graph health checks
+  validate plan entity frontmatter and references
+- **Vault ingest plan support** — planning content from
+  external sources can be ingested as plan entities
+- **Schema validation** — `validate_schema.py` validates
+  plan entities (required fields, plan_type enum)
+- **Migration 1.6.6 → 1.7.0** — documents structural and
+  content changes for existing vaults
+
+---
+
 ## [1.6.6] — 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -798,6 +798,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[1.7.0]: https://github.com/AntTheLimey/gm-apprentice/releases/tag/v1.7.0
 [1.6.6]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.5...v1.6.6
 [1.6.5]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/AntTheLimey/gm-apprentice/compare/v1.6.3...v1.6.4

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -38,6 +38,7 @@ ADVENTURE_BRIEF_SHAPE = {
     "linear", "branching", "hub-and-spoke", "open-node", "sandbox"
 }
 WORLD_DOMAIN_STATUS = {"active", "stub", "inactive"}
+PLAN_TYPES = {"arc", "scene", "investigation", "timeline"}
 
 # Required fields per entity type
 # All entities need: type, source_confidence
@@ -65,6 +66,7 @@ REQUIRED_FIELDS = {
     "player-characters": ["type"],
     "campaign_overview": ["type", "source_confidence"],
     "heritage": ["type", "source_confidence"],
+    "plan": ["type", "source_confidence", "plan_type", "chapter"],
     "world_domain": ["type", "domain", "status"],
     "world_flags": ["type"],
 }
@@ -273,6 +275,18 @@ def validate_file(filepath: Path) -> list[str]:
                 f"Invalid status '{value}' — "
                 f"must be one of: {', '.join(sorted(WORLD_DOMAIN_STATUS))}"
             )
+
+    # Validate plan fields
+    if entity_type == "plan":
+        if "plan_type" in frontmatter:
+            value = frontmatter["plan_type"]
+            if not isinstance(value, str):
+                errors.append("Field 'plan_type' must be a string")
+            elif value not in PLAN_TYPES:
+                errors.append(
+                    f"Invalid plan_type '{value}' — "
+                    f"must be one of: {', '.join(sorted(PLAN_TYPES))}"
+                )
 
     # Validate portrait field — only allowed for supported entity types
     portrait = frontmatter.get("portrait")

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -241,6 +241,12 @@ tools used to read, write, and search differ.
      `shared/templates/heritage.md`.
    - Add `_Templates/_Template_Faction.md` from
      `shared/templates/faction.md` if not already present.
+   - Add `_Templates/_Template_Plan.md` from
+     `shared/templates/plan.md` if not already present.
+   - For each chapter directory, create `Planning/` subfolder
+     if it doesn't already exist. This is where narrative
+     planning entities (scene designs, arc structures,
+     investigation flows) live.
 4. **Extract and file** — For each entity, read
    `_Templates/_Template_{Type}.md` first, then create the note
    using that template as the structure. Fill in frontmatter per

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -243,7 +243,7 @@ for the full procedure.
   companion `{Name}_Story.md` file, story files where
   `asOfSession` is more than 1 session behind the latest
   wrap-up
-- Plan entity validation: plan entities in `Planning/` with
+- Plan entity validation: plan entities in `Chapters/{chapter}/Planning/` with
   missing `plan_type`, `chapter` links pointing to
   non-existent chapter overviews, or scene plans with empty
   `participants` or `locations` (arc and timeline plans may

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -244,9 +244,10 @@ for the full procedure.
   `asOfSession` is more than 1 session behind the latest
   wrap-up
 - Plan entity validation: plan entities in `Planning/` with
-  missing `plan_type`, empty `participants` or `locations`,
-  or `chapter` links pointing to non-existent chapter
-  overviews
+  missing `plan_type`, `chapter` links pointing to
+  non-existent chapter overviews, or scene plans with empty
+  `participants` or `locations` (arc and timeline plans may
+  legitimately have sparse relational data)
 
 ### World Consistency
 

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -243,6 +243,10 @@ for the full procedure.
   companion `{Name}_Story.md` file, story files where
   `asOfSession` is more than 1 session behind the latest
   wrap-up
+- Plan entity validation: plan entities in `Planning/` with
+  missing `plan_type`, empty `participants` or `locations`,
+  or `chapter` links pointing to non-existent chapter
+  overviews
 
 ### World Consistency
 

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -85,6 +85,7 @@ Route these requests directly — don't search, load the file.
 | Scene fell flat | `ttrpg-expert/active-play-management.md` §Mid-Session Adjustments |
 | Pacing / tension | `ttrpg-expert/active-play-management.md` §Pacing and Flow |
 | Improvisation help | `ttrpg-expert/active-play-management.md` §Improvisation |
+| Scene plan | `Chapters/{chapter}/Planning/{scene}.md` — read the relevant plan entity for decision trees and contingencies |
 
 Read `ttrpg-expert/active-play-management.md` when the GM needs
 GM-craft advice (spotlight, pacing, improv, difficulty tuning)

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -85,7 +85,7 @@ Route these requests directly — don't search, load the file.
 | Scene fell flat | `ttrpg-expert/active-play-management.md` §Mid-Session Adjustments |
 | Pacing / tension | `ttrpg-expert/active-play-management.md` §Pacing and Flow |
 | Improvisation help | `ttrpg-expert/active-play-management.md` §Improvisation |
-| Scene plan | `Chapters/{chapter}/Planning/{scene}.md` — read the relevant plan entity for decision trees and contingencies |
+| Narrative plan | `Chapters/{chapter}/Planning/` — read the relevant plan entity (scene designs, arc structure, investigation flow, or timeline) |
 
 Read `ttrpg-expert/active-play-management.md` when the GM needs
 GM-craft advice (spotlight, pacing, improv, difficulty tuning)

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -139,6 +139,32 @@ worldbuilding conversation.
 If Reconcile ran, steps 7-10 read `## Reconciliation Context` and skip
 what's already established.
 
+#### Step 10c: Narrative plans
+
+If `Chapters/{chapter}/Planning/` exists, scan it for plan
+entities relevant to the upcoming session:
+
+1. Read all files in `Planning/` and categorize by
+   `plan_type` (arc, scene, investigation, timeline)
+2. Surface scene plans whose `participants` or `locations`
+   overlap with the threads, NPCs, or locations already
+   gathered in steps 8-10
+3. Present a brief summary:
+
+> **Narrative plans available for this chapter:**
+> - Arc: Arc_Shape.md — four-phase dramatic structure
+> - Scenes: Temple_Approach.md, Recognition_Scene.md,
+>   Escort_Betrayal.md — scene designs with decision trees
+> - Investigation: Investigation_Design.md — clue flow
+>
+> **Most relevant for next session:** [list based on thread
+> and NPC overlap]
+
+Do not copy plan content into the session plan — link to
+it. Plans are reference documents the GM consults during
+play, not material to be duplicated.
+→ Write `## Available Plans` to Plan file.
+
 ## Phase 2: Prep Forward — Creative Planning
 
 **11. PC Roster + Arc Check** — Per-PC deep review:

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -557,6 +557,7 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 | event (all subtypes) | Events/ |
 | document (all subtypes) | Documents/ |
 | clue | Clues/ |
+| plan | `Chapters/{chapter}/Planning/` |
 | adventure-brief | Adventures/{adventure-name}/ |
 | campaign_overview | _Campaign/ |
 | heritage | Heritages/ |

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -86,6 +86,7 @@ narrative (abstract)
 │   ├── betrayal_event
 │   └── celebration
 ├── clue
+├── plan
 ├── adventure-brief
 └── campaign_overview
 
@@ -266,6 +267,15 @@ Extraction defaults:
 | location | string | Where (wiki-link to Location entity) |
 | participants | array | Who — entries can be `[[Entity]] (role)`, `[[Entity\|Display]] (role)`, or plain text |
 | outcome | string | Result |
+
+### Plan
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| plan_type | string | `arc`, `scene`, `investigation`, or `timeline` |
+| chapter | string | Wiki-link to chapter overview (`"[[Chapter_N_Overview]]"`) |
+| participants | array | Wiki-link array to NPCs, factions, creatures involved |
+| locations | array | Wiki-link array to location entities |
 
 ### Document
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.6.5"
+current_version: "1.6.0"
 ---
 
 # Vault Migration Registry

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.6.0"
+current_version: "1.6.5"
 ---
 
 # Vault Migration Registry
@@ -203,3 +203,33 @@ Standardizes date field names across session and event entities.
 - **New templates:** `heritage.md`, `faction.md`, `world-index.md`,
   `world-flags.md`, `world-domain.md` added to
   `skills/shared/templates/`.
+
+## Migration: 1.6.6 → 1.7.0
+
+### Structural
+
+- **New entity type:** `plan` added to entity schema under
+  `narrative (abstract)`, alongside `event` and `clue`.
+  Existing vaults continue to work without modification.
+- **New field:** `plan_type` on plan entities — values:
+  `arc`, `scene`, `investigation`, `timeline`.
+- **New fields:** `participants` and `locations` on plan
+  entities — wiki-link arrays pointing to existing vault
+  entities.
+- **New relationship types:** `leads_to`, `precedes`,
+  `alternative_to` added to relationship ontology for
+  expressing sequencing, causation, and branching between
+  plan entities.
+
+### Content
+
+- **New folder:** `Planning/` added to chapter directory
+  structure. Created during chapter scaffolding (Midwife
+  Phase 4 handoff) or on demand by campaign-organizer.
+  Not backfilled — existing chapters are unaffected until
+  the GM creates plans.
+- **New template:** `plan.md` added to
+  `skills/shared/templates/`.
+- **Existing `_midwife/` content** is NOT auto-promoted.
+  The GM decides if/when to bring old Midwife output into
+  the vault using the new structure.

--- a/skills/shared/templates/plan.md
+++ b/skills/shared/templates/plan.md
@@ -8,7 +8,7 @@ asOfSession: ""
 lastUpdated: ""
 aliases: []
 tags: []
-plan_type: ""
+plan_type: ""               # arc | scene | investigation | timeline
 chapter: "[[]]"
 campaign: "[[Campaign_Overview_Updated]]"
 participants: []

--- a/skills/shared/templates/plan.md
+++ b/skills/shared/templates/plan.md
@@ -1,0 +1,31 @@
+---
+name: ""
+type: plan
+source_confidence: DRAFT
+source: prep
+createdSession: ""
+asOfSession: ""
+lastUpdated: ""
+aliases: []
+tags: []
+plan_type: ""
+chapter: "[[]]"
+campaign: "[[Campaign_Overview_Updated]]"
+participants: []
+locations: []
+relationships:
+  - target: "[[]]"
+    type: ""
+    tone: neutral
+    strength: 5
+    bidirectional: false
+    description: ""
+---
+
+## Overview
+
+## Design
+
+## Contingencies
+
+## GM Notes

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -302,9 +302,9 @@ brief using the template below.
   relative to CWD — campaign-organizer will wrap the vault
   around it.
 
-### Step 2: Entity Promotion
+### Step 2: Entity & Plan Promotion
 
-List all entity sketches from
+**2a. Entity promotion** — List all entity sketches from
 `_midwife/{adventure}/entity-sketches/` and ask which
 to promote to real vault entities:
 
@@ -312,16 +312,64 @@ to promote to real vault entities:
 [Name] ([type]), [Name] ([type]), ...
 Which should I create as vault entities?"
 
-**Self-check after each promoted entity:**
-1. Re-read the entity file just created
-2. Compare frontmatter fields against `_Templates/_Template_{Type}.md`
-3. Verify: `type` matches, `source_confidence: DRAFT` is set, all required fields present
-4. Verify: wiki-links use `[[Entity Name]]` format (no bare text references to entities)
-5. Fix any issues before promoting the next entity
-
 Approved entities are filed by campaign-organizer to the
 correct vault folders with proper frontmatter. Do not
 auto-promote — the GM chooses.
+
+**2b. Plan promotion** — List all topic files from
+`_midwife/{adventure}/` that contain narrative planning
+content (arc design, scene designs, investigation flows,
+timelines). Categorize each:
+
+"These planning documents are ready for the vault:
+
+Arc/structure:
+- chapter-shape.md → Arc_Shape.md (plan_type: arc)
+- narrative-arc.md → Narrative_Arc.md (plan_type: arc)
+
+Investigation:
+- investigation-shape.md → Investigation_Design.md (plan_type: investigation)
+
+Scenes:
+- temple-approach.md → Temple_Approach.md (plan_type: scene)
+- recognition-scene.md → Recognition_Scene.md (plan_type: scene)
+[etc.]
+
+Timeline:
+- timeline.md → Timeline.md (plan_type: timeline)
+
+Which should I promote to the vault?"
+
+For each approved plan:
+1. Create `Planning/` under the chapter directory if it
+   doesn't exist
+2. Read `_Templates/_Template_Plan.md` for the frontmatter
+   structure
+3. Transform the freeform Midwife draft into a vault entity:
+   - Set `plan_type` based on the categorization above
+   - Set `chapter` to the chapter overview wiki-link
+   - Populate `participants` with wiki-links to NPCs,
+     factions, and creatures mentioned in the plan
+   - Populate `locations` with wiki-links to locations
+     mentioned in the plan
+   - Add `relationships` between plans where sequencing
+     or branching exists (e.g., `leads_to`, `precedes`,
+     `alternative_to`)
+   - Preserve the full narrative content in body sections,
+     adapting section headers to fit the plan type
+4. Write to `Chapters/{chapter}/Planning/{Plan_Name}.md`
+
+**Self-check after each promoted entity or plan:**
+1. Re-read the file just created
+2. Compare frontmatter fields against `_Templates/_Template_{Type}.md`
+3. Verify: `type` matches, `source_confidence: DRAFT` is set, all required fields present
+4. Verify: wiki-links use `[[Entity Name]]` format (no bare text references to entities)
+5. Fix any issues before promoting the next item
+
+Content left in `_midwife/` after promotion (seeds, unused
+sketches, half-formed ideas) stays as creative archive.
+Update `_midwife/index.md` to record what was promoted
+and what remains.
 
 ### Step 3: Vault Scaffold (greenfield only)
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -199,6 +199,14 @@ Read `references/synthesis-templates.md` for the output format.
 Include `> [!info] Reconstruction Note` with source descriptions
 and limitations. Mark uncertain items with `<!-- UNVERIFIED -->`.
 
+**Planning content:** If the ingested material contains
+narrative planning documents (scene designs, arc structures,
+investigation flows), create them as `type: plan` entities
+in `Chapters/{chapter}/Planning/`. Read
+`_Templates/_Template_Plan.md` for the frontmatter structure.
+Set `plan_type` to the closest match: `arc`, `scene`,
+`investigation`, or `timeline`.
+
 ### Phase 6: Review
 
 Invoke `shared/reconcile.md` to walk the GM through reviewing


### PR DESCRIPTION
## Summary

- Adds a new `plan` entity type under `narrative (abstract)` with a `plan_type` discriminator (arc, scene, investigation, timeline)
- Plans live in a flat `Planning/` subdirectory under each chapter, keeping narrative planning content (scene designs, arc structures, investigation flows, timelines) inside the knowledge graph
- Updates six skills: Midwife (Phase 4 plan promotion), campaign-organizer (scaffold), session-prep (plan surfacing), session-play (routing), campaign-qa (validation), vault-ingest (ingestion)
- Includes shared template, entity schema, schema validation, migration entry (1.6.6 → 1.7.0), and version bump

## Test plan

- [x] `python3 scripts/validate_schema.py` passes (41 files, no errors)
- [x] Positive validation: test plan entity with valid `plan_type: scene` passes
- [x] Negative validation: test plan entity with `plan_type: invalid_type` correctly rejected
- [ ] Verify Midwife Phase 4 handoff promotes plans to `Planning/` in a test campaign
- [ ] Verify session-prep surfaces plans from `Planning/` during context gathering
- [ ] Verify campaign-organizer scaffolds `Planning/` folder and `_Template_Plan.md`