### PR TITLE
Version check reads migrations.md frontmatter only

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.6] — 2026-07-05
+
+### Changed
+
+- **Version check reads `shared/migrations.md` frontmatter only**
+  (Read with a 10-line limit) in all eight consuming skills — the
+  file is 16 KB of append-only migration history, and the check
+  needs one frontmatter field. Saves roughly 4k tokens on nearly
+  every skill invocation. Compaction plan Phase 0.
+
 ## [1.8.5] — 2026-07-04
 
 ### Added

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -96,7 +96,7 @@ version before proceeding with any user request:
 
 1. Read `gm_apprentice_version` from `_meta/vault-config.md`
    frontmatter
-2. Read `current_version` from `shared/migrations.md` frontmatter
+2. Read `current_version` from `shared/migrations.md` frontmatter (Read with `limit: 10` — the rest is migration history, not needed here)
 3. If versions match or vault is higher — proceed normally
 4. If vault version is lower or absent — run the migration
    workflow from `references/migration-procedure.md` before
@@ -109,7 +109,7 @@ version as part of setup).
 
 When initialization creates a new vault, set
 `gm_apprentice_version` in vault-config to the
-`current_version` from `shared/migrations.md`.
+`current_version` from `shared/migrations.md` frontmatter.
 
 ### Schema Evolution
 

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -60,7 +60,7 @@ utility usage.
 
 **Version check:** On first invocation, read
 `gm_apprentice_version` from `_meta/vault-config.md` and
-`current_version` from `shared/migrations.md`. If the vault
+`current_version` from `shared/migrations.md` — frontmatter only, Read with `limit: 10`; the rest of the file is a long migration history you don't need for the check. If the vault
 version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -16,7 +16,7 @@ git, or a terminal command does without explaining it.
 
 **Version check:** On first invocation, read
 `gm_apprentice_version` from `_meta/vault-config.md` and
-`current_version` from `shared/migrations.md`. If the vault
+`current_version` from `shared/migrations.md` — frontmatter only, Read with `limit: 10`; the rest of the file is a long migration history you don't need for the check. If the vault
 version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -19,7 +19,7 @@ intended scenes, NPCs, and hooks for quick reference during play.
 
 **Version check:** On first invocation, read
 `gm_apprentice_version` from `_meta/vault-config.md` and
-`current_version` from `shared/migrations.md`. If the vault
+`current_version` from `shared/migrations.md` — frontmatter only, Read with `limit: 10`; the rest of the file is a long migration history you don't need for the check. If the vault
 version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -12,7 +12,7 @@ first invocation.
 
 **Version check:** On first invocation, read
 `gm_apprentice_version` from `_meta/vault-config.md` and
-`current_version` from `shared/migrations.md`. If the vault
+`current_version` from `shared/migrations.md` — frontmatter only, Read with `limit: 10`; the rest of the file is a long migration history you don't need for the check. If the vault
 version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -12,7 +12,7 @@ first invocation.
 
 **Version check:** On first invocation, read
 `gm_apprentice_version` from `_meta/vault-config.md` and
-`current_version` from `shared/migrations.md`. If the vault
+`current_version` from `shared/migrations.md` — frontmatter only, Read with `limit: 10`; the rest of the file is a long migration history you don't need for the check. If the vault
 version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -50,7 +50,7 @@ On start, before any creative conversation:
 
 **Version check:** Read `gm_apprentice_version` from
 `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md`. If vault version is lower or absent,
+`shared/migrations.md` (frontmatter only — Read with `limit: 10`). If vault version is lower or absent,
 hand off to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`).
 Skip if no `_meta/`.

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -57,7 +57,7 @@ paths and missing metadata.
 
 **Version check:** After confirming the vault exists, read
 `gm_apprentice_version` from `_meta/vault-config.md` and
-`current_version` from `shared/migrations.md`. If the vault
+`current_version` from `shared/migrations.md` — frontmatter only, Read with `limit: 10`; the rest of the file is a long migration history you don't need for the check. If the vault
 version is lower or absent, announce the mismatch and hand off
 to campaign-organizer's migration workflow
 (`campaign-organizer/references/migration-procedure.md`) before


### PR DESCRIPTION
## Summary

Compaction plan Phase 0 — the quick win. The version check in all
eight vault-aware skills reads `current_version`, a single
frontmatter field in the first three lines of
`shared/migrations.md` — but the instruction had every skill
reading the whole 16 KB append-only migration history to get it.

All eight consuming skills now instruct a frontmatter-only read
(`limit: 10`). Saves roughly 4k tokens on nearly every skill
invocation — the highest-frequency large read in the plugin.

No content changes to migrations.md itself; no behavior change to
the check's logic.

## Testing

- Schema validation, 59-check utility regression suite,
  markdownlint on all eight touched skills, frontmatter integrity —
  all green
- Verified `current_version` sits within the first 3 lines of
  migrations.md, comfortably inside the 10-line limit

Bumps plugin to 1.8.6.