### PR TITLE
Drive landing page off _Campaign overview metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.7.2] — 2026-06-26
+
+### Fixed
+
+- **Landing page reflects authoritative campaign state.** The hero (in-game date
+  and session count) and the *Latest Session* card now read `current_game_date`,
+  `sessions_played`, `last_session`, and `last_play_date` from the `_Campaign`
+  overview frontmatter (maintained by `session-wrapup`) instead of re-deriving
+  them by scanning session pages. The overview is located by its
+  `type: campaign_overview` frontmatter — not by filename, so a renamed overview
+  such as `Campaign_Overview_Updated` still works — and is read from the full
+  vault corpus, so it applies even though the overview is normally excluded from
+  publishing. `getLatestSession` now sorts by `play_date` (most recently played),
+  with `session_number` only as a tiebreak, so chapters that restart session
+  numbering no longer surface the wrong "latest" session. All fields fall back to
+  the previous behaviour when absent.
+
+### Internal
+
+- `build` now exposes the full scanned corpus to the landing template, kept
+  separate from the manifest publish-filter that governs what is rendered.
+
+---
+
 ## [1.7.1] — 2026-06-06
 
 ### Added

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -22,7 +22,16 @@ any equivalent in `vault.config.json`.
 | 404 message | `publish.four_oh_four.message` | Custom in-world 404 text |
 | Overrides | `publish.overrides` | Per-file include/exclude/field overrides |
 | Exclude drafts | `publish.exclude_drafts` | When `true`, DRAFT entities are excluded entirely (default: `false`) |
-| Setting year | `setting_year` | In-game date shown on the landing page |
+| Setting year | `setting_year` | Fallback in-game date on the landing page (used only when the campaign overview has no `current_game_date`) |
+
+> **Landing page state.** The landing hero (in-game date, session count) and the
+> *Latest Session* card are driven by the **`_Campaign` overview frontmatter** —
+> `current_game_date`, `sessions_played`, `last_session`, `last_play_date` — which
+> the `session-wrapup` skill keeps current. The overview is located by its
+> `type: campaign_overview` frontmatter (not by filename, so a renamed overview
+> still resolves) and is read from the full vault corpus, so it applies even
+> though the overview is normally excluded from publishing. `setting_year` and
+> `total_sessions` remain as fallbacks when those fields are absent.
 
 ## `vault.config.json` (in the site repo)
 

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -125,10 +125,12 @@ function build(options = {}) {
   console.log('Scanning vault:', config.vaultPath);
   let pages = scanVault(config);
   console.log(`Found ${pages.length} pages`);
-  // The full scanned corpus stays available for templates to read context from (campaign-overview
-  // metadata, cross-references, link resolution) — independent of the manifest/draft filtering
-  // below, which only governs what gets *rendered*. Captured here because the filters reassign
-  // `pages` to the published subset.
+  // Capture the scanned pages before the manifest/draft filters reassign `pages` to the published
+  // subset, so templates can reach context that is excluded from rendering — above all the
+  // `_Campaign` overview, which is normally unpublished. This preserves page *membership* only:
+  // the page objects are shared, so any later field-level frontmatter filtering on published pages
+  // is visible here too. Use corpus to reach excluded *pages* (e.g. the overview), not to recover
+  // fields stripped from a *published* page.
   const corpus = pages.slice();
   pairStoryFiles(pages, config.vaultPath);
 

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -125,6 +125,11 @@ function build(options = {}) {
   console.log('Scanning vault:', config.vaultPath);
   let pages = scanVault(config);
   console.log(`Found ${pages.length} pages`);
+  // The full scanned corpus stays available for templates to read context from (campaign-overview
+  // metadata, cross-references, link resolution) — independent of the manifest/draft filtering
+  // below, which only governs what gets *rendered*. Captured here because the filters reassign
+  // `pages` to the published subset.
+  const corpus = pages.slice();
   pairStoryFiles(pages, config.vaultPath);
 
   // Exclude DRAFT entities when configured (after pairing so story files resolve)
@@ -497,7 +502,7 @@ function build(options = {}) {
   }
 
   // Landing page
-  const landingHtml = landingTemplate(pages, navFor, config, publishConfig, imageMap);
+  const landingHtml = landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus);
   fs.writeFileSync(path.join(outputDir, 'index.html'), landingHtml);
   console.log('  wrote index.html');
 

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -675,7 +675,11 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig) {
     bodyContent = renderFactions(pages, dir);
   } else if (isItems) {
     bodyContent = renderArmory(pages, dir);
-  } else if (isCampaign) {
+  } else if (isCampaign && pages.some(p => p.frontmatter.type === 'campaign_overview')) {
+    // Only render the overview deep-dive (which surfaces the overview's prose) when the overview
+    // is actually published. In player mode the overview is excluded as a spoiler doc, so fall
+    // through to the normal card index of the published _Campaign pages rather than showing
+    // "No campaign overview found".
     bodyContent = renderCampaignDeepDive(pages, dir, publishConfig);
   } else {
     const cardItems = pages.map(p => {

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -3,7 +3,14 @@ function getLatestSession(pages) {
     p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')
   );
   if (played.length === 0) return null;
-  played.sort((a, b) => (b.frontmatter.session_number || 0) - (a.frontmatter.session_number || 0));
+  // "Latest" = most recently played (by play_date), not highest session_number — chapters can
+  // restart numbering. Fall back to session_number only when play dates tie or are absent.
+  played.sort((a, b) => {
+    const da = new Date(a.frontmatter.play_date || a.frontmatter.actual_date || 0).getTime() || 0;
+    const db = new Date(b.frontmatter.play_date || b.frontmatter.actual_date || 0).getTime() || 0;
+    if (db !== da) return db - da;
+    return (b.frontmatter.session_number || 0) - (a.frontmatter.session_number || 0);
+  });
   return played[0];
 }
 

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -76,9 +76,10 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
 </div>`;
 
   // --- Zone 2: Latest Session Recap ---
-  // Prefer the overview's authoritative last_session pointer; fall back to scanning sessions only
-  // when it is absent or unresolvable (e.g. the named session page is not itself published).
-  const latestSession = resolveSessionLink(overviewFm.last_session, corpusPages) || getLatestSession(pages);
+  // Prefer the overview's authoritative last_session pointer, resolved against the *published*
+  // pages so the "Read full session" link always targets a rendered page. Fall back to scanning
+  // when last_session is absent or points to a page that isn't itself published.
+  const latestSession = resolveSessionLink(overviewFm.last_session, pages) || getLatestSession(pages);
   const latestWrapUp = getLatestWrapUp(pages, latestSession);
   let recapZone = '';
   if (latestSession) {

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -28,24 +28,43 @@ function statusLabel(status) {
   return 'Active';
 }
 
-function landingTemplate(pages, navFor, config, publishConfig, imageMap) {
+// Resolve a wiki-link such as "[[Session 03 - Give Rest]]" to its session page by matching the
+// page's source filename (page.title). Returns null when no matching session page is present.
+function resolveSessionLink(link, pages) {
+  if (!link) return null;
+  const target = String(link).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim();
+  if (!target) return null;
+  return pages.find(p => p.frontmatter.type === 'session' && p.title === target) || null;
+}
+
+function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus) {
   const outputPath = 'index.html';
   const theme = (publishConfig && publishConfig.theme) || {};
   const campaignImage = theme.campaign_image || null;
   const settingYear = publishConfig ? publishConfig.setting_year : null;
   const landingConfig = (publishConfig && publishConfig.landing) || {};
   const genre = publishConfig._genrePreset || null;
+  // The full corpus (all scanned pages, pre-publish-filter) is available for context; fall back to
+  // the published `pages` if a caller doesn't supply it. The _Campaign overview holds authoritative
+  // campaign state (maintained by the session-wrapup skill: current_game_date, sessions_played,
+  // last_session, last_play_date). Looked up by `type === 'campaign_overview'`, never by filename,
+  // so name drift such as "Campaign_Overview_Updated" is tolerated.
+  const corpusPages = (corpus && corpus.length) ? corpus : pages;
+  const overviewFm = (corpusPages.find(p => p.frontmatter.type === 'campaign_overview') || {}).frontmatter || {};
+  const inGameLabel = overviewFm.current_game_date || settingYear;
 
   // --- Zone 1: Hero ---
   const heroImgHtml = campaignImage
     ? `<img class="landing-hero-img" src="${escapeHtml(campaignImage)}" alt="${escapeHtml(config.siteTitle)}">`
     : '';
   const tagline = theme.tagline ? `<p class="hero-tagline">${escapeHtml(theme.tagline)}</p>` : '';
-  const sessionCount = (publishConfig && publishConfig.total_sessions != null)
-    ? publishConfig.total_sessions
-    : pages.filter(p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')).length;
+  const sessionCount = (overviewFm.sessions_played != null)
+    ? overviewFm.sessions_played
+    : (publishConfig && publishConfig.total_sessions != null)
+      ? publishConfig.total_sessions
+      : pages.filter(p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')).length;
   const heroDateParts = [];
-  if (settingYear) heroDateParts.push(`<span><span class="date-label">In-Game</span> ${escapeHtml(String(settingYear))}</span>`);
+  if (inGameLabel) heroDateParts.push(`<span><span class="date-label">In-Game</span> ${escapeHtml(String(inGameLabel))}</span>`);
   heroDateParts.push(`<span><span class="date-label">Sessions</span> ${sessionCount}</span>`);
   const heroDates = heroDateParts.length > 0 ? `<div class="hero-dates">${heroDateParts.join('')}</div>` : '';
 
@@ -57,13 +76,15 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap) {
 </div>`;
 
   // --- Zone 2: Latest Session Recap ---
-  const latestSession = getLatestSession(pages);
+  // Prefer the overview's authoritative last_session pointer; fall back to scanning sessions only
+  // when it is absent or unresolvable (e.g. the named session page is not itself published).
+  const latestSession = resolveSessionLink(overviewFm.last_session, corpusPages) || getLatestSession(pages);
   const latestWrapUp = getLatestWrapUp(pages, latestSession);
   let recapZone = '';
   if (latestSession) {
     const recapSource = latestWrapUp || latestSession;
     const recap = extractRecap(recapSource);
-    const dateStr = formatDate(latestSession.frontmatter.play_date || latestSession.frontmatter.actual_date);
+    const dateStr = formatDate(overviewFm.last_play_date || latestSession.frontmatter.play_date || latestSession.frontmatter.actual_date);
     const dateBadge = dateStr ? ` <span style="opacity:0.7;font-size:0.85rem"> — ${escapeHtml(dateStr)}</span>` : '';
     const linkTarget = latestWrapUp || latestSession;
     const recapLink = `<a class="recap-link" href="${escapeHtml(linkTarget.outputPath)}">Read full session &rarr;</a>`;

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/index-filters.test.js
+++ b/tools/publish/test/unit/index-filters.test.js
@@ -50,3 +50,34 @@ describe('buildLocationTree', () => {
     assert.strictEqual(tree.length, 1);
   });
 });
+
+describe('indexTemplate — campaign index', () => {
+  const navFor = () => '<nav></nav>';
+  const config = { siteTitle: 'GURPS Special Forces' };
+  const publishConfig = { theme: {} };
+
+  it('renders the overview deep-dive when the overview is published', () => {
+    const overview = {
+      frontmatter: { type: 'campaign_overview', campaign: 'GURPS Special Forces' },
+      title: 'Campaign Overview',
+      outputPath: 'campaign/index.html',
+      markdown: '# GURPS Special Forces\n\nThe premise.',
+    };
+    const html = indexTemplate('campaign', 'Campaign', [overview], navFor, config, publishConfig);
+    assert.ok(!html.includes('No campaign overview found'), 'must not show the error string');
+    assert.ok(html.includes('campaign-deep-dive'), 'renders the deep-dive when the overview is published');
+  });
+
+  it('falls back to a card index of published _Campaign pages when the overview is excluded (no spoiler leak, no error string)', () => {
+    const pages = [
+      { frontmatter: { type: 'timeline' }, title: 'Timeline', displayTitle: 'Timeline', outputPath: 'campaign/timeline.html' },
+      { frontmatter: { type: 'reference' }, title: 'Glossary', displayTitle: 'Glossary', outputPath: 'campaign/glossary.html' },
+    ];
+    const html = indexTemplate('campaign', 'Campaign', pages, navFor, config, publishConfig);
+    assert.ok(!html.includes('No campaign overview found'), 'must not show the error string');
+    assert.ok(!html.includes('campaign-deep-dive'), 'must not render the (spoiler) deep-dive');
+    assert.ok(html.includes('card-grid'), 'renders the published _Campaign pages as a card index');
+    assert.ok(html.includes('Timeline'), 'includes the published _Campaign content');
+    assert.ok(html.includes('GURPS Special Forces'), 'header still shows the campaign name (site-title fallback)');
+  });
+});

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -38,6 +38,26 @@ describe('getLatestSession', () => {
     const result = getLatestSession(pages);
     assert.strictEqual(result.title, 'Session 5');
   });
+
+  it('picks the most recently played session even when a later chapter restarts numbering', () => {
+    // Regression: "latest" must mean most recently played (play_date), not highest session_number.
+    // Vienna ran 1-14; Calcutta restarted at 1-3 — the June session (number 3) is the real latest.
+    const pages = [
+      { frontmatter: { type: 'session', status: 'reviewed', session_number: 14, play_date: '2026-05-21' }, title: 'Session 14' },
+      { frontmatter: { type: 'session', status: 'reviewed', session_number: 3, play_date: '2026-06-25' }, title: 'Session 03 - Give Rest' },
+    ];
+    const result = getLatestSession(pages);
+    assert.strictEqual(result.title, 'Session 03 - Give Rest');
+  });
+
+  it('falls back to session_number when play dates are equal or absent', () => {
+    const pages = [
+      { frontmatter: { type: 'session', status: 'played', session_number: 2 }, title: 'Session 2' },
+      { frontmatter: { type: 'session', status: 'played', session_number: 5 }, title: 'Session 5' },
+    ];
+    const result = getLatestSession(pages);
+    assert.strictEqual(result.title, 'Session 5');
+  });
 });
 
 describe('getLatestWrapUp', () => {

--- a/tools/publish/test/unit/landing.test.js
+++ b/tools/publish/test/unit/landing.test.js
@@ -1,0 +1,54 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { landingTemplate } = require('../../lib/templates/landing');
+
+const navFor = () => '<nav></nav>';
+const config = { siteTitle: 'Canticle of the End', attachmentsDir: '_attachments', footer: '', siteUrl: '' };
+const publishConfig = { theme: {}, setting_year: 1814 };
+
+function sessionPage() {
+  return {
+    frontmatter: { type: 'session', status: 'reviewed', session_number: 3, play_date: 'June 25, 2026' },
+    title: 'Session 03 - Give Rest',
+    displayTitle: 'Give Rest',
+    outputDir: 'chapters/c4',
+    outputPath: 'chapters/c4/session-03-give-rest.html',
+    markdown: '# Session 03\n\n## Narrative Recap\n\nThe becalming broke and the wind returned.',
+  };
+}
+
+function overviewPage() {
+  return {
+    // Deliberately drifted filename — the lookup is by frontmatter type, not by filename.
+    frontmatter: {
+      type: 'campaign_overview',
+      campaign: 'Canticle of the End',
+      current_game_date: 'September 9, 1814',
+      sessions_played: 17,
+      last_session: '[[Session 03 - Give Rest]]',
+      last_play_date: 'June 25, 2026',
+    },
+    title: 'Campaign_Overview_Updated',
+    markdown: '# Overview',
+  };
+}
+
+describe('landingTemplate — campaign overview metadata', () => {
+  it('reads in-game date, session count and latest session from the overview, even when it is excluded from the published pages', () => {
+    const session = sessionPage();
+    const pages = [session];                  // published set — overview deliberately absent
+    const corpus = [overviewPage(), session]; // full corpus — overview present
+    const html = landingTemplate(pages, navFor, config, publishConfig, {}, corpus);
+    assert.ok(html.includes('September 9, 1814'), 'in-game date comes from current_game_date');
+    assert.ok(/Sessions<\/span>\s*17/.test(html), 'session count comes from sessions_played');
+    assert.ok(html.includes('June 25, 2026'), 'latest-session date comes from last_play_date');
+    assert.ok(html.includes('session-03-give-rest.html'), 'latest session resolved from last_session');
+  });
+
+  it('falls back to setting_year and the scanned count when no overview metadata exists', () => {
+    const session = sessionPage();
+    const html = landingTemplate([session], navFor, config, publishConfig, {}, [session]);
+    assert.ok(html.includes('1814'), 'in-game falls back to setting_year');
+    assert.ok(/Sessions<\/span>\s*1/.test(html), 'session count falls back to counting played/reviewed pages');
+  });
+});


### PR DESCRIPTION
## Problem

The landing page derived "latest session" and the hero figures (in-game date, session count) by scanning/sorting session pages:

- `getLatestSession` sorted by `session_number`, so a chapter that restarts numbering (e.g. Calcutta sessions 1–3 after Vienna 1–14) surfaced the wrong "latest" session.
- The in-game date and session count were re-derived rather than read from the campaign's authoritative state.

## Fix

Drive the landing off the `_Campaign` overview frontmatter, which `session-wrapup` already maintains:

- Reads `current_game_date`, `sessions_played`, `last_session`, `last_play_date`.
- Overview located by `type: campaign_overview` (not filename — tolerates drift like `Campaign_Overview_Updated`).
- Read from the **full scanned corpus**, kept separate from the manifest publish-filter, so it works even though the overview is excluded from publishing.
- `last_session` resolves against the **published** pages so the recap link always targets a rendered page; falls back to the latest published session otherwise.
- `getLatestSession` now sorts by `play_date`, with `session_number` only as a tiebreak.
- All fields fall back to the previous behaviour when absent.

## Tests

- `getLatestSession`: chapter-restart regression + date-tie tiebreak.
- `landingTemplate`: reads campaign state from the overview (including when the overview is excluded from the published pages) + the no-overview fallback.
- Full suite: **396 pass, 0 fail**. Verified end-to-end against two real campaigns (Call of Cthulhu and GURPS).

## Follow-up (separate change, not in this PR)

The campaign **index** page's deep-dive renders the overview's prose sections; in player mode the overview is excluded, so it shows "No campaign overview found." Rendering the published `_Campaign` content there (without leaking the excluded spoiler overview) is tracked separately.

## Release

gm-apprentice 1.7.1 → 1.7.2; gm-apprentice-publish 1.2.1 → 1.2.2; CHANGELOG + publish-site configuration docs.