### PR TITLE
Make 'NPCs in Play' reflect recent play

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.7.3] — 2026-06-26
+
+### Fixed
+
+- **"NPCs in Play" now reflects who's actually in recent play.** `scoreByRecency`
+  identified recent sessions by `session_number`, which breaks when a chapter
+  restarts numbering (Calcutta 1–3 ranked below Vienna 12–14), so the landing
+  surfaced old NPCs. It now selects recent sessions by `play_date`, scores
+  mentions from the paired **wrap-up recaps** (the session index pages are thin
+  stubs), counts sessions that are still in the `wrap-up` state (played but not yet
+  reviewed), and **recency-weights** so the latest session counts most. Terminal-status
+  entities (dead, destroyed, …) are no longer hidden outright — they appear when
+  they feature in the **latest** session (e.g. an NPC who just died) and are
+  otherwise retired from the list.
+
+---
+
 ## [1.7.2] — 2026-06-26
 
 ### Fixed

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -209,6 +209,7 @@ function build(options = {}) {
   const chapters = pages.filter(p => p.frontmatter.type === 'chapter');
   const npcs = pages.filter(p => p.frontmatter.type === 'npc');
   const locations = pages.filter(p => p.frontmatter.type === 'location');
+  const wrapUps = pages.filter(p => ['session-wrap-up', 'session_wrap', 'session-wrapup'].includes(p.frontmatter.type));
 
   const landingConfig = (publishConfig.landing || {});
   const recencyWindow = landingConfig.recency_window || 3;
@@ -217,12 +218,14 @@ function build(options = {}) {
     window: recencyWindow,
     max: landingConfig.max_npcs || 6,
     type: 'npc',
+    wrapUps,
   });
 
   const recentLocations = scoreByRecency(locations, sessions, chapters, {
     window: recencyWindow,
     max: landingConfig.max_locations || 4,
     type: 'location',
+    wrapUps,
   });
 
   console.log(`Recency: ${recentNPCs.length} NPCs, ${recentLocations.length} locations`);

--- a/tools/publish/lib/recency.js
+++ b/tools/publish/lib/recency.js
@@ -1,5 +1,8 @@
 const WIKI_LINK_RE = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 const TERMINAL_STATUSES = new Set(['dead', 'deceased', 'destroyed', 'kia', 'dissolved']);
+// A session counts as "played" once it has been run — including the post-wrap-up, pre-reconcile
+// `wrap-up` state — so a freshly wrapped session still drives "recent" before it's reviewed.
+const PLAYED_STATUSES = new Set(['played', 'reviewed', 'wrap-up']);
 
 function extractMentions(markdown) {
   const mentions = new Set();
@@ -11,67 +14,89 @@ function extractMentions(markdown) {
   return mentions;
 }
 
+// All entity names mentioned "in" a session: its own body, its frontmatter participants/location,
+// and — because the narrative recap lives in the wrap-up, not the thin index stub — the body of
+// its paired wrap-up.
+function sessionMentions(session, wrapUpByTitle) {
+  const names = extractMentions(session.markdown || '');
+  const fm = session.frontmatter || {};
+  if (Array.isArray(fm.participants)) {
+    for (const p of fm.participants) {
+      const m = String(p).match(/\[\[([^\]|]+)/);
+      if (m) names.add(m[1].trim());
+    }
+  }
+  if (fm.location) {
+    const m = String(fm.location).match(/\[\[([^\]|]+)/);
+    if (m) names.add(m[1].trim());
+  }
+  const wu = wrapUpByTitle.get(session.title);
+  if (wu) {
+    for (const n of extractMentions(wu.markdown || '')) names.add(n);
+  }
+  return names;
+}
+
 function scoreByRecency(entities, sessions, chapters, options = {}) {
   const window = options.window || 3;
   const max = options.max || 6;
   const type = options.type;
+  const wrapUps = options.wrapUps || [];
 
+  // Most recently *played* first. session_number restarts per chapter, so it can't identify the
+  // recent sessions — sort by play_date and fall back to session_number only when dates tie/absent.
   const played = sessions
-    .filter(s => s.frontmatter.type === 'session' && (s.frontmatter.status === 'played' || s.frontmatter.status === 'reviewed'))
-    .sort((a, b) => (b.frontmatter.session_number || 0) - (a.frontmatter.session_number || 0));
+    .filter(s => s.frontmatter.type === 'session' && PLAYED_STATUSES.has(String(s.frontmatter.status || '').toLowerCase()))
+    .sort((a, b) => {
+      const da = new Date(a.frontmatter.play_date || a.frontmatter.actual_date || 0).getTime() || 0;
+      const db = new Date(b.frontmatter.play_date || b.frontmatter.actual_date || 0).getTime() || 0;
+      if (db !== da) return db - da;
+      return (b.frontmatter.session_number || 0) - (a.frontmatter.session_number || 0);
+    });
 
   const recentSessions = played.slice(0, window);
   if (recentSessions.length === 0) return [];
 
+  // Pair each session with its wrap-up via the wrap-up's `session` wiki-link. session_number is
+  // not unique once a chapter restarts numbering, so it can't key the pairing.
+  const wrapUpByTitle = new Map();
+  for (const w of wrapUps) {
+    const ref = w.frontmatter && w.frontmatter.session;
+    if (!ref) continue;
+    const target = String(ref).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim();
+    if (target && !wrapUpByTitle.has(target)) wrapUpByTitle.set(target, w);
+  }
+
+  // Mentions per recent session, recency-weighted (the most recent session counts most).
+  const recent = recentSessions.map((session, i) => ({
+    mentions: sessionMentions(session, wrapUpByTitle),
+    weight: window - i,
+  }));
+  const latestMentions = recent[0].mentions;
+
   const currentChapter = chapters
     .filter(c => c.frontmatter.type === 'chapter')
     .sort((a, b) => (b.frontmatter.sort_order || 0) - (a.frontmatter.sort_order || 0))[0];
+  const chapterMentions = currentChapter ? extractMentions(currentChapter.markdown || '') : new Set();
 
-  const filtered = entities.filter(e => {
-    if (type && e.frontmatter.type !== type) return false;
-    const status = String(e.frontmatter.status || '').toLowerCase();
-    return !TERMINAL_STATUSES.has(status);
-  });
-
-  const scored = filtered.map(entity => {
-    let score = 0;
+  const scored = entities.map(entity => {
+    if (type && entity.frontmatter.type !== type) return null;
     const names = [entity.title, ...(entity.frontmatter.aliases || [])];
 
-    for (const session of recentSessions) {
-      const mentions = extractMentions(session.markdown || '');
-      const fm = session.frontmatter;
-      const fmMentions = new Set();
-      if (fm.participants) {
-        for (const p of fm.participants) {
-          const m = String(p).match(/\[\[([^\]|]+)/);
-          if (m) fmMentions.add(m[1].trim());
-        }
-      }
-      if (fm.location) {
-        const m = String(fm.location).match(/\[\[([^\]|]+)/);
-        if (m) fmMentions.add(m[1].trim());
-      }
+    // Terminal-status entities (dead, destroyed, …) are retired from "in play" — unless they
+    // feature in the latest session (e.g. an NPC who died there is still current news).
+    const isTerminal = TERMINAL_STATUSES.has(String(entity.frontmatter.status || '').toLowerCase());
+    const inLatest = names.some(n => latestMentions.has(n));
+    if (isTerminal && !inLatest) return null;
 
-      for (const name of names) {
-        if (mentions.has(name) || fmMentions.has(name)) {
-          score += 2;
-          break;
-        }
-      }
+    let score = 0;
+    for (const rs of recent) {
+      if (names.some(n => rs.mentions.has(n))) score += 2 * rs.weight;
     }
-
-    if (currentChapter) {
-      const chapterMentions = extractMentions(currentChapter.markdown || '');
-      for (const name of names) {
-        if (chapterMentions.has(name)) {
-          score += 1;
-          break;
-        }
-      }
-    }
+    if (names.some(n => chapterMentions.has(n))) score += 1;
 
     return { page: entity, score };
-  });
+  }).filter(Boolean);
 
   return scored
     .filter(s => s.score > 0)

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/recency.test.js
+++ b/tools/publish/test/unit/recency.test.js
@@ -51,3 +51,82 @@ describe('scoreByRecency', () => {
     assert.deepStrictEqual(scored, []);
   });
 });
+
+describe('scoreByRecency — play_date recency, wrap-ups, terminal status', () => {
+  it('uses play_date (not session_number) to find recent sessions across a chapter restart, and counts freshly wrapped sessions', () => {
+    // Vienna S14 (number 14) was played before Calcutta S3 (number 3). With window 1, only the
+    // most-recently-played session (Calcutta S3) is in scope — even though it's still `wrap-up`.
+    const sessions = [
+      { title: 'S14', frontmatter: { type: 'session', status: 'reviewed', session_number: 14, play_date: '2026-05-21' }, markdown: 'Vienna with [[Old_NPC]].' },
+      { title: 'S3', frontmatter: { type: 'session', status: 'wrap-up', session_number: 3, play_date: '2026-06-25' }, markdown: 'Alexandria with [[New_NPC]].' },
+    ];
+    const entities = [
+      { title: 'Old_NPC', frontmatter: { type: 'npc', status: 'alive' } },
+      { title: 'New_NPC', frontmatter: { type: 'npc', status: 'alive' } },
+    ];
+    const titles = scoreByRecency(entities, sessions, [], { window: 1, max: 10, type: 'npc' }).map(s => s.page.title);
+    assert.ok(titles.includes('New_NPC'), 'the play_date-latest session is scored');
+    assert.ok(!titles.includes('Old_NPC'), 'the higher-numbered but older session is outside the recent window');
+  });
+
+  it('counts mentions from the paired wrap-up (recaps live there, not in the index stub)', () => {
+    const sessions = [
+      { title: 'S1', frontmatter: { type: 'session', status: 'reviewed', session_number: 1, play_date: '2026-06-25' }, markdown: 'See the wrap-up.' },
+    ];
+    const wrapUps = [
+      { title: 'Wrap', frontmatter: { type: 'session_wrap', session: '[[S1]]' }, markdown: 'The party met [[Dragoman|Yusuf]] and [[Thibault]].' },
+    ];
+    const entities = [
+      { title: 'Dragoman', frontmatter: { type: 'npc', status: 'alive' } },
+      { title: 'Thibault', frontmatter: { type: 'npc', status: 'alive' } },
+    ];
+    const titles = scoreByRecency(entities, sessions, [], { window: 3, max: 10, type: 'npc', wrapUps }).map(s => s.page.title);
+    assert.ok(titles.includes('Dragoman'), 'aliased mention in the wrap-up is counted');
+    assert.ok(titles.includes('Thibault'), 'bare mention in the wrap-up is counted');
+  });
+
+  it('includes a dead NPC only when they appear in the latest session', () => {
+    const sessions = [
+      { title: 'S2', frontmatter: { type: 'session', status: 'reviewed', session_number: 2, play_date: '2026-06-25' }, markdown: 'They lost [[Endicott]] to the sea.' },
+      { title: 'S1', frontmatter: { type: 'session', status: 'reviewed', session_number: 1, play_date: '2026-06-04' }, markdown: 'Long ago, [[Old_Casualty]] fell.' },
+    ];
+    const entities = [
+      { title: 'Endicott', frontmatter: { type: 'npc', status: 'dead' } },
+      { title: 'Old_Casualty', frontmatter: { type: 'npc', status: 'dead' } },
+    ];
+    const titles = scoreByRecency(entities, sessions, [], { window: 3, max: 10, type: 'npc' }).map(s => s.page.title);
+    assert.ok(titles.includes('Endicott'), 'died in the latest session → still in play');
+    assert.ok(!titles.includes('Old_Casualty'), 'died earlier → retired from in play');
+  });
+
+  it('weights the most recent session highest', () => {
+    const sessions = [
+      { title: 'S3', frontmatter: { type: 'session', status: 'reviewed', session_number: 3, play_date: '2026-06-25' }, markdown: 'Now: [[Fresh_NPC]].' },
+      { title: 'S1', frontmatter: { type: 'session', status: 'reviewed', session_number: 1, play_date: '2026-06-04' }, markdown: 'Earlier: [[Older_NPC]].' },
+    ];
+    const entities = [
+      { title: 'Fresh_NPC', frontmatter: { type: 'npc', status: 'alive' } },
+      { title: 'Older_NPC', frontmatter: { type: 'npc', status: 'alive' } },
+    ];
+    const scored = scoreByRecency(entities, sessions, [], { window: 3, max: 10, type: 'npc' });
+    assert.strictEqual(scored[0].page.title, 'Fresh_NPC', 'latest-session NPC outranks an older-session NPC');
+  });
+
+  it('pairs a session with its own wrap-up by wiki-link, not a same-numbered wrap-up from another chapter', () => {
+    const sessions = [
+      { title: 'Session 03 - Give Rest', frontmatter: { type: 'session', status: 'wrap-up', session_number: 3, play_date: '2026-06-25' }, markdown: '' },
+    ];
+    const wrapUps = [
+      // Same session_number (3) but belongs to an earlier chapter — must NOT be used.
+      { title: 'Vienna_S3_Wrap', frontmatter: { type: 'session_wrap', session_number: 3, session: '[[Session_03]]' }, markdown: 'Vienna with [[Wrong_NPC]].' },
+      { title: 'Calcutta_S3_Wrap', frontmatter: { type: 'session_wrap', session_number: 3, session: '[[Session 03 - Give Rest]]' }, markdown: 'Alexandria with [[Right_NPC]].' },
+    ];
+    const entities = [
+      { title: 'Wrong_NPC', frontmatter: { type: 'npc', status: 'alive' } },
+      { title: 'Right_NPC', frontmatter: { type: 'npc', status: 'alive' } },
+    ];
+    const titles = scoreByRecency(entities, sessions, [], { window: 3, max: 10, type: 'npc', wrapUps }).map(s => s.page.title);
+    assert.ok(titles.includes('Right_NPC'), 'pairs by the session wiki-link');
+    assert.ok(!titles.includes('Wrong_NPC'), 'ignores the same-numbered wrap-up from another chapter');
+  });
+});


### PR DESCRIPTION
## Problem

The landing's **NPCs in Play** showed stale, campaign-spanning NPCs (e.g. Vienna's Kaunitz/Herzfeld) instead of who's actually in recent play. `scoreByRecency` had several issues:

- Picked recent sessions by **`session_number`**, which breaks when a chapter restarts numbering (Calcutta 1–3 ranked below Vienna 12–14).
- Dropped sessions still in the **`wrap-up`** state (played but not yet reviewed), so the two most-recent Calcutta sessions weren't counted.
- Scored mentions only from the **thin session index stubs**, not the wrap-up recaps where NPCs are actually named.
- **Excluded all dead NPCs** outright.

## Fix

- Select recent sessions by **`play_date`** (session_number tiebreak).
- Treat **`wrap-up`** as a played status.
- Score mentions from the **paired wrap-up recap**, paired by the wrap-up's **`session` wiki-link** (session_number isn't unique across chapters).
- **Recency-weight** so the latest session counts most.
- Include terminal-status entities (dead/destroyed) **only when they appear in the latest session** (e.g. an NPC who just died is still current news).

## Tests

New `recency.test.js` cases: play_date recency across a chapter restart, wrap-up sessions counted, aliased + wrap-up mentions, dead-only-if-in-latest, recency weighting, and the same-numbered-wrap-up pairing. Full suite **403 pass**.

Verified end-to-end on a real campaign: NPCs in Play went from Vienna figures to **Zanier · Endicott (died this session) · Thomas Wyndham · Thibault · Pyke · Rosa**.

## Release

gm-apprentice 1.7.2 → 1.7.3; gm-apprentice-publish 1.2.2 → 1.2.3; CHANGELOG updated.