### PR TITLE
Standardize GM-only content hiding, add spoiler lifecycle, fix publish leaks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.9.0",
+  "version": "1.8.3",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and guided adventure creation",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Portrait-less entity hero banners rendered their initials avatar as
   a clipped sliver overlapping the entity name instead of stacking
   above it.
+- NPC portraits rendered as a cropped hero-banner background — showing
+  only a thin band around the image's 25%-height line, with no way to
+  view the full portrait — because the with-portrait branch used the
+  same landscape-oriented layout as location art instead of the
+  portrait-shaped card PC pages already use. Also, hero images
+  (portraits included) weren't wired into the site's click-to-enlarge
+  lightbox at all, since the binding only looked inside `.content`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.0] — 2026-07-04
+
+### Added
+
+- **`## GM Notes` is now the single canonical heading for whole-section
+  GM-only content**, replacing the exact-heading-string-list approach
+  (`exclude_sections`) that couldn't generalize — a production vault
+  had grown that list to 47 one-off entries and was still leaking.
+  Anything that used to get its own top-level heading (Keeper
+  Checklist, World State, Source References, tactical notes, etc.)
+  becomes a subsection nested under `## GM Notes` instead; the publish
+  tool's heading filter is already level-aware, so this needed no
+  filtering-code changes.
+- **`<!-- spoiler -->` marker** for narrative content that's hidden
+  only until it's revealed in play, distinct from permanently-hidden
+  `<!-- gm-only -->` content. `reconcile` gains a step asking the GM,
+  per session, whether any spoilers in entities touched that session
+  were revealed — if so, the fence is stripped and the content becomes
+  permanently public prose.
+- **campaign-qa: two new checks** — un-fenced GM-only content
+  (headings or bold-paragraph lines that look GM-only but sit outside
+  any hiding mechanism) and an open-spoilers audit listing every
+  currently-pending `<!-- spoiler -->` block for GM review.
+- Migration entry backfilling existing vaults: re-nests every heading
+  already in a vault's `exclude_sections` list under `## GM Notes`,
+  with a GM-confirmed batch for bold-wrapped headings, bold-paragraph
+  pseudo-headings, and callout-only-marked content that exact-string
+  matching can't catch.
+
+### Fixed
+
+- `exclude_fields` had the same config-shadowing bug already fixed for
+  `exclude_sections`/`exclude_dirs` in previous work — a field named
+  only in `vault.config.json` was silently never stripped. Now unions
+  both sources like its siblings. Defaults gain `gm_notes` and
+  `prep_notes` (real, populated fields that were never excluded);
+  `secrets`/`current_plan`/`plan_progress` stay in the list even
+  though unused, since removing them could strip less than some vault
+  depends on.
+- Landing page session recap extraction read raw markdown instead of
+  the publish-filtered view, so it could quote GM-only content; also
+  fixed matching the wrong chapter's wrap-up when two chapters share a
+  session number, and wikilink targets rendering with literal
+  underscores instead of spaces.
+- Portrait-less entity hero banners rendered their initials avatar as
+  a clipped sliver overlapping the entity name instead of stacking
+  above it.
+
+### Removed
+
+- `PUBLISH_SITE_BUGS_SPEC.md` — verified against current code that
+  every item in it (a narrative-IA redesign and eight defects) already
+  shipped in previous releases.
+
 ## [1.8.2] — 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.9.0] — 2026-07-04
+## [1.8.3] — 2026-07-04
 
 ### Added
 

--- a/skills/campaign-organizer/references/migration-procedure.md
+++ b/skills/campaign-organizer/references/migration-procedure.md
@@ -137,7 +137,8 @@ List each content change as a checkbox. Example:
 >       Notes` subsection under `## GM Notes`
 > - [ ] Move `> [!info] Keeper Only` callout in
 >       `Creatures/Harmonische_Wachter.md` (currently unprotected)
->       under `## GM Notes`
+>       under `## GM Notes` (or wrap in `<!-- spoiler -->` if this
+>       is a time-locked reveal, not a permanent secret)
 
 **Tooling (choose which to apply):**
 List each tooling change as a checkbox. Example:
@@ -193,8 +194,9 @@ Apply all confirmed changes in this order:
    appending under an existing one otherwise), demoting the
    moved heading and any of its own sub-headings by the amount
    needed to sit one level below `## GM Notes`. Once every
-   entry has been re-nested somewhere, collapse the vault's own
-   `exclude_sections` list down to `["GM Notes"]` (structural)
+   entry that had at least one matching heading has been
+   re-nested, collapse the vault's own `exclude_sections` list
+   down to `["GM Notes"]` (structural)
 7. Copy selected templates to `_Templates/` (content)
 8. Overwrite selected templates in `_Templates/` (content)
 9. Update or add selected `_meta/entity-types.md`
@@ -206,7 +208,9 @@ Apply all confirmed changes in this order:
 10. Apply selected bold-wrapped-heading, bold-paragraph, and
     callout-only conversions from the judgment batch — each one
     the GM checked in the Content preview becomes a `###`
-    subsection under `## GM Notes` in its file (content)
+    subsection under `## GM Notes`, or is wrapped in
+    `<!-- spoiler -->` fence markers instead, per which
+    destination the GM chose for that item (content)
 11. Create selected story files using
     `shared/templates/character-story.md` as the base, filling
     in the PC name and campaign from the PC file's frontmatter

--- a/skills/campaign-organizer/references/migration-procedure.md
+++ b/skills/campaign-organizer/references/migration-procedure.md
@@ -74,6 +74,29 @@ already satisfied:
   too, for the same reason as the entity-types.md check above —
   an old-pattern file can reappear from any skill that still
   emits the old link, not just from a pending versioned migration
+- **GM-only heading vocabulary matches the canonical single
+  heading** — read the vault's own `_meta/vault-config.md`
+  `exclude_sections` list. If it's exactly `["GM Notes"]` (or a
+  subset of it), skip. Otherwise, for each other entry, search the
+  vault for real markdown headings (any level) matching that text
+  exactly — pending, listed as a mechanical re-nesting item. This
+  check always runs, for the same reason as the two checks above —
+  drift accumulates one new heading name at a time, from any skill
+  invocation, not from a single migration event
+- **Bold-wrapped or bold-paragraph GM-only content** — for each
+  entry in the vault's `exclude_sections` list, also search for
+  that text appearing inside a bold-wrapped heading
+  (`### **{text}**`) or as a bold-paragraph line with no heading
+  marker at all (`**{text}:**`). Any match → pending, listed as a
+  judgment item requiring GM confirmation (not safe to auto-convert
+  — a bold-paragraph line isn't a real heading, and converting it
+  needs the GM to confirm the boundary of what should move)
+- **Callout-only-marked content** — any Obsidian callout (`> [!info]`,
+  `> [!warning]`, etc.) whose title contains "keeper" or "gm" and
+  which is NOT already inside an excluded heading or a
+  `<!-- gm-only -->`/`<!-- spoiler -->` fence → pending, listed as a
+  judgment item (no automatic signal for what it should become —
+  the GM decides whether it's `## GM Notes` or a spoiler)
 
 Only unsatisfied steps appear in the preview.
 
@@ -91,6 +114,9 @@ List each structural change as a bullet. Example:
 >   (`Chapter_03_Session_01_Wrap_Up.md`, ...) — 2 basename
 >   collisions found live in the vault; repair 33 wiki-links
 >   pointing at the old ambiguous names
+> - Re-nest 47 headings (Keeper Checklist, World State, Quality
+>   Notes, ...) under `## GM Notes` across 62 files; collapse
+>   `exclude_sections` from 47 entries down to `["GM Notes"]`
 
 **Content (choose which to apply):**
 List each content change as a checkbox. Example:
@@ -102,6 +128,16 @@ List each content change as a checkbox. Example:
 >       (has `date` (in-game); canonical is `in_game_date` (in-game))
 > - [ ] Add `entity-types.md` — `character-story` field block
 >       (missing from vault schema mirror)
+> - [ ] Convert `### **Keeper Notes**` (bold-wrapped heading) in
+>       `Characters/NPCs/Doctor_Carreau.md` to a plain `### Keeper
+>       Notes` subsection under `## GM Notes`
+> - [ ] Convert `**Keeper Notes – Reactions to Rescue:**`
+>       (bold-paragraph, no heading) in
+>       `Locations/Orphean_Society_Building.md` to a `### Keeper
+>       Notes` subsection under `## GM Notes`
+> - [ ] Move `> [!info] Keeper Only` callout in
+>       `Creatures/Harmonische_Wachter.md` (currently unprotected)
+>       under `## GM Notes`
 
 **Tooling (choose which to apply):**
 List each tooling change as a checkbox. Example:
@@ -151,19 +187,31 @@ Apply all confirmed changes in this order:
    sits outside any chapter context and more than one renamed
    file could be the referent), list it in the Step 8 report for
    the GM to resolve by hand rather than guessing (structural)
-6. Copy selected templates to `_Templates/` (content)
-7. Overwrite selected templates in `_Templates/` (content)
-8. Update or add selected `_meta/entity-types.md`
+6. Re-nest every mechanically-matched heading from the vault's
+   `exclude_sections` list as a `###` subsection under `##
+   GM Notes` in its file (creating `## GM Notes` if absent,
+   appending under an existing one otherwise), demoting the
+   moved heading and any of its own sub-headings by the amount
+   needed to sit one level below `## GM Notes`. Once every
+   entry has been re-nested somewhere, collapse the vault's own
+   `exclude_sections` list down to `["GM Notes"]` (structural)
+7. Copy selected templates to `_Templates/` (content)
+8. Overwrite selected templates in `_Templates/` (content)
+9. Update or add selected `_meta/entity-types.md`
    Type-Specific Fields entries — replace the stale line in
    place for an update, or insert the new line in the same
    relative position it holds in `shared/entity-schema.md` for
    an addition. Never touch vault-only (custom/evolved) entries
    (content)
-9. Create selected story files using
-   `shared/templates/character-story.md` as the base, filling
-   in the PC name and campaign from the PC file's frontmatter
-   (content)
-10. Run `npm update gm-apprentice-publish` in site directory if
+10. Apply selected bold-wrapped-heading, bold-paragraph, and
+    callout-only conversions from the judgment batch — each one
+    the GM checked in the Content preview becomes a `###`
+    subsection under `## GM Notes` in its file (content)
+11. Create selected story files using
+    `shared/templates/character-story.md` as the base, filling
+    in the PC name and campaign from the PC file's frontmatter
+    (content)
+12. Run `npm update gm-apprentice-publish` in site directory if
     selected (tooling)
 
 ## Step 7: Stamp version

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -290,7 +290,7 @@ entries. Skip undefined domains — no false positives.
 Runs all modes in order: Canon Audit → Timeline
 Validation → Name Similarity → Clue Redundancy → Graph
 Health → Legacy Canon Field Repair → World Consistency
-(if `_World/` exists).
+(if `_World/` exists) → Open Spoilers.
 Deduplicates findings that appear in multiple checks.
 Produces a unified report.
 

--- a/skills/campaign-qa/references/check-procedures.md
+++ b/skills/campaign-qa/references/check-procedures.md
@@ -376,6 +376,19 @@ relationships (more than 2 standard deviations above the mean
 for their type). These are often over-linked — some
 connections are implied by traversal rather than direct.
 
+**Un-fenced GM-only content:** Search every file for headings
+(any level) and bold-paragraph lines (`**Text:**` with no `#`)
+whose text contains one of: "keeper", "secret", "tactic",
+"confidential", "gm-only", "dm notes" — case-insensitive. For
+each match, check whether it sits inside a `## GM Notes` section
+or a `<!-- gm-only -->`/`<!-- spoiler -->` fence. If it doesn't,
+flag it — this is exactly the shape of content that silently
+leaks to the published site (an NPC's tactical notes under a
+bold-wrapped `### **Keeper Notes**` heading defeat exact-string
+matching the same way a genuinely un-fenced heading does).
+Severity: Critical if the vault has `publish.site_dir`
+configured (it's actually publishing); Warning otherwise.
+
 ### Step 3: Schema Compliance
 
 Read `_meta/entity-types.md` for the type hierarchy and
@@ -525,3 +538,30 @@ files restored from backups, copied from old campaigns, or
 written by outdated tooling can reintroduce legacy names. This
 check makes campaign-qa the permanent enforcement point:
 always repair to `canon_status`.
+
+---
+
+## Open Spoilers
+
+Not gated behind any trigger — run this section during any full QA
+pass, since spoilers carry no timestamp and there's no way to compute
+staleness for them.
+
+**Procedure:** search the whole vault for `<!-- spoiler -->` markers.
+For each one found, list:
+- The file it's in
+- The first ~15 words of the spoiler text (enough to identify it, not
+  the whole spoiler)
+- Whether the file's `lastUpdated`/`asOfSession` suggests it's from an
+  old session (informational only — not a hard staleness rule, since
+  there's no per-spoiler timestamp)
+
+Present as a single list for GM review: "Here are your N open
+spoilers — anything here that got revealed in play and just never got
+unwrapped? Anything that's dead because the plot moved on and should
+just be deleted rather than left pending forever?"
+
+- Severity: **Info** (this is a review prompt, not a defect)
+- No automated fix — the GM decides per spoiler whether to leave it,
+  manually strip the markers (revealed), or delete the content
+  (dropped plot thread)

--- a/skills/campaign-qa/references/check-procedures.md
+++ b/skills/campaign-qa/references/check-procedures.md
@@ -18,6 +18,7 @@ perform each check systematically.
 5. [Graph Health](#graph-health)
 6. [Stale DRAFT Detection](#stale-draft-detection)
 7. [Legacy Canon Field Repair](#legacy-canon-field-repair)
+8. [Open Spoilers](#open-spoilers)
 
 ---
 
@@ -386,6 +387,11 @@ flag it — this is exactly the shape of content that silently
 leaks to the published site (an NPC's tactical notes under a
 bold-wrapped `### **Keeper Notes**` heading defeat exact-string
 matching the same way a genuinely un-fenced heading does).
+Skip files the publish pipeline would already exclude wholesale
+(Session Plans and prep-status files, anything under
+`exclude_dirs`, and — when the vault has `exclude_drafts`
+configured — draft entities), so this check only flags content
+that would actually reach the site.
 Severity: Critical if the vault has `publish.site_dir`
 configured (it's actually publishing); Warning otherwise.
 

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -13,7 +13,7 @@ any equivalent in `vault.config.json`.
 |---------|----------|-------------|
 | Publish mode | `publish.mode` | `player` or `full` |
 | Excluded sections | `publish.exclude_sections` | H2 headings to strip (default: `["GM Notes"]`) |
-| Excluded fields | `publish.exclude_fields` | Frontmatter fields to strip (default: `["secrets", "current_plan", "plan_progress"]`) |
+| Excluded fields | `publish.exclude_fields` | Frontmatter fields to strip (default: `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`) |
 | Excluded directories | `publish.exclude_dirs` | Vault directories to skip (default: `["_meta", "_Templates"]`) |
 | Campaign image | `publish.theme.campaign_image` | Vault-relative path to hero image |
 | Theme palette | `publish.theme.palette` | Colour scheme (primary, accent, background, text) |

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -13,7 +13,7 @@ All campaign content falls into three categories:
 - H2 sections listed in `exclude_sections` (default: `["GM Notes"]`)
 - Content between `<!-- gm-only -->` / `<!-- /gm-only -->` markers
 - Frontmatter fields in `exclude_fields` (default:
-  `["secrets", "current_plan", "plan_progress"]`)
+  `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`)
 
 ### Always included
 

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -70,6 +70,42 @@ within a section.
 - Unclosed marker: content stripped to end of file (safe default)
 - Marker inside a code block: ignored (treated as literal)
 
+## Inline Spoiler Markers
+
+For narrative content that's hidden only because the story hasn't
+reached it yet — not permanently secret — use `<!-- spoiler -->` /
+`<!-- /spoiler -->` instead of `<!-- gm-only -->`. Mechanically
+identical (same open/close-pair rules: own lines, body text only, can
+span paragraphs, code-fence-literal), but semantically and
+operationally different:
+
+~~~markdown
+The innkeeper seems friendly enough.
+
+<!-- spoiler -->
+He's secretly reporting the party's movements to the cult.
+<!-- /spoiler -->
+~~~
+
+**`<!-- gm-only -->` never converts** — it's meta content (tactics,
+design notes) that's never meant to be player-facing, regardless of
+story progress.
+
+**`<!-- spoiler -->` is lifecycle-managed.** There's no pre-declared
+reveal date — a GM doesn't know which session will reveal a given
+secret until play gets there. Instead, `reconcile` (run every session)
+checks entities the session actually touched for open `<!-- spoiler -->`
+blocks and asks the GM whether each was revealed in play. On yes, the
+fence markers are stripped — a plain text edit, so the content is
+permanently public prose from then on with no new state to track. See
+`shared/reconcile.md` for the exact step.
+
+Because a spoiler can be revealed in an entity that reconcile didn't
+happen to check that session (the reveal happened in dialogue that
+never made it into the wrap-up notes, or the entity wasn't obviously
+"touched"), campaign-qa also runs a full-vault open-spoilers audit on
+demand — see `campaign-qa/references/check-procedures.md`.
+
 ## Publish Manifest
 
 The manifest at `_meta/publish-manifest.md` is the work order

--- a/skills/session-prep/references/session-templates.md
+++ b/skills/session-prep/references/session-templates.md
@@ -211,39 +211,41 @@ tags: []
 [3-5 paragraphs of dramatic prose capturing the session's events.
 Written for players to read or for campaign journaling.]
 
-## Quick Bullets
+## GM Notes
+
+### Quick Bullets
 
 - [One-line summary of each major event]
 - [Key decisions made]
 - [Important discoveries]
 - [Significant mechanical outcomes]
 
-## PC Carry-Forward
+### PC Carry-Forward
 
 | PC | Arc Update | Open Threads | Next Beat |
 |----|-----------|--------------|-----------|
 | [[Name]] | What changed for this PC | Unresolved threads | What comes next |
 
-## What Carries Forward
+### What Carries Forward
 
-### Active Threads
+#### Active Threads
 [Threads still in play, updated with this session's events]
 
-### New Clues & Hooks
+#### New Clues & Hooks
 [Information or hooks introduced this session]
 
-### Pending Consequences
+#### Pending Consequences
 [Decisions made this session that will have future effects]
 
-### Next Session Seeds
+#### Next Session Seeds
 [Concrete starting points for the next session's prep]
 
-## World State
+### World State
 
 [Updated in-game date, location, active threats, faction
 postures, ticking clocks. Reflects post-session reality.]
 
-## Keeper Checklist
+### Keeper Checklist
 
 - [ ] Entity files created/updated for all new and changed entities
 - [ ] Scene notes updated with played/skipped status
@@ -251,7 +253,7 @@ postures, ticking clocks. Reflects post-session reality.]
 - [ ] Carry-forward threads verified against play notes
 - [ ] Canon status set correctly on all new files
 
-## Quality Notes
+### Quality Notes
 
 [Self-assessment of the session: pacing, spotlight balance,
 player engagement, what worked, what to improve.]

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -296,8 +296,8 @@ facts (heritage references, deity names, new place names):
    suppress), `_World/` domain files (already encoded →
    suppress), and existing entity files (already exists →
    suppress)
-3. Stage findings in the Wrap-Up file under
-   `## World Fact Findings`
+3. Stage findings in the Wrap-Up file's `## GM Notes` section,
+   as a `### World Fact Findings` subsection
 
 **Do not present three-state prompts.** Findings are staged
 for the reconcile procedure (step 2.5) to present during

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -159,8 +159,10 @@ and any who were off-screen this session):
    section is absent, create it; place it before `## Notes`, outside
    any `<!-- gm-only -->` fence. See `shared/entity-schema.md` for the
    field spec.
-4. Leave `## Notes`, `## GM Notes`, and all gm-only content
-   untouched (protected sections).
+4. Leave `## Notes`, `## GM Notes`, and all gm-only/spoiler
+   content untouched (protected sections — see
+   `shared/entity-schema.md`'s PC Body Structure for the
+   protected-vs-excluded distinction).
 
 **Input:** the prior `## Current Status` block + this session's PC
 Carry-Forward (Step 3) and Narrative Recap (Step 2). No new source
@@ -306,7 +308,8 @@ this step entirely — no empty section.
 
 ### 5. What Carries Forward
 
-Write into Wrap-Up file:
+Write under the Wrap-Up file's `## GM Notes` section, as
+`### What Carries Forward`:
 - Unresolved cliffhangers
 - Player-stated intentions
 - Unrealised consequences
@@ -316,18 +319,19 @@ Write into Wrap-Up file:
 ### 6. World State
 
 In-game date, location, active threats, faction postures,
-ticking clocks. Brief. Write into Wrap-Up file.
+ticking clocks. Brief. Write under `## GM Notes` as
+`### World State`.
 
 ### 7. Keeper Checklist
 
-Concrete tasks for next prep. Write into Wrap-Up file:
-scenes to write, GM decisions needed, rules to review,
-handouts to prepare.
+Concrete tasks for next prep. Write under `## GM Notes` as
+`### Keeper Checklist`: scenes to write, GM decisions needed,
+rules to review, handouts to prepare.
 
 ### 8. Quality Notes
 
 Brief, honest: what worked in prep, what was missing,
-what to adjust. Write into Wrap-Up file.
+what to adjust. Write under `## GM Notes` as `### Quality Notes`.
 
 ### 9. Review (Reconcile)
 
@@ -347,12 +351,13 @@ Wrap-up **must** produce all sections so prep reads one file:
 | Section | Required | Written to |
 |---------|----------|------------|
 | Narrative Recap | Yes | Wrap-Up file |
-| Quick Bullets | Standard path only | Wrap-Up file |
-| PC Carry-Forward | Yes | Wrap-Up file |
-| What Carries Forward | Yes | Wrap-Up file |
-| World State | Yes | Wrap-Up file |
-| Keeper Checklist | Yes | Wrap-Up file |
-| World Fact Findings | If findings exist | Wrap-Up file |
+| GM Notes → Quick Bullets | Standard path only | Wrap-Up file |
+| GM Notes → PC Carry-Forward | Yes | Wrap-Up file |
+| GM Notes → What Carries Forward | Yes | Wrap-Up file |
+| GM Notes → World State | Yes | Wrap-Up file |
+| GM Notes → Keeper Checklist | Yes | Wrap-Up file |
+| GM Notes → Quality Notes | Yes | Wrap-Up file |
+| GM Notes → World Fact Findings | If findings exist | Wrap-Up file |
 
 Entity files and timeline are updated separately (Step 4).
 Character story files are updated separately (Step 3b).

--- a/skills/session-wrapup/references/world-fact-detection.md
+++ b/skills/session-wrapup/references/world-fact-detection.md
@@ -48,11 +48,11 @@ Before staging a finding:
 
 ## Output Format
 
-Stage findings in the Wrap-Up file under
-`## World Fact Findings`:
+Stage findings in the Wrap-Up file's `## GM Notes` section,
+as a `### World Fact Findings` subsection:
 
 ```markdown
-## World Fact Findings
+### World Fact Findings
 
 - **Dwarf heritage** — Torga described as "a dwarf merchant"
   (first mention). No heritage definition exists.

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -661,7 +661,7 @@ skills.
 | `site_dir` | string | Absolute path to the site repo directory. Read by publish-site skill instead of asking each session. Optional — omit if vault doesn't use the publish tool. |
 | `mode` | string | `"player"` or `"full"` — controls GM-only content visibility |
 | `exclude_sections` | array | H2 heading names to strip from published output (default: `["GM Notes"]`) |
-| `exclude_fields` | array | Frontmatter field names to strip (default: `["secrets", "current_plan", "plan_progress"]`) |
+| `exclude_fields` | array | Frontmatter field names to strip (default: `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`) |
 | `exclude_dirs` | array | Vault folders to exclude from publishing (default: `["_meta", "_Templates"]`) |
 | `theme` | object | Theme configuration: `genre`, `palette`, `fonts`, `campaign_image` |
 | `four_oh_four` | object | Custom 404 page: `style`, `message` |

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -440,16 +440,33 @@ same skeleton.
 ## [System Sections]   — varies by system (see per-system template)
 ## Equipment           — gear, possessions, wealth/encumbrance
 ## Current Status      — player-facing present-state snapshot (maintained by session-wrapup)
-## Notes               — player-facing (protected: skills never modify)
-## GM Notes            — keeper-only (protected: skills never modify)
+## Notes               — player-facing, protected, published
+## GM Notes            — keeper-only, protected, excluded from publish
 ```
 
 Templates may omit inapplicable sections (e.g., FitD crews
 have no `## Equipment` — gear is handled through Quality).
 
-`## Notes` and `## GM Notes` are **protected sections** — only
-the GM edits them directly. Automated skills must preserve
-their content unchanged.
+`## Notes` and `## GM Notes` are both **protected sections** —
+only the GM edits them directly; automated skills must preserve
+their content unchanged. That's the only thing they share.
+**Protected (edit-safety) and excluded-from-publish (visibility)
+are two different, independent properties** — `## Notes` is
+protected *and published*; `## GM Notes` is protected *and
+excluded*. `## GM Notes` is the single canonical heading for
+whole-section GM-only content: any content that used to get its
+own top-level heading (Keeper Checklist, World State, Source
+References, tactical notes, "Optional Keeper Hooks," etc.)
+belongs as a freeform subsection nested under `## GM Notes`
+instead of inventing a new top-level heading — the publish
+tool's section filter is heading-level-aware, so anything nested
+under an excluded `## GM Notes` stays excluded regardless of its
+own subsection name. For a single spoiler-free aside embedded in
+otherwise-public prose, use an inline `<!-- gm-only -->` fence
+instead of a whole subsection. For narrative content that's only
+hidden until it's revealed in play (not permanently secret), use
+`<!-- spoiler -->` instead of `<!-- gm-only -->` — see
+`shared/reconcile.md` for how spoilers get revealed.
 
 `## Current Status` is the inverse: a **skill-maintained**,
 player-facing block holding the PC's **cumulative living state** —
@@ -483,8 +500,9 @@ carries unresolved items forward across sessions, gains items as they
 arise, and loses them only when resolved. NPC-relationship shifts fold
 into Open threads rather than a separate field.
 
-The block **must** sit outside any `<!-- gm-only -->` fence (it
-publishes) and before the protected `## Notes`/`## GM Notes` sections.
+The block **must** sit outside any `<!-- gm-only -->` or
+`<!-- spoiler -->` fence (it publishes) and before the protected
+`## Notes`/`## GM Notes` sections.
 The GM may also edit it directly; the next wrap-up reconciles it either
 way.
 

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -462,8 +462,9 @@ instead of inventing a new top-level heading — the publish
 tool's section filter is heading-level-aware, so anything nested
 under an excluded `## GM Notes` stays excluded regardless of its
 own subsection name. For a single spoiler-free aside embedded in
-otherwise-public prose, use an inline `<!-- gm-only -->` fence
-instead of a whole subsection. For narrative content that's only
+otherwise-public prose, use a standalone `<!-- gm-only -->` block
+(on its own lines) instead of a whole subsection. For narrative
+content that's only
 hidden until it's revealed in play (not permanently secret), use
 `<!-- spoiler -->` instead of `<!-- gm-only -->` — see
 `shared/reconcile.md` for how spoilers get revealed.

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -367,3 +367,46 @@ campaign, but that nothing was ever checking.
   until this release. Vaults predating each type's introduction
   are missing the corresponding entry. Offered via Schema Mirror
   Sync.
+
+## Migration: {last version} → {next version}
+
+Standardizes GM-only content hiding onto two primitives — a single
+`## GM Notes` container heading and the existing `<!-- gm-only -->`
+inline fence — replacing the exact-heading-string-list approach that
+can't generalize past whatever's already been manually added to it.
+Also introduces `<!-- spoiler -->` for narrative content that's only
+hidden until revealed in play, not permanently secret.
+
+### Structural
+
+- **GM-only heading re-nesting** — every heading in the vault's own
+  `_meta/vault-config.md` `exclude_sections` list gets re-nested as a
+  `###` subsection under one `## GM Notes` heading per file (creating
+  it where absent), and the vault's `exclude_sections` list collapses
+  down to `["GM Notes"]` once everything's been moved. This is a pure
+  structural move — no content is added, removed, or reworded, only
+  relocated and demoted a heading level — so it applies automatically
+  after preview confirmation like other structural changes.
+
+### Content
+
+- **Bold-wrapped and bold-paragraph GM-only content** — headings like
+  `### **Keeper Notes**` and bold-paragraph lines like `**Keeper
+  Notes:**` with no heading marker at all defeat exact-string
+  matching against the vault's `exclude_sections` list even though
+  they're clearly meant to be hidden. Offered as opt-in Content items
+  since converting a bold-paragraph line into a real heading needs a
+  GM to confirm where the section actually ends.
+- **Callout-only-marked content** — an Obsidian callout (`>
+  [!info] Keeper Only`, etc.) with no heading or fence protection at
+  all. Offered as opt-in Content items — there's no automatic signal
+  for whether it should become `## GM Notes` or a time-locked
+  `<!-- spoiler -->`, so the GM decides per item.
+
+### Tooling
+
+- **Publish tool:** `gm-apprentice-publish` gains `<!-- spoiler -->`
+  support and the `exclude_fields` union-merge fix (previously
+  `exclude_sections`/`exclude_dirs` only). If `publish.site_dir` is
+  set in vault-config, offer to run `npm update gm-apprentice-publish`
+  in the site directory.

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -368,7 +368,7 @@ campaign, but that nothing was ever checking.
   are missing the corresponding entry. Offered via Schema Mirror
   Sync.
 
-## Migration: 1.8.2 → 1.9.0
+## Migration: 1.8.2 → 1.8.3
 
 Standardizes GM-only content hiding onto two primitives — a single
 `## GM Notes` container heading and the existing `<!-- gm-only -->`

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -368,7 +368,7 @@ campaign, but that nothing was ever checking.
   are missing the corresponding entry. Offered via Schema Mirror
   Sync.
 
-## Migration: {last version} → {next version}
+## Migration: 1.8.2 → 1.9.0
 
 Standardizes GM-only content hiding onto two primitives — a single
 `## GM Notes` container heading and the existing `<!-- gm-only -->`

--- a/skills/shared/reconcile.md
+++ b/skills/shared/reconcile.md
@@ -68,8 +68,9 @@ Present as a short inventory, not a wall of text.
 
 ### 2.5. World fact review
 
-If the Wrap-Up file contains a `## World Fact Findings` section
-(staged by session-wrapup), review each finding with the GM.
+If the Wrap-Up file's `## GM Notes` section contains a
+`### World Fact Findings` subsection (staged by session-wrapup),
+review each finding with the GM.
 
 For each finding, present the three-state prompt:
 

--- a/skills/shared/reconcile.md
+++ b/skills/shared/reconcile.md
@@ -42,7 +42,7 @@ On GM confirmation:
 - Set Wrap-Up `canon_status` to `AUTHORITATIVE`
 - Promote all DRAFT entities from this session to AUTHORITATIVE
 - Update session index `status` to `reviewed`
-- Skip to step 5.5 (world evolution offer)
+- Skip to step 6.5 (world evolution offer)
 
 If any condition fails → proceed with the full 6-step procedure
 below.
@@ -91,7 +91,7 @@ For each finding, present the three-state prompt:
 
 One finding at a time. Wait for GM decision before continuing.
 Record each resolution in the `## Reconciliation Context`
-section (step 6).
+section (step 7).
 
 ### 3. Walk through conflicts
 
@@ -105,7 +105,28 @@ One conflict at a time. For each:
 Each answer shapes the next question. This is a conversation,
 not a report.
 
-### 4. Salvageable prep triage
+### 3.5. Spoiler reveal check
+
+For every entity this session's Wrap-Up actually touched (created or
+updated — the same bounded set session-wrapup already produced in its
+receipt), check for open `<!-- spoiler -->` blocks. For each one
+found, ask:
+
+> "[[{Entity}]] has a pending spoiler: '{first ~10 words of the
+> spoiler text}...' — was this revealed to the players this session?
+> (y/n)"
+
+On yes: remove the `<!-- spoiler -->` / `<!-- /spoiler -->` markers
+from that entity's file, leaving the content as plain published
+prose. On no: leave it untouched — it stays hidden and gets asked
+about again next time this entity is touched, or caught by
+campaign-qa's full-vault audit if it never comes up again (see
+`publish-site/references/content-filtering.md`).
+
+Skip this step entirely if none of this session's touched entities
+contain a `<!-- spoiler -->` block — no empty prompt.
+
+### 5. Salvageable prep triage
 
 If a Plan file exists for this session, scan unplayed content.
 For each unplayed element, ask the GM:
@@ -119,7 +140,7 @@ For each unplayed element, ask the GM:
 Flag `must-still-happen` items prominently — these carry
 forward into the next session's prep.
 
-### 5. Promote canon status
+### 6. Promote canon status
 
 On GM approval:
 1. Set Wrap-Up `canon_status` to `AUTHORITATIVE`
@@ -142,7 +163,7 @@ Do the bookkeeping immediately — don't leave a list for
 the GM. Hand off to campaign-organizer if entity filing
 is needed.
 
-### 5.5. World evolution (conditional)
+### 6.5. World evolution (conditional)
 
 **Gate:** Only offer when reconciling the **most recent**
 session. Check the session index for a `world_evolved` field
@@ -152,7 +173,7 @@ session. Check the session index for a `world_evolved` field
 > turns, consequence surfacing, foreshadowing review? This
 > updates how the world responds to what just happened. (y/n)"
 
-If the GM declines → skip to step 6.
+If the GM declines → skip to step 7.
 
 If the GM accepts → read and follow
 `ttrpg-expert/world-evolution.md`, skipping the Storage
@@ -168,7 +189,7 @@ conversational style as the rest of reconcile.
 - Entity files created or updated use
   `source: "world-evolution"`, with `lastUpdated` and
   `asOfSession` set to the current session
-- Results feed into step 6's `## Reconciliation Context`
+- Results feed into step 7's `## Reconciliation Context`
   under `### World Evolution`, containing:
   - Faction turn summaries (one line per faction: action,
     impact level, what's visible to PCs)
@@ -177,7 +198,7 @@ conversational style as the rest of reconcile.
   - Discovery state changes (per-PC knowledge shifts)
   - World state changes (calendar, environment, politics)
 
-### 6. Record decisions
+### 7. Record decisions
 
 Write a `## Reconciliation Context` section capturing:
 - **Consequences** — forward-looking summary of what this
@@ -185,7 +206,7 @@ Write a `## Reconciliation Context` section capturing:
   play notes, no invention)
 - **Salvageable prep** — disposition of each unplayed item
 - **GM decisions** — each conflict resolution with rationale
-- **World evolution** — if step 5.5 ran, include a
+- **World evolution** — if step 6.5 ran, include a
   `### World Evolution` sub-section with faction turn
   summaries, surfaced consequences, foreshadowing and
   discovery state changes, and world state updates

--- a/skills/shared/session-document-chain.md
+++ b/skills/shared/session-document-chain.md
@@ -56,7 +56,7 @@ appears on its own entity page.
 | wrap-up | Wrap-Up file exists |
 | reviewed | GM has reviewed and confirmed the Wrap-Up |
 
-**`world_evolved`:** Set by reconcile step 5.5 after the
+**`world_evolved`:** Set by reconcile step 6.5 after the
 world-evolution procedure completes. Value is the session
 reference (e.g., `"Session_07"`). Null until world-evolution
 runs. Prevents reconcile from re-offering world-evolution

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -406,7 +406,9 @@ If yes:
    - Key Themes section: from tone and genre conversation
    - Key Factions section: from driving forces in the brief
    - Current Arc section: "Not yet begun."
-   - GM Notes section: empty
+   - GM Notes section: empty (a bare `## GM Notes` heading — the
+     canonical single heading for whole-section GM-only content,
+     see `shared/entity-schema.md`)
 
 2. **Hand off** to campaign-organizer with the adventure
    brief as context. campaign-organizer builds the vault
@@ -451,25 +453,43 @@ source_document: ""
 
 ### Required Sections
 
-| Section | Content |
-|---------|---------|
-| Premise | One paragraph elevator pitch |
-| Tone & Genre | Sensory and emotional descriptors |
-| Adventure Shape | Structure type and rationale |
-| Core Tension | Central conflict or mystery |
-| Driving Forces | Per-faction: goal, victory state, plan, timeline, resources |
-| Key NPCs | Per-NPC: role, motivation, connection, first appearance |
-| Locations | Per-location: atmosphere, significance, connections |
-| Entry Points | ≥3 hooks (Three Clue Rule at adventure scale) |
-| Escalation | How pressure increases |
-| If They Do Nothing | Antagonist plan runs to completion |
-| Open Questions | Things the GM still needs to decide |
-| CATS Pitch | Concept/Aim/Tone/Subject for Session 0 |
-| Session 0 Agenda | Checklist items for player buy-in |
-| Vault Notes | Existing entities, updates implied (vault only) |
+| Section | Content | Visibility |
+|---------|---------|------------|
+| Premise | One paragraph elevator pitch | Public |
+| Tone & Genre | Sensory and emotional descriptors | Public |
+| Adventure Shape | Structure type and rationale | Public |
+| Core Tension | Central conflict or mystery | Public |
+| Key NPCs | Per-NPC: role, motivation, connection, first appearance | Public |
+| Locations | Per-location: atmosphere, significance, connections | Public |
+| Entry Points | ≥3 hooks (Three Clue Rule at adventure scale) | Public |
+| Escalation | How pressure increases | Public |
+| CATS Pitch | Concept/Aim/Tone/Subject for Session 0 | Public — see note below |
+| Session 0 Agenda | Checklist items for player buy-in | Public — see note below |
+| Driving Forces | Per-faction: goal, victory state, plan, timeline, resources | GM Notes |
+| If They Do Nothing | Antagonist plan runs to completion | GM Notes |
+| Vault Notes | Existing entities, updates implied (vault only) | GM Notes |
+| Open Questions | Things the GM still needs to decide | Spoiler |
 
 "If They Do Nothing" is required. Open Questions are preserved
 — never invent answers for things the GM was undecided on.
+
+**Visibility column meaning:**
+- **Public** — plain section, no fence, publishes as written.
+- **GM Notes** — write as a `###` subsection under one `## GM Notes`
+  heading in the brief, not its own top-level section (see
+  `shared/entity-schema.md`'s PC Body Structure).
+- **Spoiler** — Open Questions get resolved into canon as play
+  reaches them (`reconcile`'s spoiler-reveal step, see
+  `shared/reconcile.md`); wrap the whole section in
+  `<!-- spoiler -->` / `<!-- /spoiler -->` rather than `## GM Notes`,
+  since it's meant to eventually publish once resolved, not stay
+  permanently hidden.
+
+**CATS Pitch and Session 0 Agenda are meant to be shared with
+players** — don't hide the whole section. If a specific line reveals
+a twist players haven't discovered yet (e.g. the true nature of a
+central horror), wrap only that sentence in an inline
+`<!-- gm-only -->` or `<!-- spoiler -->` fence, not the section.
 
 ## Worldbuilding Mode
 

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -488,8 +488,9 @@ source_document: ""
 **CATS Pitch and Session 0 Agenda are meant to be shared with
 players** — don't hide the whole section. If a specific line reveals
 a twist players haven't discovered yet (e.g. the true nature of a
-central horror), wrap only that sentence in an inline
-`<!-- gm-only -->` or `<!-- spoiler -->` fence, not the section.
+central horror), wrap only that sentence in a standalone
+`<!-- gm-only -->` or `<!-- spoiler -->` block on its own lines, not
+the section.
 
 ## Worldbuilding Mode
 

--- a/skills/ttrpg-expert/content-generation.md
+++ b/skills/ttrpg-expert/content-generation.md
@@ -164,7 +164,9 @@ Behaviour:
 Lair: [If relevant]
 Hooks: [How PCs encounter; foreshadowing clues]
 Stat Block: [System-specific]
-GM Notes: [Running tips, atmosphere]
+
+## GM Notes
+[Running tips, atmosphere]
 ```
 
 ## Document Template
@@ -174,9 +176,11 @@ GM Notes: [Running tips, atmosphere]
 Type: [Letter / Diary / Newspaper / Map / Record / Tome]
 Author:  Date:  Physical Description:
 Content: [In-character text per type format]
-What It Reveals: [GM-only: clues contained]
 Discovery Method: [How PCs find it]
 System Notes: [Checks to read/translate, SAN costs]
+
+## GM Notes
+What It Reveals: [clues contained]
 ```
 
 For detailed handout guidance: `handouts-and-props.md`.
@@ -189,7 +193,6 @@ Limit to 3-5 handouts per session. Every handout must contain
 ## [Scenario Title]
 System:  Premise: [2-3 sentences]
 Hook(s): [≥3 hooks drawing PCs in]
-The Truth: [GM-only: what's actually happening]
 
 Key NPCs:
 - [NPC]: [Role, goal, connection to truth]
@@ -202,6 +205,9 @@ Timeline: [What happens without PC intervention]
 Climax: [Confrontation/revelation scenario builds toward]
 Resolution: [Possible endings and consequences]
 Sequel Hooks: [Future adventures enabled]
+
+## GM Notes
+The Truth: [what's actually happening]
 ```
 
 Design: state truth first (GM must know everything); ≥3 hooks;

--- a/skills/ttrpg-expert/npc-generation.md
+++ b/skills/ttrpg-expert/npc-generation.md
@@ -175,7 +175,9 @@ Relationships:
 - [Entity]: [Type + description]
 
 Stat Block: [System-specific]
-GM Notes: [Running context]
+
+## GM Notes
+[Running context]
 ```
 
 ## Generation from Constraints

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -5,7 +5,7 @@ advance plans, consequences ripen, rumours spread, and the
 calendar turns. Run this procedure after every session.
 
 **Invocation:** This procedure normally runs as reconcile
-step 5.5 — offered to the GM after session canon status is
+step 6.5 — offered to the GM after session canon status is
 promoted. It can also be invoked standalone via ttrpg-expert
 ("update the world" / "post-session update").
 
@@ -136,7 +136,7 @@ After filing: "Updates filed. Run campaign-qa to validate,
 or proceed to session prep?"
 
 **When invoked from reconcile:** skip this prompt — results
-flow into reconcile step 6's `## Reconciliation Context`
+flow into reconcile step 7's `## Reconciliation Context`
 under `### World Evolution`. Set `world_evolved` on the
 session index to the current session reference.
 

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -402,9 +402,16 @@ h3 {
 .hero-banner-no-img {
   background: linear-gradient(135deg, var(--bg-hero) 0%, var(--bg-card) 100%);
   padding: 2.5rem 1.5rem 1.5rem;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-end;
 }
 .hero-banner-no-img h1 {
   color: var(--text);
+}
+.hero-banner-no-img .pc-portrait {
+  flex-shrink: 0;
+  margin: 0 0 0.75rem;
 }
 
 /* Cinematic banner (PCs) */

--- a/tools/publish/js/lightbox.js
+++ b/tools/publish/js/lightbox.js
@@ -28,7 +28,7 @@
     if (e.key === 'Escape' && overlay.classList.contains('open')) close();
   });
 
-  document.querySelectorAll('.content img').forEach(function(el) {
+  document.querySelectorAll('.content img, .hero-banner-img, .hero-cinematic-img').forEach(function(el) {
     el.style.cursor = 'pointer';
     el.addEventListener('click', function() {
       open(el.src, el.alt);

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
-const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, filterFields, resolveImageEmbeds, resolveWikiLinks, relativeHref, escapeHtml } = require('./processor');
+const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, filterFields, resolveImageEmbeds, resolveWikiLinks, relativeHref, escapeHtml } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest } = require('./manifest');
@@ -205,12 +205,17 @@ function build(options = {}) {
   const { buildSearchIndex } = require('./search-index');
   const { scoreByRecency } = require('./recency');
 
-  // Compute each page's "published view" — markdown with gm-only blocks and excluded
-  // sections removed — once, so derived widgets (backlinks, recency, the relationship
-  // graph) never surface names that only appear in unpublished content (B6 spoiler leak).
+  // Compute each page's "published view" — markdown with gm-only/spoiler blocks and
+  // excluded sections removed — once, so derived widgets (backlinks, recency, the
+  // relationship graph) never surface names that only appear in unpublished content
+  // (B6 spoiler leak). Spoiler blocks are unrevealed narrative content, not permanent
+  // secrets, but they're just as unpublished until reconcile's reveal step strips the
+  // fence — until then they must never surface in a derived widget either.
   for (const page of pages) {
-    const stripped = stripGmOnly(page.markdown || '');
-    const text = typeof stripped === 'string' ? stripped : stripped.text;
+    const gmStripped = stripGmOnly(page.markdown || '');
+    const afterGm = typeof gmStripped === 'string' ? gmStripped : gmStripped.text;
+    const spoilerStripped = stripSpoiler(afterGm);
+    const text = typeof spoilerStripped === 'string' ? spoilerStripped : spoilerStripped.text;
     page.publishedMarkdown = filterSections(text, excludeSections);
   }
 
@@ -350,6 +355,8 @@ function build(options = {}) {
           let filtered = stripDataview(page.markdown.replace(/\r/g, ''));
           const gmResult = stripGmOnly(filtered);
           filtered = typeof gmResult === 'string' ? gmResult : gmResult.text;
+          const spoilerResult = stripSpoiler(filtered);
+          filtered = typeof spoilerResult === 'string' ? spoilerResult : spoilerResult.text;
           filtered = filterSections(filtered, excludeSections);
           filtered = resolveWikiLinks(filtered, linkMap, page.outputPath);
           filtered = resolveImageEmbeds(filtered, imageMap, page.outputPath, usedImages);

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -6,7 +6,7 @@ const PUBLISH_DEFAULTS = {
   mode: 'player',
   exclude_drafts: false,
   exclude_sections: ['GM Notes'],
-  exclude_fields: ['secrets', 'current_plan', 'plan_progress'],
+  exclude_fields: ['secrets', 'current_plan', 'plan_progress', 'gm_notes', 'prep_notes'],
   exclude_dirs: ['_meta', '_Templates'],
   theme: {
     genre: null,
@@ -79,7 +79,11 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
       jsonConfigFallback.excludeSections,
       PUBLISH_DEFAULTS.exclude_sections,
     ),
-    exclude_fields: publish.exclude_fields || [...PUBLISH_DEFAULTS.exclude_fields],
+    exclude_fields: unionExcludeList(
+      publish.exclude_fields,
+      jsonConfigFallback.excludeFields,
+      PUBLISH_DEFAULTS.exclude_fields,
+    ),
     exclude_dirs: unionExcludeList(
       publish.exclude_dirs,
       jsonConfigFallback.excludeDirs,

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -98,7 +98,13 @@ function stripDataview(markdown) {
   return markdown.replace(/```dataview[\s\S]*?```/g, '');
 }
 
-function stripGmOnly(markdown) {
+// Strip content between a named HTML-comment marker pair (e.g. "gm-only" for
+// <!-- gm-only -->...<!-- /gm-only -->). Shared implementation behind
+// stripGmOnly and stripSpoiler — same stripping behavior, different marker
+// name, so a marker of one name never strips a block of the other name.
+function stripMarkedBlocks(markdown, markerName) {
+  const openRe = new RegExp(`^<!--\\s*${markerName}\\s*-->`);
+  const closeRe = new RegExp(`^<!--\\s*/${markerName}\\s*-->`);
   const lines = markdown.split('\n');
   const result = [];
   const warnings = [];
@@ -117,13 +123,13 @@ function stripGmOnly(markdown) {
       continue;
     }
 
-    if (/^<!--\s*gm-only\s*-->/.test(line.trim())) {
+    if (openRe.test(line.trim())) {
       excluding = true;
       result.push('');
       continue;
     }
 
-    if (/^<!--\s*\/gm-only\s*-->/.test(line.trim())) {
+    if (closeRe.test(line.trim())) {
       excluding = false;
       continue;
     }
@@ -134,11 +140,19 @@ function stripGmOnly(markdown) {
   }
 
   if (excluding) {
-    warnings.push('unclosed <!-- gm-only --> marker — content stripped to end of file');
+    warnings.push(`unclosed <!-- ${markerName} --> marker — content stripped to end of file`);
   }
 
   const text = result.join('\n');
   return warnings.length > 0 ? { text, warnings } : text;
+}
+
+function stripGmOnly(markdown) {
+  return stripMarkedBlocks(markdown, 'gm-only');
+}
+
+function stripSpoiler(markdown) {
+  return stripMarkedBlocks(markdown, 'spoiler');
 }
 
 // Strip a single leading H1 from the markdown body. Templates inject their own H1
@@ -230,6 +244,13 @@ function processContent(page, linkMap, excludeSections, imageMap = {}, options =
   } else {
     markdown = gmResult;
   }
+  const spoilerResult = stripSpoiler(markdown);
+  if (spoilerResult.warnings) {
+    warnings.push(...spoilerResult.warnings);
+    markdown = spoilerResult.text;
+  } else {
+    markdown = spoilerResult;
+  }
   markdown = stripLeadingH1(markdown);
   markdown = filterSections(markdown, excludeSections);
   markdown = separateBoldLabelLines(markdown);
@@ -274,4 +295,4 @@ function filterFields(frontmatter, excludeFields = [], overrides = {}) {
   return filtered;
 }
 
-module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, filterFields };
+module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, filterFields };

--- a/tools/publish/lib/search-index.js
+++ b/tools/publish/lib/search-index.js
@@ -15,6 +15,13 @@ function getSubtitle(fm) {
   return fm.occupation || fm.location_type || fm.faction_type || fm.event_type || fm.type || '';
 }
 
+// Search results must reflect only what readers can see, so prefer each page's published
+// view (gm-only + spoiler content stripped) over its raw markdown when available.
+function publishedText(page) {
+  if (!page) return '';
+  return page.publishedMarkdown != null ? page.publishedMarkdown : (page.markdown || '');
+}
+
 function buildSearchIndex(pages) {
   const documents = {};
 
@@ -43,7 +50,7 @@ function buildSearchIndex(pages) {
         title: page.displayTitle,
         aliases: Array.isArray(fm.aliases) ? fm.aliases.join(' ') : '',
         type: fm.type || '',
-        body: stripMarkdown(page.markdown).slice(0, 500),
+        body: stripMarkdown(publishedText(page)).slice(0, 500),
       });
     }
   });

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -16,15 +16,19 @@ function getLatestSession(pages) {
 
 function stripWikiLinks(text) {
   return text.replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
-    .replace(/\[\[([^\]]+)\]\]/g, '$1');
+    .replace(/\[\[([^\]]+)\]\]/g, (m, target) => target.replace(/_/g, ' '));
 }
 
 function extractRecap(page) {
   if (!page) return null;
-  const md = page.markdown;
+  // Prefer the published view (gm-only blocks + excluded sections stripped) so the
+  // landing recap can never quote Keeper-only content.
+  const md = page.publishedMarkdown || page.markdown;
   if (!md) return null;
 
-  const recapMatch = md.match(/^## Narrative Recap\s*$/m);
+  // Wrap-ups title this section in variants — "Narrative Recap", "What Happened —
+  // Narrative Recap", numbered forms — so match any H2 containing the phrase.
+  const recapMatch = md.match(/^##\s+.*Narrative Recap.*$/m);
   let paragraph;
 
   if (recapMatch) {
@@ -32,11 +36,13 @@ function extractRecap(page) {
     const nextHeading = after.search(/^## /m);
     const section = nextHeading === -1 ? after : after.slice(0, nextHeading);
     const paragraphs = section.split(/\n\n+/).map(p => p.trim()).filter(Boolean);
-    paragraph = paragraphs[0] || null;
+    paragraph = paragraphs.find(p => !/^#{1,6}\s/.test(p) && !p.startsWith('>')) || null;
   } else {
-    const withoutH1 = md.replace(/^# .+\n+/, '');
+    // Tolerate blank lines before the H1, and never surface a bare heading or a
+    // blockquote as "the recap" — take the first real prose paragraph.
+    const withoutH1 = md.replace(/^\s*# .+\n+/, '');
     const paragraphs = withoutH1.split(/\n\n+/).map(p => p.trim()).filter(Boolean);
-    paragraph = paragraphs[0] || null;
+    paragraph = paragraphs.find(p => !/^#{1,6}\s/.test(p) && !p.startsWith('>')) || null;
   }
 
   if (!paragraph) return null;
@@ -198,6 +204,20 @@ function getLatestWrapUp(pages, session) {
   if (!session) return null;
   const wrapTypes = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
   const wrapUps = pages.filter(p => wrapTypes.has(p.frontmatter.type));
+
+  // Chapters restart session numbering, so a bare session_number match can return
+  // ANOTHER chapter's wrap-up (Vienna Session 4 shadowing Calcutta Session 4). A
+  // wrap-up lives in the same session folder as its index file — prefer that match
+  // before falling back to session_number.
+  const sessionDir = session.sourcePath
+    ? String(session.sourcePath).replace(/[^\\/]+$/, '')
+    : null;
+  if (sessionDir) {
+    for (const wu of wrapUps) {
+      if (wu.sourcePath && String(wu.sourcePath).startsWith(sessionDir)) return wu;
+    }
+  }
+
   const num = session.frontmatter.session_number;
   if (num != null) {
     for (const wu of wrapUps) {

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -33,9 +33,9 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
     const imgTag = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
     const imgMatch = (imgTag || '').match(/src="([^"]+)"/);
     const imgUrl = imgMatch ? imgMatch[1] : '';
-    heroBanner = `<div class="hero-banner">
-  <img class="hero-banner-img" src="${imgUrl}" alt="${escapeHtml(page.displayTitle)}">
-  <div class="hero-banner-overlay">
+    heroBanner = `<div class="hero-cinematic">
+  <img class="hero-cinematic-img" src="${imgUrl}" alt="${escapeHtml(page.displayTitle)}">
+  <div class="hero-cinematic-overlay">
     <h1>${escapeHtml(page.displayTitle)}${canonStatusBadge(fm)}</h1>
     <div class="meta">${metaHtml}</div>
   </div>

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/fixtures/with-gm-only-markers/Characters/PCs/Test_PC.md
+++ b/tools/publish/test/fixtures/with-gm-only-markers/Characters/PCs/Test_PC.md
@@ -1,0 +1,20 @@
+---
+type: pc
+player_name: Alex
+occupation: Investigator
+status: active
+---
+
+# Test PC
+
+## Background
+
+An investigator drawn into events beyond their understanding.
+
+<!-- gm-only -->
+Secretly serves Zalgorath, an entity beyond the veil.
+<!-- /gm-only -->
+
+<!-- spoiler -->
+Is the long-lost heir of Ithaqua's bloodline.
+<!-- /spoiler -->

--- a/tools/publish/test/fixtures/with-gm-only-markers/Locations/Market.md
+++ b/tools/publish/test/fixtures/with-gm-only-markers/Locations/Market.md
@@ -27,3 +27,8 @@ The blacksmith is also a fence for stolen goods.
 <!-- /gm-only -->
 
 The apothecary sells herbs and tonics.
+
+<!-- spoiler -->
+The market square is a fading dream of Carcosa, waiting to be
+revealed once the players find the Yellow Sign.
+<!-- /spoiler -->

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -966,6 +966,7 @@ describe('build integration', () => {
         excludeSections: [],
         folderMap: {
           'Locations': 'locations',
+          'Characters/PCs': 'characters/pcs',
         },
       };
 
@@ -975,6 +976,26 @@ describe('build integration', () => {
 
     after(() => {
       fs.rmSync(outputDir, { recursive: true, force: true });
+    });
+
+    it('strips spoiler blocks from market page', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'locations', 'market.html'), 'utf-8');
+      assert.ok(!html.includes('Carcosa'));
+    });
+
+    it('strips gm-only and spoiler blocks from PC page', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'characters', 'pcs', 'test-pc.html'), 'utf-8');
+      assert.ok(!html.includes('Zalgorath'));
+      assert.ok(!html.includes('Ithaqua'));
+    });
+
+    it('excludes spoiler and gm-only content from search-index.json', () => {
+      // lunr lowercases and stems indexed tokens, so check case-insensitively for
+      // the raw distinctive words rather than exact phrases.
+      const indexJson = fs.readFileSync(path.join(outputDir, 'docs', 'search-index.json'), 'utf-8').toLowerCase();
+      assert.ok(!indexJson.includes('carcosa'));
+      assert.ok(!indexJson.includes('zalgorath'));
+      assert.ok(!indexJson.includes('ithaqua'));
     });
 
     it('strips gm-only blocks from market page', () => {

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -14,8 +14,8 @@ describe('PUBLISH_DEFAULTS', () => {
     assert.ok(PUBLISH_DEFAULTS.exclude_sections.includes('GM Notes'));
   });
 
-  it('excludes secrets, current_plan, plan_progress by default', () => {
-    assert.deepStrictEqual(PUBLISH_DEFAULTS.exclude_fields, ['secrets', 'current_plan', 'plan_progress']);
+  it('excludes secrets, current_plan, plan_progress, gm_notes, prep_notes by default', () => {
+    assert.deepStrictEqual(PUBLISH_DEFAULTS.exclude_fields, ['secrets', 'current_plan', 'plan_progress', 'gm_notes', 'prep_notes']);
   });
 
   it('excludes _meta and _Templates dirs by default', () => {
@@ -39,7 +39,7 @@ describe('loadPublishConfig', () => {
     fs.writeFileSync(path.join(metaDir, 'vault-config.md'), '---\ntitle: Test\n---\nSome config');
     const result = loadPublishConfig(tmpDir);
     assert.strictEqual(result.mode, 'player');
-    assert.deepStrictEqual(result.exclude_fields, ['secrets', 'current_plan', 'plan_progress']);
+    assert.deepStrictEqual(result.exclude_fields, ['secrets', 'current_plan', 'plan_progress', 'gm_notes', 'prep_notes']);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -179,6 +179,40 @@ describe('system field', () => {
     const result = loadPublishConfig(tmpDir, {});
     assert.strictEqual(result.system, null);
 
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe('exclude_fields union merge', () => {
+  it('unions vault-config.md and vault.config.json exclude_fields (neither shadows the other)', () => {
+    // Regression: exclude_fields still had the A || B shadowing bug after
+    // exclude_sections/exclude_dirs were already fixed to union.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(
+      path.join(metaDir, 'vault-config.md'),
+      '---\npublish:\n  exclude_fields:\n    - "secrets"\n---\n',
+    );
+    const fallback = { excludeFields: ['secrets', 'custom_field'] };
+    const result = loadPublishConfig(tmpDir, fallback);
+    assert.ok(result.exclude_fields.includes('secrets'));
+    assert.ok(result.exclude_fields.includes('custom_field'), 'field listed only in vault.config.json must still be excluded');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('dedupes the unioned exclude_fields case-insensitively', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(
+      path.join(metaDir, 'vault-config.md'),
+      '---\npublish:\n  exclude_fields:\n    - "Secrets"\n---\n',
+    );
+    const result = loadPublishConfig(tmpDir, { excludeFields: ['secrets', 'gm_notes'] });
+    const secretsCount = result.exclude_fields.filter((f) => f.toLowerCase() === 'secrets').length;
+    assert.strictEqual(secretsCount, 1, 'case-insensitive duplicate should collapse to one');
+    assert.ok(result.exclude_fields.includes('gm_notes'));
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -113,6 +113,30 @@ describe('getLatestWrapUp', () => {
       assert.ok(result, `should match type "${type}"`);
     }
   });
+
+  it('prefers the wrap-up in the same session folder when chapters restart numbering', () => {
+    // Regression: Vienna S4 and Calcutta S4 both have session_number 4 — a bare
+    // number match returned Vienna's wrap-up for Calcutta's session.
+    const pages = [
+      {
+        frontmatter: { type: 'session_wrap', session_number: 4 },
+        title: 'Chapter_03_Session_04_Wrap_Up',
+        sourcePath: '/vault/Chapters/Chapter 3 - Vienna/Session 4/Chapter_03_Session_04_Wrap_Up.md',
+      },
+      {
+        frontmatter: { type: 'session_wrap', session_number: 4 },
+        title: 'Chapter_04_Session_04_Wrap_Up',
+        sourcePath: '/vault/Chapters/Chapter 4 - Calcutta/Sessions/Session 04/Chapter_04_Session_04_Wrap_Up.md',
+      },
+    ];
+    const calcuttaSession = {
+      title: 'Session 04 - The Road to Cairo',
+      frontmatter: { type: 'session', session_number: 4 },
+      sourcePath: '/vault/Chapters/Chapter 4 - Calcutta/Sessions/Session 04/Session 04 - The Road to Cairo.md',
+    };
+    const result = getLatestWrapUp(pages, calcuttaSession);
+    assert.strictEqual(result.title, 'Chapter_04_Session_04_Wrap_Up');
+  });
 });
 
 describe('extractRecap', () => {
@@ -132,12 +156,47 @@ describe('extractRecap', () => {
     assert.strictEqual(result, 'John Smith met Jane Doe at the Tavern.');
   });
 
+  it('humanizes underscored wiki-link targets in recap text', () => {
+    const page = {
+      markdown: '# S1\n\n## Narrative Recap\n\nBreakfast at the [[Locanda_del_Leone]].\n\n## Next',
+    };
+    const result = extractRecap(page);
+    assert.strictEqual(result, 'Breakfast at the Locanda del Leone.');
+  });
+
   it('falls back to first body paragraph when no Narrative Recap heading', () => {
     const page = {
       markdown: '# Session 1\n\nThe group gathered at dawn.\n\nThey set off.\n',
     };
     const result = extractRecap(page);
     assert.strictEqual(result, 'The group gathered at dawn.');
+  });
+
+  it('matches heading variants like "What Happened — Narrative Recap"', () => {
+    const page = {
+      markdown: '# S4\n\n## Session Metadata\n\nStuff.\n\n## What Happened — Narrative Recap\n\nThe party rode for Cairo at dawn.\n\n## World State\n\nSecret.',
+    };
+    const result = extractRecap(page);
+    assert.strictEqual(result, 'The party rode for Cairo at dawn.');
+  });
+
+  it('never returns a bare heading as the recap', () => {
+    // Regression: a body whose H1 sits after a blank line, followed by more headings,
+    // rendered a raw "# Session 4 — ..." line on the landing page.
+    const page = {
+      markdown: '\n# Session 4 — The Hofburg Reception\n\n## Session Metadata\n\n- **Date:** August 5\n',
+    };
+    const result = extractRecap(page);
+    assert.ok(result === null || !result.startsWith('#'), `got: ${result}`);
+  });
+
+  it('prefers publishedMarkdown over raw markdown when present', () => {
+    const page = {
+      markdown: '# S1\n\n## Narrative Recap\n\nKeeper secret draft.\n',
+      publishedMarkdown: '# S1\n\n## Narrative Recap\n\nThe players saw this.\n',
+    };
+    const result = extractRecap(page);
+    assert.strictEqual(result, 'The players saw this.');
   });
 
   it('truncates to ~500 chars at word boundary', () => {

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { escapeHtml, relativePath, relativeHref, parseWikiRef, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, filterFields, renderRelationships } = require('../../lib/processor');
+const { escapeHtml, relativePath, relativeHref, parseWikiRef, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, stripSpoiler, filterFields, renderRelationships } = require('../../lib/processor');
 
 describe('escapeHtml', () => {
   it('escapes angle brackets', () => {
@@ -186,6 +186,39 @@ describe('stripGmOnly', () => {
     const md = 'Public\n<!--  gm-only  -->\nSecret\n<!--  /gm-only  -->\nMore';
     const result = stripGmOnly(md);
     assert.strictEqual(result, 'Public\n\nMore');
+  });
+});
+
+describe('stripSpoiler', () => {
+  it('removes content between spoiler markers', () => {
+    const md = 'Public text\n<!-- spoiler -->\nSecret stuff\n<!-- /spoiler -->\nMore public';
+    const result = stripSpoiler(md);
+    assert.strictEqual(result, 'Public text\n\nMore public');
+  });
+
+  it('handles multiple spoiler blocks', () => {
+    const md = 'A\n<!-- spoiler -->\nB\n<!-- /spoiler -->\nC\n<!-- spoiler -->\nD\n<!-- /spoiler -->\nE';
+    const result = stripSpoiler(md);
+    assert.strictEqual(result, 'A\n\nC\n\nE');
+  });
+
+  it('warns on an unclosed spoiler marker', () => {
+    const md = 'Public\n<!-- spoiler -->\nSecret to end';
+    const { text, warnings } = stripSpoiler(md);
+    assert.strictEqual(text, 'Public\n');
+    assert.ok(warnings[0].includes('spoiler'));
+  });
+
+  it('treats a spoiler marker inside a code fence as literal', () => {
+    const md = 'Text\n```\n<!-- spoiler -->\ncode\n<!-- /spoiler -->\n```\nAfter';
+    const result = stripSpoiler(md);
+    assert.strictEqual(result, md);
+  });
+
+  it('does not strip gm-only markers, and stripGmOnly does not strip spoiler markers', () => {
+    const md = '<!-- gm-only -->\nA\n<!-- /gm-only -->\n<!-- spoiler -->\nB\n<!-- /spoiler -->';
+    assert.strictEqual(stripSpoiler(md), '<!-- gm-only -->\nA\n<!-- /gm-only -->\n');
+    assert.strictEqual(stripGmOnly(md), '\n<!-- spoiler -->\nB\n<!-- /spoiler -->');
   });
 });
 

--- a/tools/publish/test/unit/templates.test.js
+++ b/tools/publish/test/unit/templates.test.js
@@ -356,6 +356,24 @@ describe('displayTitle usage', () => {
     assert.ok(!html.includes('<h1>Captain_James'), 'Should not use raw title in h1');
   });
 
+  it('npc template with a portrait uses the cinematic card, not the cropped banner (B-portrait)', () => {
+    // Regression: NPC portraits (portrait-orientation) rendered as a cropped
+    // hero-banner background — only a thin band around 25% height survived.
+    // The cinematic layout shows the full portrait beside the name instead.
+    const page = {
+      title: 'Thomas_Wyndham',
+      displayTitle: 'Thomas Wyndham',
+      outputPath: 'characters/npcs/thomas-wyndham.html',
+      frontmatter: { type: 'npc', portrait: '_attachments/characters/thomas-wyndham.png' },
+    };
+    const processed = { html: '<p>Content</p>', relationships: '' };
+    const imageMap = { 'thomas-wyndham.png': true };
+    const html = npcTemplate(page, processed, mockNavFor, mockConfig, imageMap);
+    assert.ok(html.includes('class="hero-cinematic"'), 'Should use hero-cinematic, not hero-banner, when a portrait exists');
+    assert.ok(html.includes('class="hero-cinematic-img"'), 'Portrait image should use the cinematic (not banner) class');
+    assert.ok(!html.includes('hero-banner-img'), 'Should not use the banner crop class when a portrait exists');
+  });
+
   it('wiki template uses displayTitle in heading', () => {
     const page = {
       title: 'Old_Fortress',


### PR DESCRIPTION
## Summary

Replaces the plugin's exact-heading-string-matching approach to hiding GM-only content (a real production vault had grown its exclude list to 47 one-off entries and was still leaking live content) with two fixed primitives, adds a lifecycle for time-locked narrative spoilers, and rolls in five publish-tool bug fixes found during the investigation.

- **`## GM Notes`** is now the single canonical heading for whole-section GM-only content. The publish tool's heading filter is already level-aware, so anything nested under it stays hidden regardless of its own subsection name — no filtering-code changes needed, only template/skill changes (Session Wrap-Up, Adventure Brief, ttrpg-expert's generation templates).
- **New `<!-- spoiler -->` marker** for content hidden only until revealed in play, distinct from permanently-hidden `<!-- gm-only -->`. `reconcile` gains a step asking the GM, per session, whether pending spoilers in touched entities were revealed; campaign-qa's new "Open Spoilers" audit is the full-vault backstop. Both are now properly routed and reachable.
- **Migration protocol**: re-nests every heading already in a vault's own `exclude_sections` list under `## GM Notes` (mechanical), plus a GM-confirmed batch for bold-wrapped headings, bold-paragraph pseudo-headings, and callout-only content — including a real choice between permanent and time-locked hiding for that last category.
- **`exclude_fields` config-shadowing bug fixed** (matching an earlier fix to its sibling settings) and a new campaign-qa check for un-fenced GM-only content.
- **Five publish-tool fixes**: landing-page recap extraction/wrap-up matching/wikilink rendering, a hero-banner CSS clip, NPC portraits rendering as a proper card with lightbox support, and — found by the final whole-branch review — the search index reading raw markdown instead of the filtered view, which would have made spoiler/GM-only content searchable on the live site. Publish tool bumped to 1.5.0.
- Removed a dead bug-tracking spec file, verified line-by-line against current code to confirm everything in it had already shipped.

Plugin version: 1.8.2 → 1.8.3.

## Test plan

- [x] `python3 scripts/validate_schema.py` passes (41 files)
- [x] `tools/publish` full test suite passes (660/660, including new regression tests for the search-index leak and spoiler-marker stripping)
- [x] markdownlint passes on every touched file
- [x] Every commit individually reviewed (spec compliance + quality)
- [x] Final whole-branch review with a manual trace-through of 5 real migration scenarios (mass re-nesting, bold-wrapped heading, bold-paragraph pseudo-heading, callout-only content, spoiler reveal lifecycle) — found and closed 1 Critical (an eighth stale heading reference that would have caused a real publish leak) and 5 Important gaps
- [x] Fix pass independently re-reviewed clean, including verifying the new search-index regression test would actually fail without the fix (lunr's token stemming made a naive version of that test permanently green)