### PR TITLE
Fix story spine wiki-links and flat-folder wrap-up matching

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.1] — 2026-07-02
+
+### Fixed
+
+- **Story spine wiki-links:** `buildStorySpine` rendered recap markdown
+  to HTML without running `resolveWikiLinks`, so story unit pages
+  showed raw `[[wiki-link]]` text. Recaps now resolve against their
+  unit's `story/` output path before rendering, matching the PC-page
+  flow.
+- **Wrap-up matching in flat `Sessions/` folders:** `wrapUpForUnit`
+  tried the same-folder heuristic before the ref index, so vaults where
+  every session and wrap-up shares one `Sessions/` folder had every
+  story unit pull the first wrap-up's recap. Exact `session:`/`chapter:`
+  ref matches now win; the folder heuristic only applies when the
+  folder contains exactly one wrap-up.
+
 ## [1.8.0] — 2026-07-02
 
 ### Changed

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -572,7 +572,7 @@ function build(options = {}) {
   }
 
   function buildStory() {
-    const spine = buildStorySpine(pages);
+    const spine = buildStorySpine(pages, linkMap);
     for (const unit of spine) {
       unit.refsHtml = renderRefsHtml(unit);
       const html = renderStoryUnit(unit, config, publishConfig, navFor);

--- a/tools/publish/lib/story-spine.js
+++ b/tools/publish/lib/story-spine.js
@@ -88,19 +88,22 @@ function chapterOwnsSession(chapter, session) {
   return chapterMatchesSession(chapter, session);
 }
 
-// The wrap-up for a unit (chapter or session): a wrap-up page in the SAME folder
-// as the unit's own page (chapter wrap-up sits in the chapter folder; a session
-// wrap-up sits in the session's subfolder). Falls back to the ref index.
+// The wrap-up for a unit (chapter or session). An explicit session:/chapter: ref
+// match always wins. The same-folder fallback (chapter wrap-up in the chapter folder;
+// session wrap-up in the session's subfolder) only applies when that folder holds
+// exactly ONE wrap-up — in flat vaults every session shares one Sessions/ folder, and
+// a first-match grab there would hand the same wrap-up to every session.
 function wrapUpForUnit(unitPage, wrapUps, idx) {
+  const byRef = idx.bySession.get(unitPage.title)
+    || idx.byChapter.get(unitPage.title)
+    || idx.byChapter.get(unitPage.title.replace(/_/g, ' '));
+  if (byRef) return byRef;
   const dir = folderOf(unitPage);
   if (dir) {
-    const sameFolder = wrapUps.find(w => folderOf(w) === dir);
-    if (sameFolder) return sameFolder;
+    const sameFolder = wrapUps.filter(w => folderOf(w) === dir);
+    if (sameFolder.length === 1) return sameFolder[0];
   }
-  return idx.bySession.get(unitPage.title)
-    || idx.byChapter.get(unitPage.title)
-    || idx.byChapter.get(unitPage.title.replace(/_/g, ' '))
-    || null;
+  return null;
 }
 
 function unitOutputPath(id) { return `story/${id}.html`; }

--- a/tools/publish/lib/story-spine.js
+++ b/tools/publish/lib/story-spine.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { extractSections, parseWikiRef } = require('./processor');
+const { extractSections, parseWikiRef, resolveWikiLinks } = require('./processor');
 const { slugify } = require('./scanner');
 
 const RECAP_TITLES = ['narrative recap', 'recap'];
@@ -14,8 +14,9 @@ function publishedOf(page) {
 // Heading match is a case-insensitive CONTAINS, because real vaults decorate the title
 // (e.g. "What Happened — Narrative Recap"). "narrative recap" is tried before the looser
 // "recap" so the more specific heading wins when both are present.
-function findRecap(page) {
-  const sections = extractSections(publishedOf(page));
+function findRecap(page, resolve) {
+  const text = publishedOf(page);
+  const sections = extractSections(resolve ? resolve(text) : text);
   for (const wanted of RECAP_TITLES) {
     const hit = sections.find(s => s.title.trim().toLowerCase().includes(wanted));
     if (hit && hit.html && hit.html.trim()) return { title: hit.title, html: hit.html };
@@ -51,12 +52,12 @@ function buildWrapUpIndex(pages) {
 
 // Recap for a unit: try its wrap-up first (the deliberate post-session/chapter recap),
 // then the unit's own file. Returns { title, html, sourcePage } or null.
-function resolveUnitRecap(unitPage, wrapUpPage) {
+function resolveUnitRecap(unitPage, wrapUpPage, resolve) {
   if (wrapUpPage) {
-    const r = findRecap(wrapUpPage);
+    const r = findRecap(wrapUpPage, resolve);
     if (r) return { ...r, sourcePage: wrapUpPage };
   }
-  const own = findRecap(unitPage);
+  const own = findRecap(unitPage, resolve);
   if (own) return { ...own, sourcePage: unitPage };
   return null;
 }
@@ -115,7 +116,13 @@ function unitRefs(unit) {
   };
 }
 
-function buildStorySpine(pages) {
+function buildStorySpine(pages, linkMap) {
+  // Recap markdown renders to HTML inside findRecap, so wiki-links must resolve here —
+  // downstream has no markdown left to work with. Resolution is relative to the unit's
+  // own output path under story/. Without a linkMap (the hasStory probe), skip it.
+  const resolverFor = linkMap
+    ? (outputPath) => (md) => resolveWikiLinks(md, linkMap, outputPath)
+    : () => undefined;
   const chapters = pages
     .filter(p => p.frontmatter && p.frontmatter.type === 'chapter')
     .sort((a, b) => (a.frontmatter.sort_order || 0) - (b.frontmatter.sort_order || 0)
@@ -126,11 +133,13 @@ function buildStorySpine(pages) {
 
   const units = [];
   for (const chapter of chapters) {
-    const chapterWrap = wrapUpForUnit(chapter, wrapUps, idx);
-    const chapterRecap = resolveUnitRecap(chapter, chapterWrap);
     // Namespace unit ids by chapter so non-unique session titles (e.g. a plain "Session 1"
     // in two chapters) can't collide on the same story/<id>.html output path.
     const chSlug = slugify(chapter.displayTitle || chapter.title);
+    const chapterWrap = wrapUpForUnit(chapter, wrapUps, idx);
+    // The chapter recap lands on either story/<chSlug>-intro.html or story/<chSlug>.html;
+    // both live in story/, so either path yields the same relative link resolution.
+    const chapterRecap = resolveUnitRecap(chapter, chapterWrap, resolverFor(unitOutputPath(chSlug)));
 
     const chapterSessions = sessions
       .filter(s => chapterOwnsSession(chapter, s))
@@ -139,9 +148,9 @@ function buildStorySpine(pages) {
 
     const sessionUnits = [];
     for (const s of chapterSessions) {
-      const recap = resolveUnitRecap(s, wrapUpForUnit(s, wrapUps, idx));
-      if (!recap) continue;
       const id = `${chSlug}-${slugify(s.title)}`;
+      const recap = resolveUnitRecap(s, wrapUpForUnit(s, wrapUps, idx), resolverFor(unitOutputPath(id)));
+      if (!recap) continue;
       sessionUnits.push({
         kind: 'session', id, outputPath: unitOutputPath(id),
         title: s.displayTitle || s.title.replace(/_/g, ' '),

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/story-spine.test.js
+++ b/tools/publish/test/unit/story-spine.test.js
@@ -193,3 +193,40 @@ describe('characterStoryGroup', () => {
     assert.strictEqual(characterStoryGroup({ status: 'missing' }), 'fallen');
   });
 });
+
+describe('wiki-link resolution in story recaps', () => {
+  const pages = [
+    { title: 'Chapter 1 Overview', displayTitle: 'Chapter 1 — The Hungry God', sourcePath: '/v/Chapters/Chapter 1/Chapter 1 Overview.md', frontmatter: { type: 'chapter', sort_order: 1 }, markdown: '## Narrative Recap\nIt began at [[Voss_Campus]].' },
+    { title: 'Session 04 - Fallen Stars', displayTitle: 'Session 04 - Fallen Stars', sourcePath: '/v/Chapters/Chapter 1/Sessions/Session 04 - Fallen Stars.md', frontmatter: { type: 'session', session_number: 4 }, markdown: '## Narrative Recap\nThe team hit [[Voss_Campus]] with [[Ronnie_Vint|Ronnie]] and met [[Nobody_Known]].' },
+  ];
+  const linkMap = {
+    Voss_Campus: 'locations/voss-campus.html',
+    Ronnie_Vint: 'characters/pcs/ronnie-vint.html',
+  };
+
+  it('resolves [[wiki-links]] in session recap HTML against the link map', () => {
+    const spine = buildStorySpine(pages, linkMap);
+    const u = spine.find(x => x.kind === 'session');
+    assert.match(u.recapHtml, /<a href="\.\.\/locations\/voss-campus\.html">Voss Campus<\/a>/);
+    assert.match(u.recapHtml, /<a href="\.\.\/characters\/pcs\/ronnie-vint\.html">Ronnie<\/a>/);
+    assert.ok(!u.recapHtml.includes('[['), 'no raw wiki-link syntax may remain');
+  });
+
+  it('renders unresolvable links as humanized plain text', () => {
+    const spine = buildStorySpine(pages, linkMap);
+    const u = spine.find(x => x.kind === 'session');
+    assert.match(u.recapHtml, /Nobody Known/);
+    assert.ok(!/Nobody_Known/.test(u.recapHtml));
+  });
+
+  it('resolves links in chapter-intro recaps too', () => {
+    const spine = buildStorySpine(pages, linkMap);
+    const intro = spine.find(x => x.kind === 'chapter-intro');
+    assert.match(intro.recapHtml, /<a href="\.\.\/locations\/voss-campus\.html">Voss Campus<\/a>/);
+  });
+
+  it('leaves recaps unresolved-but-intact when no link map is given (hasStory probe)', () => {
+    const spine = buildStorySpine(pages);
+    assert.ok(spine.length > 0);
+  });
+});

--- a/tools/publish/test/unit/story-spine.test.js
+++ b/tools/publish/test/unit/story-spine.test.js
@@ -230,3 +230,37 @@ describe('wiki-link resolution in story recaps', () => {
     assert.ok(spine.length > 0);
   });
 });
+
+describe('wrap-up matching in a flat Sessions/ folder', () => {
+  // Real vaults often keep every session AND every wrap-up in one shared Sessions/
+  // folder. The same-folder heuristic must not shotgun the first wrap-up onto every
+  // session — the explicit session: ref has to win.
+  const pages = [
+    { title: 'Chapter 1 Overview', displayTitle: 'Chapter 1', sourcePath: '/v/Chapters/Ch1/Chapter 1 Overview.md', frontmatter: { type: 'chapter', sort_order: 1 }, markdown: '## Overview\nx' },
+    { title: 'Session 01 - Alpha', sourcePath: '/v/Chapters/Ch1/Sessions/Session 01 - Alpha.md', frontmatter: { type: 'session', session_number: 1 }, markdown: '## Overview\nx' },
+    { title: 'Session 02 - Bravo', sourcePath: '/v/Chapters/Ch1/Sessions/Session 02 - Bravo.md', frontmatter: { type: 'session', session_number: 2 }, markdown: '## Overview\nx' },
+    { title: 'Session 01 - Alpha - Wrap-Up', sourcePath: '/v/Chapters/Ch1/Sessions/Session 01 - Alpha - Wrap-Up.md', frontmatter: { type: 'session_wrap', session: '[[Session 01 - Alpha]]' }, markdown: '## Narrative Recap\nALPHA RECAP' },
+    { title: 'Session 02 - Bravo - Wrap-Up', sourcePath: '/v/Chapters/Ch1/Sessions/Session 02 - Bravo - Wrap-Up.md', frontmatter: { type: 'session_wrap', session: '[[Session 02 - Bravo]]' }, markdown: '## Narrative Recap\nBRAVO RECAP' },
+  ];
+
+  it('gives each session its OWN wrap-up recap, not the first wrap-up in the folder', () => {
+    const spine = buildStorySpine(pages);
+    const s1 = spine.find(u => u.title.includes('Alpha'));
+    const s2 = spine.find(u => u.title.includes('Bravo'));
+    assert.match(s1.recapHtml, /ALPHA RECAP/);
+    assert.ok(!/BRAVO/.test(s1.recapHtml), 'session 1 must not get session 2 content');
+    assert.match(s2.recapHtml, /BRAVO RECAP/);
+    assert.ok(!/ALPHA/.test(s2.recapHtml), 'session 2 must not get session 1 content');
+  });
+
+  it('still uses the same-folder heuristic when it is unambiguous (per-session subfolders)', () => {
+    const nested = [
+      { title: 'Chapter 4 Overview', displayTitle: 'Chapter 4', sourcePath: '/v/Chapters/Ch4/Chapter 4 Overview.md', frontmatter: { type: 'chapter', sort_order: 4 }, markdown: '## Overview\nx' },
+      { title: 'Session 01', sourcePath: '/v/Chapters/Ch4/Sessions/Session 01/Session 01.md', frontmatter: { type: 'session', session_number: 1 }, markdown: '## Overview\nx' },
+      { title: 'Session 01 Wrap Up', sourcePath: '/v/Chapters/Ch4/Sessions/Session 01/Session_01_Wrap_Up.md', frontmatter: { type: 'session_wrap', session: 'Session 01 - The Morning After' }, markdown: '## Narrative Recap\nSubfolder recap.' },
+    ];
+    const spine = buildStorySpine(nested);
+    assert.strictEqual(spine.length, 1);
+    assert.match(spine[0].recapHtml, /Subfolder recap/);
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve `[[wiki-links]]` in story-spine recap markdown before rendering to HTML, matching the PC-page flow. Previously raw `[[...]]` text leaked onto published story unit pages.
- Fix `wrapUpForUnit` to try exact `session:`/`chapter:` ref matches before the same-folder heuristic, and only fall back to same-folder when it's unambiguous (exactly one wrap-up in the folder). Previously vaults with a flat `Sessions/` folder had every story unit pull the first wrap-up's recap regardless of which session it belonged to.

## Test plan
- [x] `node --test test/unit/story-spine.test.js` — 24/24 passing
- [x] Local code review (medium effort) — no defects found