### PR TITLE
session-wrapup: keep PC entity sheets current each wrap-up

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Validate content filtering rules
         run: python scripts/validate_schema.py filtering tests/benchmark-campaign
 
+      - name: PC entity-sheet freshness regression
+        run: python tests/test_pc_freshness.py
+
   pr-discipline:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ _backup/
 # Skill zip distribution files (built by scripts/build-skill-zips.sh)
 dist/
 
+# Python bytecode (from scripts/ and tests/)
+__pycache__/
+*.pyc
+
 # Personal GURPS reference files (not for distribution)
 skills/ttrpg-expert/systems/gurps-4e/personal/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.7.4] — 2026-06-26
+
+### Fixed
+
+- **session-wrapup now keeps PC entity sheets current.** Wrap-up advanced
+  each active PC's Story file (Step 3b) and the campaign overview (Step 4b)
+  every session, but never the PC's own entity sheet — so its `asOfSession`,
+  `lastUpdated`, chapter `tags`, and especially the player-facing
+  `## Current Status` block froze at whatever session it was last hand-edited.
+  Because `## Current Status` publishes (it sits outside the `<!-- gm-only -->`
+  fence), the live character page rendered a stale status that contradicted
+  the current Story narrative on the same page. A new **Step 3c (PC Sheet
+  Refresh)** reconciles those fields and the `## Current Status` block every
+  wrap-up, skipping `dead` PCs.
+
+### Added
+
+- **`## Current Status` is now a canonical PC body section.** Documented in
+  `shared/entity-schema.md` and added to all six `pc-*` templates as a
+  skill-maintained, player-facing block holding the PC's **cumulative living
+  state** in labelled fields (`Location`, `Condition`, `Carrying`,
+  `Open threads`, `Knows (exclusive)`) — the counterpart to the protected
+  `## Notes`/`## GM Notes`. Each wrap-up reconciles it cumulatively:
+  unresolved `Open threads` carry forward across sessions, new ones are
+  added, resolved ones removed — so a single read of the latest sheet gives
+  the always-current state without walking old wrap-ups. Existing sheets
+  self-heal on their next wrap-up.
+- **PC freshness check** (`validate_schema.py freshness <vault>`): flags
+  active PC entity sheets whose `asOfSession` lags the campaign overview's,
+  with a Python regression suite (`tests/test_pc_freshness.py`) and fixture.
+  Pointed at a vault with the old behaviour it fails; after a wrap-up it
+  passes — guarding the drift from returning.
+
+---
+
 ## [1.7.3] — 2026-06-26
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
-- ~~session-wrapup: PC entity-sheet drift fix~~ — Wrap-up never refreshed the PC's own sheet, so its `asOfSession`, chapter `tags`, and the published `## Current Status` froze behind the Story file and overview. New Step 3c refreshes active PC sheets each session; `## Current Status` is now a canonical template section; added a `validate_schema.py freshness` regression check + test fixture (PR #TBD)
+- ~~session-wrapup: PC entity-sheet drift fix~~ — Wrap-up never refreshed the PC's own sheet, so its `asOfSession`, chapter `tags`, and the published `## Current Status` froze behind the Story file and overview. New Step 3c refreshes active PC sheets each session; `## Current Status` is now a canonical template section; added a `validate_schema.py freshness` regression check + test fixture (PR #57)
 - ~~World evolution integration into reconcile~~ — Reconcile step 5.5 offers faction turns, consequence surfacing, foreshadowing review after session confidence is promoted. Removed dead campaign-tracker.md references. Added `world-evolution` entity source and `world_evolved` session field (PR #52)
 - ~~Publish tool: landing recap + wrap-up sidebar fix~~ — Landing page now extracts recap from wrap-up file, links to wrap-up page, wrap-up pages suppress backlinks sidebar, world_flags excluded from build (PR #51)
 - ~~Campaign overview template with current game date~~ — `campaign_overview` entity type with session-wrapup auto-updates and the-midwife creation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ Items are force-ranked by score. Higher score = do first.
 
 ## Completed
 
+- ~~session-wrapup: PC entity-sheet drift fix~~ — Wrap-up never refreshed the PC's own sheet, so its `asOfSession`, chapter `tags`, and the published `## Current Status` froze behind the Story file and overview. New Step 3c refreshes active PC sheets each session; `## Current Status` is now a canonical template section; added a `validate_schema.py freshness` regression check + test fixture (PR #TBD)
 - ~~World evolution integration into reconcile~~ — Reconcile step 5.5 offers faction turns, consequence surfacing, foreshadowing review after session confidence is promoted. Removed dead campaign-tracker.md references. Added `world-evolution` entity source and `world_evolved` session field (PR #52)
 - ~~Publish tool: landing recap + wrap-up sidebar fix~~ — Landing page now extracts recap from wrap-up file, links to wrap-up page, wrap-up pages suppress backlinks sidebar, world_flags excluded from build (PR #51)
 - ~~Campaign overview template with current game date~~ — `campaign_overview` entity type with session-wrapup auto-updates and the-midwife creation

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -371,8 +371,9 @@ FreshnessResult = namedtuple(
 )
 
 # A PC with one of these statuses is intentionally frozen at the session
-# it left the story — staleness there is correct, not drift.
-FROZEN_PC_STATUSES = {"dead"}
+# it left active play — died, or off-screen/missing — so staleness there
+# is correct, not drift. `alive` and `unknown` PCs are checked.
+FROZEN_PC_STATUSES = {"dead", "missing"}
 
 
 def parse_session_ordinal(value: str | None) -> tuple[int, int] | None:

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -15,6 +15,7 @@ Defaults to tests/benchmark-campaign/ if no path provided.
 
 import re
 import sys
+from collections import namedtuple
 from pathlib import Path
 
 # Valid enum values
@@ -64,6 +65,7 @@ REQUIRED_FIELDS = {
     "meta": ["type"],
     "timeline": ["type"],
     "player-characters": ["type"],
+    "character-story": ["type", "source_confidence"],
     "campaign_overview": ["type", "source_confidence"],
     "heritage": ["type", "source_confidence"],
     "plan": ["type", "source_confidence", "plan_type", "chapter"],
@@ -355,6 +357,125 @@ def validate_filtering(campaign_dir: Path) -> int:
     return errors
 
 
+# PC entity-sheet freshness
+#
+# session-wrapup advances each active PC's Story file and the campaign
+# overview every session, but historically never the PC's own entity
+# sheet — so `asOfSession` (and the published `## Current Status`) froze
+# sessions behind the rest of the vault. This check flags active PC
+# sheets whose `asOfSession` lags the campaign overview's.
+
+StalePc = namedtuple("StalePc", ["name", "pc_asof", "campaign_asof"])
+FreshnessResult = namedtuple(
+    "FreshnessResult", ["stale", "campaign_asof", "unparseable", "checked", "reference"]
+)
+
+# A PC with one of these statuses is intentionally frozen at the session
+# it left the story — staleness there is correct, not drift.
+FROZEN_PC_STATUSES = {"dead"}
+
+
+def parse_session_ordinal(value: str | None) -> tuple[int, int] | None:
+    """Parse an `asOfSession` label into a comparable (chapter, session) pair.
+
+    Handles the mixed labelling real vaults accumulate as chapters
+    renumber sessions: "Chapter 4, Session 3" -> (4, 3),
+    "Session 10" -> (0, 10), "Chapter 2" -> (2, 0). A missing chapter
+    sorts as chapter 0, so any bare "Session N" ranks below a later
+    chapter. Returns None when neither a chapter nor a session number is
+    present (unparseable — skipped rather than guessed).
+    """
+    if not isinstance(value, str):
+        return None
+    chapter = re.search(r"\bchapter\s*(\d+)", value, re.IGNORECASE)
+    session = re.search(r"\bsession\s*(\d+)", value, re.IGNORECASE)
+    if not chapter and not session:
+        return None
+    return (
+        int(chapter.group(1)) if chapter else 0,
+        int(session.group(1)) if session else 0,
+    )
+
+
+def find_stale_pcs(campaign_dir: Path) -> FreshnessResult:
+    """Find active PC entity sheets lagging the campaign overview's asOfSession.
+
+    Only `type: pc` sheets are inspected — never `character-story`
+    companions or the `player-characters` digest. The check no-ops when
+    there is no campaign overview asOfSession to compare against.
+    """
+    campaign_asof = None
+    pcs = []  # (name, asOfSession, status)
+
+    for filepath in sorted(campaign_dir.rglob("*.md")):
+        # Skip template scaffolding — templates carry empty temporal
+        # fields by design and are never "stale".
+        if "_Templates" in filepath.parts or filepath.stem.startswith("_Template"):
+            continue
+        try:
+            content = filepath.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        frontmatter = extract_frontmatter(content)
+        if frontmatter is None:
+            continue
+        entity_type = frontmatter.get("type", "")
+        if entity_type == "campaign_overview":
+            campaign_asof = frontmatter.get("asOfSession") or campaign_asof
+        elif entity_type == "pc":
+            pcs.append(
+                (filepath.stem, frontmatter.get("asOfSession"), frontmatter.get("status"))
+            )
+
+    reference = parse_session_ordinal(campaign_asof)
+    stale = []
+    unparseable = []
+    checked = 0
+
+    if reference is None:
+        # No usable campaign position — cannot judge freshness.
+        return FreshnessResult([], campaign_asof, unparseable, checked, None)
+
+    for name, pc_asof, status in pcs:
+        if status in FROZEN_PC_STATUSES:
+            continue
+        pc_ordinal = parse_session_ordinal(pc_asof)
+        if pc_ordinal is None:
+            unparseable.append(name)
+            continue
+        checked += 1
+        if pc_ordinal < reference:
+            stale.append(StalePc(name, pc_asof, campaign_asof))
+
+    return FreshnessResult(stale, campaign_asof, unparseable, checked, reference)
+
+
+def validate_freshness(campaign_dir: Path) -> int:
+    """Report stale PC entity sheets. Returns exit code (1 if any stale)."""
+    result = find_stale_pcs(campaign_dir)
+
+    if result.reference is None:
+        print(
+            "  No comparable campaign-overview asOfSession found — "
+            "skipping PC freshness check."
+        )
+        return 0
+
+    print(f"  Campaign position: asOfSession = {result.campaign_asof!r}")
+    print(f"  Active PC sheets checked: {result.checked}")
+
+    for name in result.unparseable:
+        print(f"  WARN  {name}: unparseable asOfSession — skipped")
+
+    for pc in result.stale:
+        print(
+            f"  STALE {pc.name}: asOfSession {pc.pc_asof!r} lags "
+            f"campaign {pc.campaign_asof!r}"
+        )
+
+    return 1 if result.stale else 0
+
+
 def validate_campaign(campaign_dir: Path) -> int:
     """Validate campaign entity schemas. Returns exit code."""
     md_files = list(campaign_dir.rglob("*.md"))
@@ -395,6 +516,9 @@ def main():
     if args and args[0] == "filtering":
         mode = "filtering"
         campaign_dir = Path(args[1]) if len(args) > 1 else campaign_dir
+    elif args and args[0] == "freshness":
+        mode = "freshness"
+        campaign_dir = Path(args[1]) if len(args) > 1 else campaign_dir
     elif args:
         campaign_dir = Path(args[0])
 
@@ -411,6 +535,9 @@ def main():
         else:
             print("\nAll scenes have deterministic filtering rules")
             sys.exit(0)
+    elif mode == "freshness":
+        print(f"PC freshness validation: {campaign_dir}")
+        sys.exit(validate_freshness(campaign_dir))
     else:
         sys.exit(validate_campaign(campaign_dir))
 

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -132,8 +132,9 @@ its frontmatter and its **published** `## Current Status` freeze
 sessions behind the narrative. The `## Current Status` block is
 the PC's **cumulative living state** — the canonical, always-current
 answer to "where is this character now, and what's still open for
-them." Refresh each **active** PC sheet (skip PCs whose `status` is
-`dead`):
+them." Refresh the sheet of each PC **active in this session** (the
+same set Step 3b writes a story entry for — this excludes `dead` PCs
+and any who were off-screen this session):
 
 1. Frontmatter: set `asOfSession` and `lastUpdated` to the
    current session (same values Step 3b writes to the Story file).

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -123,6 +123,53 @@ Writes for the current session only — no backfilling. If prior
 sessions are missing from a story file, that's vault-ingest
 territory. Never edit prior session entries (append-only).
 
+### 3c. PC Sheet Refresh
+
+The Story file (3b) and PC Carry-Forward (3) advance every
+session, but the PC's own entity sheet
+(`Characters/PCs/{Name}.md`) does not unless refreshed here — so
+its frontmatter and its **published** `## Current Status` freeze
+sessions behind the narrative. The `## Current Status` block is
+the PC's **cumulative living state** — the canonical, always-current
+answer to "where is this character now, and what's still open for
+them." Refresh each **active** PC sheet (skip PCs whose `status` is
+`dead`):
+
+1. Frontmatter: set `asOfSession` and `lastUpdated` to the
+   current session (same values Step 3b writes to the Story file).
+2. `tags`: replace the prior chapter/arc tag with the current
+   chapter's tag (from the session index or campaign overview).
+   Preserve all non-chapter tags (archetype, system, status).
+3. `## Current Status`: **reconcile** the block — don't just
+   overwrite it. Read the PC's *prior* block, then update it
+   against this session's PC Carry-Forward (Step 3) and Recap:
+   - **Carry** unresolved `Open threads` forward unchanged.
+   - **Add** threads and exclusive knowledge introduced this session.
+   - **Remove** `Open threads` the session resolved.
+   - **Refresh** `Location` / `Condition` / `Carrying` to current truth.
+
+   Use the labelled-field format (present tense, player-facing),
+   **not** the retrospective narrative of the Story file. If the
+   section is absent, create it; place it before `## Notes`, outside
+   any `<!-- gm-only -->` fence. See `shared/entity-schema.md` for the
+   field spec.
+4. Leave `## Notes`, `## GM Notes`, and all gm-only content
+   untouched (protected sections).
+
+**Input:** the prior `## Current Status` block + this session's PC
+Carry-Forward (Step 3) and Narrative Recap (Step 2). No new source
+gathering.
+
+*Authoring operation — reconcile the living state to match the
+session just played. Stay grounded in the carry-forward and recap;
+no embellishment, never invent state the session didn't produce.*
+(authoring exception to `shared/content-fidelity.md`)
+
+Surface each PC's refreshed `## Current Status` and changed
+frontmatter in the conversation for GM review (alongside the
+Step 4 entity receipt). Do **not** write a receipt into the
+Wrap-Up file — the PC sheet is the permanent record.
+
 ### 4. Update the World
 
 **gmassistant.app path:** When the Play Notes are a
@@ -299,6 +346,8 @@ Wrap-up **must** produce all sections so prep reads one file:
 
 Entity files and timeline are updated separately (Step 4).
 Character story files are updated separately (Step 3b).
+Active PC entity sheets are refreshed separately (Step 3c) —
+frontmatter, chapter tags, and the published `## Current Status`.
 The session index is updated to `wrap-up` status (or `reviewed`
 if reconcile completes). Update `play_date` and `in_game_date`
 on the session index if not already set.

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -439,6 +439,7 @@ same skeleton.
 ## Background          — backstory, personality, description
 ## [System Sections]   — varies by system (see per-system template)
 ## Equipment           — gear, possessions, wealth/encumbrance
+## Current Status      — player-facing present-state snapshot (maintained by session-wrapup)
 ## Notes               — player-facing (protected: skills never modify)
 ## GM Notes            — keeper-only (protected: skills never modify)
 ```
@@ -449,6 +450,43 @@ have no `## Equipment` — gear is handled through Quality).
 `## Notes` and `## GM Notes` are **protected sections** — only
 the GM edits them directly. Automated skills must preserve
 their content unchanged.
+
+`## Current Status` is the inverse: a **skill-maintained**,
+player-facing block holding the PC's **cumulative living state** —
+the single always-current answer to "where is this character now,
+and what's still open for them." session-wrapup maintains it every
+session (Step 3c), so the published page and any future consumer
+never drift behind the narrative. It is the canonical current-state
+source, distinct from the `_Story.md` companion (retrospective
+narrative) and the Wrap-Up's PC Carry-Forward (a per-session delta
+that feeds this block).
+
+It uses **stable labelled fields** so the block is both publishable
+and machine-readable; an optional one-line prose lede may precede the
+labels for the website's human read. Fields are omitted when empty:
+
+```markdown
+## Current Status
+
+{optional one-line present-tense lede}
+
+**Location:** {where the PC is now}
+**Condition:** {wounds, SAN, conditions, phobias}
+**Carrying:** {narratively-significant items/objects in hand — not the full Equipment list}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive information this PC holds}
+```
+
+`Open threads` is the load-bearing field: a **cumulative** list that
+carries unresolved items forward across sessions, gains items as they
+arise, and loses them only when resolved. NPC-relationship shifts fold
+into Open threads rather than a separate field.
+
+The block **must** sit outside any `<!-- gm-only -->` fence (it
+publishes) and before the protected `## Notes`/`## GM Notes` sections.
+The GM may also edit it directly; the next wrap-up reconciles it either
+way.
 
 ### Story Companion Convention
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.6.0"
+current_version: "1.7.4"
 ---
 
 # Vault Migration Registry
@@ -233,3 +233,26 @@ Standardizes date field names across session and event entities.
 - **Existing `_midwife/` content** is NOT auto-promoted.
   The GM decides if/when to bring old Midwife output into
   the vault using the new structure.
+
+## Migration: 1.7.3 → 1.7.4
+
+### Content
+
+- **New canonical PC section:** `## Current Status` added to the
+  PC body skeleton (`shared/entity-schema.md`) and to all six
+  `pc-*` templates. It is a player-facing, skill-maintained block
+  holding the PC's cumulative living state in **labelled fields**
+  (`Location`, `Condition`, `Carrying`, `Open threads`,
+  `Knows (exclusive)`) with an optional prose lede. Not backfilled
+  and no GM action required — existing PC sheets without the section
+  gain it automatically on their next wrap-up (the step creates it
+  if absent), and sheets that already carry a hand-written
+  `## Current Status` are reconciled in place.
+- **session-wrapup now refreshes PC entity sheets** (Step 3c):
+  each active PC's `asOfSession`, `lastUpdated`, chapter `tags`,
+  and `## Current Status` advance every session. The status block
+  is reconciled cumulatively — unresolved `Open threads` carry
+  forward across sessions, new ones are added, resolved ones
+  removed — so the published character page no longer drifts behind
+  the Story file and campaign overview. No vault changes are
+  required; the refresh happens during normal wrap-up.

--- a/skills/shared/templates/pc-coc-7e-regency.md
+++ b/skills/shared/templates/pc-coc-7e-regency.md
@@ -191,6 +191,21 @@ createdSession: ""
 | Cash | |
 | Assets | |
 
+## Current Status
+
+{Optional one-line present-tense lede for the published page.}
+
+**Location:** {where the PC is now}
+**Condition:** {wounds, SAN, conditions}
+**Carrying:** {narratively-significant items in hand}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive knowledge, if any}
+
+{Player-facing; sits outside any gm-only fence. Maintained cumulatively
+by session-wrapup (Step 3c): carries unresolved Open threads forward,
+adds new, removes resolved. See shared/entity-schema.md.}
+
 ## Notes
 
 {Player-facing notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-coc-7e.md
+++ b/skills/shared/templates/pc-coc-7e.md
@@ -176,6 +176,21 @@ createdSession: ""
 | Cash | |
 | Assets | |
 
+## Current Status
+
+{Optional one-line present-tense lede for the published page.}
+
+**Location:** {where the PC is now}
+**Condition:** {wounds, SAN, conditions}
+**Carrying:** {narratively-significant items in hand}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive knowledge, if any}
+
+{Player-facing; sits outside any gm-only fence. Maintained cumulatively
+by session-wrapup (Step 3c): carries unresolved Open threads forward,
+adds new, removes resolved. See shared/entity-schema.md.}
+
 ## Notes
 
 {Player-facing notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-dnd-5e-2024.md
+++ b/skills/shared/templates/pc-dnd-5e-2024.md
@@ -180,6 +180,21 @@ createdSession: ""
 |----|----|----|----|----|
 | 0 | 0 | 0 | 0 | 0 |
 
+## Current Status
+
+{Optional one-line present-tense lede for the published page.}
+
+**Location:** {where the PC is now}
+**Condition:** {wounds, conditions, exhaustion}
+**Carrying:** {narratively-significant items in hand}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive knowledge, if any}
+
+{Player-facing; sits outside any gm-only fence. Maintained cumulatively
+by session-wrapup (Step 3c): carries unresolved Open threads forward,
+adds new, removes resolved. See shared/entity-schema.md.}
+
 ## Notes
 
 {Player-facing notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-fitd.md
+++ b/skills/shared/templates/pc-fitd.md
@@ -132,6 +132,21 @@ createdSession: ""
 |------|------|
 | | |
 
+## Current Status
+
+{Optional one-line present-tense lede for the published page.}
+
+**Location:** {where the PC is now}
+**Condition:** {harm, stress, trauma}
+**Carrying:** {narratively-significant items in hand}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive knowledge, if any}
+
+{Player-facing; sits outside any gm-only fence. Maintained cumulatively
+by session-wrapup (Step 3c): carries unresolved Open threads forward,
+adds new, removes resolved. See shared/entity-schema.md.}
+
 ## Notes
 
 {Player-facing notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-generic.md
+++ b/skills/shared/templates/pc-generic.md
@@ -39,6 +39,21 @@ createdSession: ""
 
 {Gear, possessions, and wealth.}
 
+## Current Status
+
+{Optional one-line present-tense lede for the published page.}
+
+**Location:** {where the PC is now}
+**Condition:** {wounds, conditions}
+**Carrying:** {narratively-significant items in hand}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive knowledge, if any}
+
+{Player-facing; sits outside any gm-only fence. Maintained cumulatively
+by session-wrapup (Step 3c): carries unresolved Open threads forward,
+adds new, removes resolved. See shared/entity-schema.md.}
+
 ## Notes
 
 {Player-facing notes. Protected — skills never modify.}

--- a/skills/shared/templates/pc-gurps-4e.md
+++ b/skills/shared/templates/pc-gurps-4e.md
@@ -189,6 +189,21 @@ Top 5 multi-step combat sequences for quick reference.
 | Heavy (3) | | | |
 | X-Heavy (4) | | | |
 
+## Current Status
+
+{Optional one-line present-tense lede for the published page.}
+
+**Location:** {where the PC is now}
+**Condition:** {injuries, HP/FP, conditions}
+**Carrying:** {narratively-significant items in hand}
+**Open threads:**
+- {unresolved, forward-looking item}
+**Knows (exclusive):** {secret/exclusive knowledge, if any}
+
+{Player-facing; sits outside any gm-only fence. Maintained cumulatively
+by session-wrapup (Step 3c): carries unresolved Open threads forward,
+adds new, removes resolved. See shared/entity-schema.md.}
+
 ## Notes
 
 {Player-facing notes. Protected — skills never modify.}

--- a/tests/fixtures/pc-freshness/Characters/PCs/Current_Scout.md
+++ b/tests/fixtures/pc-freshness/Characters/PCs/Current_Scout.md
@@ -1,0 +1,27 @@
+---
+type: pc
+source_confidence: AUTHORITATIVE
+player_name: "Mira"
+status: alive
+asOfSession: "Chapter 2, Session 4"
+lastUpdated: "Chapter 2, Session 4"
+tags:
+  - chapter-2
+---
+
+# Current Scout
+
+## Current Status
+
+**Location:** Forward camp, Chapter 2 frontier
+**Condition:** Healthy
+**Open threads:**
+- Tracks the campaign exactly at Chapter 2, Session 4 — should not be flagged as stale
+
+## Notes
+
+Player-facing notes. Protected — skills never modify.
+
+## GM Notes
+
+Keeper-only notes. Protected — skills never modify.

--- a/tests/fixtures/pc-freshness/Characters/PCs/Fallen_Knight.md
+++ b/tests/fixtures/pc-freshness/Characters/PCs/Fallen_Knight.md
@@ -1,0 +1,27 @@
+---
+type: pc
+source_confidence: AUTHORITATIVE
+player_name: "Tomas"
+status: dead
+asOfSession: "Chapter 1, Session 1"
+lastUpdated: "Chapter 1, Session 1"
+tags:
+  - chapter-1
+---
+
+# Fallen Knight
+
+## Current Status
+
+**Location:** Fell at the Chapter 1 bridge
+**Condition:** Dead (Chapter 1, Session 1)
+**Open threads:**
+- Intentionally frozen at the session of death — staleness here is correct, so the freshness check must skip dead PCs
+
+## Notes
+
+Player-facing notes. Protected — skills never modify.
+
+## GM Notes
+
+Keeper-only notes. Protected — skills never modify.

--- a/tests/fixtures/pc-freshness/Characters/PCs/Stale_Veteran.md
+++ b/tests/fixtures/pc-freshness/Characters/PCs/Stale_Veteran.md
@@ -1,0 +1,27 @@
+---
+type: pc
+source_confidence: AUTHORITATIVE
+player_name: "Reza"
+status: alive
+asOfSession: "Session 2"
+lastUpdated: "Session 2"
+tags:
+  - chapter-1
+---
+
+# Stale Veteran
+
+## Current Status
+
+**Location:** Harborside garrison
+**Condition:** Battle-worn but whole
+**Open threads:**
+- Body frozen at Session 2 while the campaign reached Chapter 2, Session 4 — the drift this regression guards against
+
+## Notes
+
+Player-facing notes. Protected — skills never modify.
+
+## GM Notes
+
+Keeper-only notes. Protected — skills never modify.

--- a/tests/fixtures/pc-freshness/Characters/PCs/Stale_Veteran_Story.md
+++ b/tests/fixtures/pc-freshness/Characters/PCs/Stale_Veteran_Story.md
@@ -1,0 +1,15 @@
+---
+type: character-story
+character: "[[Stale_Veteran]]"
+campaign: "[[Campaign_Overview]]"
+source_confidence: DRAFT
+asOfSession: "Chapter 1, Session 3"
+lastUpdated: "Chapter 1, Session 3"
+createdSession: "Chapter 1, Session 1"
+---
+
+## Chapter 1, Session 3 — Proving the Filter
+
+A `character-story` companion file. Even with an older `asOfSession`,
+it must never be flagged by the PC freshness check — only `type: pc`
+entity sheets are in scope.

--- a/tests/fixtures/pc-freshness/Characters/PCs/Vanished_Agent.md
+++ b/tests/fixtures/pc-freshness/Characters/PCs/Vanished_Agent.md
@@ -1,0 +1,27 @@
+---
+type: pc
+source_confidence: AUTHORITATIVE
+player_name: "Devi"
+status: missing
+asOfSession: "Chapter 1, Session 2"
+lastUpdated: "Chapter 1, Session 2"
+tags:
+  - chapter-1
+---
+
+# Vanished Agent
+
+## Current Status
+
+**Location:** Last seen at the Chapter 1 docks
+**Condition:** Missing since Chapter 1, Session 2
+**Open threads:**
+- Off-screen and unaccounted for — the sheet legitimately freezes while the PC is missing, so the freshness check must skip it like a dead PC
+
+## Notes
+
+Player-facing notes. Protected — skills never modify.
+
+## GM Notes
+
+Keeper-only notes. Protected — skills never modify.

--- a/tests/fixtures/pc-freshness/_Campaign/Campaign_Overview.md
+++ b/tests/fixtures/pc-freshness/_Campaign/Campaign_Overview.md
@@ -1,0 +1,15 @@
+---
+type: campaign_overview
+source_confidence: AUTHORITATIVE
+status: in_progress
+scope: campaign
+current_game_date: "March 12, 1888"
+sessions_played: 9
+asOfSession: "Chapter 2, Session 4"
+lastUpdated: "Chapter 2, Session 4"
+---
+
+# The Hollow Tide
+
+The party's true position. Every active PC sheet should track to
+`asOfSession: "Chapter 2, Session 4"`.

--- a/tests/test_pc_freshness.py
+++ b/tests/test_pc_freshness.py
@@ -61,6 +61,12 @@ class FindStalePcsTests(unittest.TestCase):
         names = [s.name for s in self.result.stale]
         self.assertNotIn("Fallen_Knight", names)
 
+    def test_missing_pc_is_skipped(self):
+        # A missing/off-screen PC's sheet legitimately freezes while
+        # they're out of play — frozen like a dead PC, not a drift bug.
+        names = [s.name for s in self.result.stale]
+        self.assertNotIn("Vanished_Agent", names)
+
     def test_current_pc_not_flagged(self):
         names = [s.name for s in self.result.stale]
         self.assertNotIn("Current_Scout", names)

--- a/tests/test_pc_freshness.py
+++ b/tests/test_pc_freshness.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Regression tests for PC entity-sheet staleness detection.
+
+Guards the bug where session-wrapup advanced PC Story files and the
+campaign overview but never the PC's own entity sheet, leaving
+`asOfSession` (and the published `## Current Status`) frozen sessions
+behind the rest of the vault.
+
+Run: python tests/test_pc_freshness.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import validate_schema as vs  # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "pc-freshness"
+
+
+class ParseSessionOrdinalTests(unittest.TestCase):
+    def test_chapter_and_session(self):
+        self.assertEqual(vs.parse_session_ordinal("Chapter 4, Session 3"), (4, 3))
+
+    def test_bare_session(self):
+        self.assertEqual(vs.parse_session_ordinal("Session 10"), (0, 10))
+
+    def test_bare_chapter(self):
+        self.assertEqual(vs.parse_session_ordinal("Chapter 2"), (2, 0))
+
+    def test_unparseable_returns_none(self):
+        self.assertIsNone(vs.parse_session_ordinal("whenever"))
+        self.assertIsNone(vs.parse_session_ordinal(None))
+        self.assertIsNone(vs.parse_session_ordinal(""))
+
+    def test_real_drift_cases_order_correctly(self):
+        # Regression: the exact Canticle labels that drifted, vs the
+        # campaign's true position (Chapter 4, Session 3).
+        campaign = vs.parse_session_ordinal("Chapter 4, Session 3")
+        self.assertLess(vs.parse_session_ordinal("Session 10"), campaign)            # Adrien/Katherine (Vienna)
+        self.assertLess(vs.parse_session_ordinal("Session 12"), campaign)            # Emma
+        self.assertLess(vs.parse_session_ordinal("Chapter 4, Session 2"), campaign)  # Georgiana (smoking gun)
+        self.assertLess(vs.parse_session_ordinal("Chapter 4, Session 1"), campaign)  # Freddy/Holt
+        # The current position is not behind itself.
+        self.assertFalse(vs.parse_session_ordinal("Chapter 4, Session 3") < campaign)
+
+
+class FindStalePcsTests(unittest.TestCase):
+    def setUp(self):
+        self.result = vs.find_stale_pcs(FIXTURE)
+
+    def test_flags_only_the_stale_active_pc(self):
+        names = sorted(s.name for s in self.result.stale)
+        self.assertEqual(names, ["Stale_Veteran"])
+
+    def test_dead_pc_is_skipped(self):
+        # A dead PC is intentionally frozen — not a drift bug.
+        names = [s.name for s in self.result.stale]
+        self.assertNotIn("Fallen_Knight", names)
+
+    def test_current_pc_not_flagged(self):
+        names = [s.name for s in self.result.stale]
+        self.assertNotIn("Current_Scout", names)
+
+    def test_story_companion_not_flagged(self):
+        # Only `type: pc` entity sheets are checked, never the
+        # append-only `character-story` companions.
+        names = [s.name for s in self.result.stale]
+        self.assertNotIn("Stale_Veteran_Story", names)
+
+
+class ValidateFreshnessTests(unittest.TestCase):
+    def test_exit_code_nonzero_when_stale_pc_present(self):
+        self.assertEqual(vs.validate_freshness(FIXTURE), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

session-wrapup advanced each PC's Story file (Step 3b) and the campaign overview (Step 4b) every session, but never the PC's own entity sheet. Its frontmatter (`asOfSession`, `lastUpdated`, chapter `tags`) and the player-facing `## Current Status` block froze at whatever session it was last hand-edited. Because `## Current Status` sits outside the `<!-- gm-only -->` fence, it publishes — so the live character page rendered a stale status contradicting the current Story narrative on the same page.

Tracing the read-path surfaced the deeper issue: the PC sheet's current-state is read by no skill — only the website and the GM. The only "carries forward" data any skill consumes is the Wrap-Up's PC Carry-Forward, and only from the latest session, so long-lived unresolved threads could silently decay.

## Fix

- New **session-wrapup Step 3c (PC Sheet Refresh)**: for each active PC (skips `dead`), advance `asOfSession` / `lastUpdated` / chapter `tags` and **reconcile** the `## Current Status` block from the prior block + this session's PC Carry-Forward + recap.
- `## Current Status` is now a **canonical PC body section** holding cumulative living state in labelled fields (`Location`, `Condition`, `Carrying`, `Open threads`, `Knows (exclusive)`). Unresolved `Open threads` carry forward across sessions, new ones are added, resolved ones removed — so a single read of the latest sheet is the always-current state. Documented in `entity-schema.md` and all six `pc-*` templates.

## Tests

- New `validate_schema.py freshness <vault>` check + `tests/test_pc_freshness.py` (10 tests) + fixture vault. Flags active PC sheets whose `asOfSession` lags the campaign overview's; skips dead PCs, template scaffolding, and story companions. Pointed read-only at a real campaign with the pre-fix behaviour it flags every stale sheet; after a wrap-up it passes. Wired into CI.
- Validator now recognizes the `character-story` type (previously errored as unknown).
- Schema + filtering pass; 9 skill zips build; markdownlint clean.

## Release

- gm-apprentice 1.7.3 → 1.7.4 (publish tool untouched — no site rebuild needed).
- CHANGELOG, self-healing Content migration entry, and ROADMAP updated.

## Follow-up

Wire the first consumer (`session-prep` reading each active PC's `## Current Status` into its context) so the data becomes load-bearing and drift is caught by a process that depends on it.