### PR TITLE
Add GURPS sheet arithmetic checker (gurps_check.py)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Vault utility regression
         run: python tests/test_vault_utilities.py
 
+      - name: gurps-check tests
+        run: python tests/test_gurps_check.py
+
   pr-discipline:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.10] — 2026-07-05
+
+### Added
+
+- **GURPS sheet arithmetic checker** — new bundled utility
+  `skills/shared/scripts/gurps_check.py` (with pure-formula core
+  `gurps_calc.py`) verifies a GURPS PC markdown sheet against Basic
+  Set arithmetic and reports advisory deltas: Basic Lift and the
+  encumbrance table (B15/B17), carried load vs the Current Status
+  `Enc:` line, Move/Dodge per level, secondary characteristics,
+  Parry/Block (B375–B376), a point-budget audit, and the
+  thrust/swing damage chain via closed-form B16 formulas with B269
+  dice-equivalence (so `2d+5` and `3d+1` compare equal). Read-only
+  and stdlib-only; wired into ttrpg-expert's GURPS chargen and
+  character-sheet references. The parser also accepts parenthetical
+  attribute labels like `ST (Strength)`. Damage formulas validated
+  against a GCS-derived oracle at development time — GCS is not a
+  dependency.
+
+---
+
 ## [1.8.9] — 2026-07-05
 
 ### Added

--- a/skills/shared/scripts/gurps_calc.py
+++ b/skills/shared/scripts/gurps_calc.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Pure GURPS 4e arithmetic. No I/O, no parsing — formulas only.
+
+Computes a character's own derived values from their attributes
+(the derived.js precedent: computed data, not reproduced rules text).
+Page references are GURPS Basic Set 4e. Stdlib only.
+"""
+
+import math
+
+# (level name, level number, Basic Lift multiplier) — B17
+ENC_LEVELS = [
+    ("None", 0, 1),
+    ("Light", 1, 2),
+    ("Medium", 2, 3),
+    ("Heavy", 3, 6),
+    ("X-Heavy", 4, 10),
+]
+
+
+def _round_half_up(x: float) -> int:
+    return math.floor(x + 0.5)
+
+
+def basic_lift(st: int) -> float:
+    """B15: ST^2/5 lb; round to nearest whole if 10 or more."""
+    bl = st * st / 5.0
+    return float(_round_half_up(bl)) if bl >= 10 else round(bl, 2)
+
+
+def enc_max_weights(bl: float) -> list:
+    """B17: the five encumbrance thresholds for a given Basic Lift."""
+    return [(name, level, bl * mult) for name, level, mult in ENC_LEVELS]
+
+
+def enc_move(basic_move: int, level: int) -> int:
+    """B17: Move x1/0.8/0.6/0.4/0.2 by level, drop fractions, minimum 1."""
+    return max(1, basic_move * (5 - level) // 5)
+
+
+def enc_dodge(basic_speed: float, level: int, combat_reflexes: bool = False) -> int:
+    """B17/B326: Basic Speed + 3 (drop fractions), +1 CR, -1 per level."""
+    return int(basic_speed) + 3 + (1 if combat_reflexes else 0) - level
+
+
+def secondaries(st: int, dx: int, iq: int, ht: int) -> dict:
+    """B15-B17 base values before bought adjustments."""
+    speed = (dx + ht) / 4.0
+    return {"hp": st, "will": iq, "per": iq, "fp": ht,
+            "speed": speed, "move": int(speed)}
+
+
+def parry(skill: int, combat_reflexes: bool = False) -> int:
+    """B376: 3 + skill/2 (drop fractions), +1 Combat Reflexes."""
+    return 3 + skill // 2 + (1 if combat_reflexes else 0)
+
+
+def block(skill: int, combat_reflexes: bool = False) -> int:
+    """B375: 3 + Shield skill/2 (drop fractions), +1 Combat Reflexes."""
+    return 3 + skill // 2 + (1 if combat_reflexes else 0)

--- a/skills/shared/scripts/gurps_calc.py
+++ b/skills/shared/scripts/gurps_calc.py
@@ -58,3 +58,59 @@ def parry(skill: int, combat_reflexes: bool = False) -> int:
 def block(skill: int, combat_reflexes: bool = False) -> int:
     """B375: 3 + Shield skill/2 (drop fractions), +1 Combat Reflexes."""
     return 3 + skill // 2 + (1 if combat_reflexes else 0)
+
+
+import re as _re
+
+_DICE_RE = _re.compile(r"^\s*(\d+)\s*d\s*(?:([+\-−])\s*(\d+))?\s*$")
+
+
+def thrust(st: int) -> tuple:
+    """B16 thrust as (dice, adds): +1 add per 2 ST, normalized per B269."""
+    if st < 19:
+        return 1, (st - 1) // 2 - 6
+    v = st - 11
+    if st > 50:
+        v -= 1
+    if st > 79:
+        v -= 1 + (st - 80) // 5
+    return v // 8 + 1, (v % 8) // 2 - 1
+
+
+def swing(st: int) -> tuple:
+    """B16 swing as (dice, adds): +1 add per ST from 10, normalized per B269."""
+    if st < 10:
+        return 1, (st - 1) // 2 - 5
+    if st < 28:
+        v = st - 9
+        return v // 4 + 1, v % 4 - 1
+    v = st
+    if st > 40:
+        v -= (st - 40) // 5
+    if st > 59:
+        v += 1
+    v += 9
+    return v // 8 + 1, (v % 8) // 2 - 1
+
+
+def fmt_dice(dice: int, adds: int) -> str:
+    if adds == 0:
+        return f"{dice}d"
+    return f"{dice}d{adds:+d}"
+
+
+def parse_dice(s: str):
+    """Parse '2d+1' / '3d-1' / '1d' -> (dice, adds); None if not dice."""
+    m = _DICE_RE.match(str(s))
+    if not m:
+        return None
+    adds = int(m.group(3)) if m.group(3) else 0
+    if m.group(2) in ("-", "−"):
+        adds = -adds
+    return int(m.group(1)), adds
+
+
+def dice_adds(dice: int, adds: int) -> int:
+    """B269 equivalence key: any +4 becomes 1d, so 4*dice + adds
+    identifies a damage roll up to legal rewrites (2d+5 == 3d+1)."""
+    return 4 * dice + adds

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -109,3 +109,110 @@ def norm_level(s):
     base = re.sub(r"[*←]|\(current\)", "", base, flags=re.I)
     base = re.sub(r"\s+", " ", base).strip().lower()
     return LEVEL_ALIASES.get(base, base)
+
+
+_ATTR_KEYS = {"st": "st", "dx": "dx", "iq": "iq", "ht": "ht",
+              "hp": "hp", "will": "will", "per": "per", "fp": "fp",
+              "basic speed": "speed", "basic move": "move"}
+
+
+def read_attributes(sheet):
+    out = {}
+    for title in ("Primary Attributes", "Secondary Characteristics",
+                  "Stat Sheet"):
+        for row in sheet.table(title)[1:]:
+            if len(row) < 2 or not row[0]:
+                continue
+            key = _ATTR_KEYS.get(row[0].strip().lower())
+            if key is None or key in out:
+                continue
+            m = re.search(r"\d+(?:\.\d+)?", row[1])
+            if m:
+                val = float(m.group(0))
+                out[key] = val if key == "speed" else int(val)
+    return out if "st" in out else None
+
+
+def has_combat_reflexes(sheet):
+    for title in ("Advantages & Perks", "Advantages", "Traits"):
+        for row in sheet.table(title)[1:]:
+            if row and "combat reflexes" in row[0].lower():
+                return True
+    return False
+
+
+def check_attributes(sheet):
+    findings = []
+    attrs = read_attributes(sheet)
+    if attrs is None:
+        return [("INFO", "attributes", "no Stat Sheet attributes found; "
+                 "attribute checks skipped")]
+    if not all(k in attrs for k in ("st", "dx", "iq", "ht")):
+        return [("INFO", "attributes", "missing one of ST/DX/IQ/HT; "
+                 "secondary checks skipped")]
+    base = gc.secondaries(attrs["st"], attrs["dx"], attrs["iq"], attrs["ht"])
+    source = {"hp": "ST", "will": "IQ", "per": "IQ", "fp": "HT",
+              "speed": "(DX+HT)/4", "move": "floor(Speed)"}
+    for key in ("hp", "will", "per", "fp", "speed", "move"):
+        if key not in attrs:
+            continue
+        declared, computed = attrs[key], base[key]
+        mismatch = (abs(declared - computed) > 0.01 if key == "speed"
+                    else declared != computed)
+        if mismatch:
+            findings.append(("INFO", f"attributes/{key}",
+                             f"{key.upper()} {declared} vs base {computed} "
+                             f"({source[key]}) — bought adjustment or error"))
+    return findings
+
+
+def _close(actual, expected):
+    return abs(actual - expected) <= max(1.0, expected * 0.02)
+
+
+def check_encumbrance(sheet):
+    findings = []
+    attrs = read_attributes(sheet)
+    if attrs is None:
+        return [("INFO", "encumbrance", "no attributes; check skipped")]
+    rows = sheet.table("Encumbrance")
+    if len(rows) < 2:
+        return [("INFO", "encumbrance", "no Encumbrance table found")]
+    bl = gc.basic_lift(attrs["st"])
+    expected = {name.lower(): (level, maxwt)
+                for name, level, maxwt in gc.enc_max_weights(bl)}
+    headers = rows[0]
+    i_wt, i_mv, i_dg = (col(headers, "weight", "max"),
+                        col(headers, "move"), col(headers, "dodge"))
+    cr = has_combat_reflexes(sheet)
+    bm, speed = attrs.get("move"), attrs.get("speed")
+    for row in rows[1:]:
+        if not row or not row[0]:
+            continue
+        name = norm_level(row[0])
+        if name not in expected:
+            findings.append(("INFO", f"encumbrance/{row[0]}",
+                             "unrecognized level name; row skipped"))
+            continue
+        level, maxwt = expected[name]
+        if i_wt >= 0:
+            declared = parse_weight(row[i_wt])
+            if declared is not None and not _close(declared, maxwt):
+                findings.append(("WARNING", f"encumbrance/{row[0]}",
+                                 f"max {declared:g} lb, computed {maxwt:g} lb "
+                                 f"(BL {bl:g})"))
+        if i_mv >= 0 and bm is not None:
+            declared = parse_cost(row[i_mv])
+            computed = gc.enc_move(bm, level)
+            if declared is not None and declared != computed:
+                findings.append(("WARNING", f"encumbrance/{row[0]}",
+                                 f"Move {declared}, computed {computed} "
+                                 f"(BM {bm})"))
+        if i_dg >= 0 and speed is not None:
+            declared = parse_cost(row[i_dg])
+            computed = gc.enc_dodge(speed, level, cr)
+            if declared is not None and declared != computed:
+                findings.append(("WARNING", f"encumbrance/{row[0]}",
+                                 f"Dodge {declared}, computed {computed}"
+                                 f"{' (with Combat Reflexes)' if cr else ''}"))
+    return findings

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -401,7 +401,7 @@ def check_points(sheet):
     return findings
 
 
-FORMULA_RE = re.compile(r"\b(sw|thr)\s*(?:([+\-−])\s*(\d+))?", re.I)
+FORMULA_RE = re.compile(r"\b(sw|thr)\b\s*(?:([+\-−])\s*(\d+))?", re.I)
 DICE_IN_TEXT_RE = re.compile(r"\b(\d+)\s*d\s*(?:([+\-−])\s*(\d+))?")
 
 

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -249,8 +249,10 @@ def check_load(sheet):
     total = 0.0
     for row in rows[1:]:
         if i_loc >= 0:
-            loc = _cell(row, i_loc)
-            if loc is not None and loc.strip().lower() not in ("carried", "worn"):
+            # blank/missing Location means unset -> counted, same as having
+            # no Location column at all
+            loc = (_cell(row, i_loc) or "").strip().lower()
+            if loc and loc not in ("carried", "worn"):
                 continue
         w = parse_weight(_cell(row, i_wt))
         if w is not None:

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -329,3 +329,73 @@ def check_defenses(sheet):
                         f"Block {declared}, computed {computed} from "
                         f"Shield {shield}{' +1 CR' if cr else ''}"))
     return findings
+
+
+_POINT_SOURCES = [
+    ("Attributes", ("Primary Attributes", "Secondary Characteristics")),
+    ("Advantages & Perks", ("Advantages & Perks", "Advantages")),
+    ("Disadvantages & Quirks", ("Disadvantages & Quirks", "Disadvantages")),
+    ("Skills", ("Skills",)),
+    ("Techniques", ("Techniques",)),
+    ("Spells", ("Spells",)),
+]
+
+
+def _sum_costs(sheet, titles):
+    total, found = 0, False
+    for title in titles:
+        rows = sheet.table(title)
+        if len(rows) < 2:
+            continue
+        i_cost = col(rows[0], "cost", "point")
+        if i_cost < 0:
+            continue
+        for row in rows[1:]:
+            if not row or "total" in row[0].lower():
+                continue
+            c = parse_cost(_cell(row, i_cost))
+            if c is not None:
+                total += c
+                found = True
+    return (total, True) if found else (0, False)
+
+
+def check_points(sheet):
+    findings = []
+    computed, missing = {}, []
+    for label, titles in _POINT_SOURCES:
+        total, found = _sum_costs(sheet, titles)
+        if found:
+            computed[label] = total
+        else:
+            missing.append(label)
+    summary_rows = sheet.table("Points Summary")
+    declared, declared_total = {}, None
+    for row in summary_rows[1:]:
+        if len(row) < 2 or not row[0]:
+            continue
+        label = re.sub(r"\*+", "", row[0]).strip()
+        val = parse_cost(_cell(row, 1))
+        if val is None:
+            continue
+        if label.lower() == "total":
+            declared_total = val
+        else:
+            declared[label] = val
+    for label, val in declared.items():
+        if label in computed and computed[label] != val:
+            findings.append(("WARNING", f"points/{label}",
+                             f"summary says {val}, section costs sum to "
+                             f"{computed[label]}"))
+    grand = sum(computed.values()) if computed else None
+    fm_total = parse_cost(sheet.fm.get("point_total"))
+    for name, total in (("Points Summary Total", declared_total),
+                        ("frontmatter point_total", fm_total)):
+        if total is not None and grand is not None and total != grand:
+            findings.append(("WARNING", "points/total",
+                             f"{name} {total}, summed section costs {grand}"))
+    if missing and (declared or fm_total is not None):
+        findings.append(("INFO", "points",
+                         "no cost data found for: " + ", ".join(missing) +
+                         " — sums are partial"))
+    return findings

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -453,3 +453,42 @@ def check_damage(sheet):
                              f"{fm_m.group(0).strip()} resolves to "
                              f"{gc.fmt_dice(dice, adds)} at ST {st}"))
     return findings
+
+
+CHECKS = [
+    ("attributes", check_attributes),
+    ("encumbrance", check_encumbrance),
+    ("load", check_load),
+    ("defenses", check_defenses),
+    ("points", check_points),
+    ("damage", check_damage),
+]
+
+
+def emit(section, findings):
+    print(f"[{section}]")
+    print(f"# count: {len(findings)}")
+    for level, locus, message in findings:
+        print(f"{level}\t{locus}\t{message}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("sheet", type=Path)
+    ap.add_argument("command", nargs="?", default="all",
+                    choices=[name for name, _fn in CHECKS] + ["all"])
+    args = ap.parse_args()
+    try:
+        text = args.sheet.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        print(f"error: cannot read {args.sheet}: {e}", file=sys.stderr)
+        return 2
+    sheet = Sheet(text)
+    for name, fn in CHECKS:
+        if args.command in (name, "all"):
+            emit(name, fn(sheet))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -123,7 +123,8 @@ def read_attributes(sheet):
         for row in sheet.table(title)[1:]:
             if len(row) < 2 or not row[0]:
                 continue
-            key = _ATTR_KEYS.get(row[0].strip().lower())
+            label = re.sub(r"\s*\([^)]*\)\s*$", "", row[0]).strip().lower()
+            key = _ATTR_KEYS.get(label)
             if key is None or key in out:
                 continue
             m = re.search(r"\d+(?:\.\d+)?", row[1])

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -270,3 +270,62 @@ def check_load(sheet):
                  f"Current Status says Enc {declared} but carried+worn "
                  f"{total:g} lb computes to {computed_name} (BL {bl:g})")]
     return []
+
+
+TRAILING_INT_RE = re.compile(r"(\d+)\s*$")
+
+
+def check_defenses(sheet):
+    findings = []
+    attrs = read_attributes(sheet) or {}
+    cr = has_combat_reflexes(sheet)
+    rows = sheet.table("Melee Weapons")
+    if len(rows) >= 2:
+        headers = rows[0]
+        i_skill, i_parry = col(headers, "skill"), col(headers, "parry")
+        if i_skill >= 0 and i_parry >= 0:
+            for row in rows[1:]:
+                if len(row) <= max(i_skill, i_parry) or not row[0]:
+                    continue
+                sm = TRAILING_INT_RE.search(row[i_skill])
+                pm = re.fullmatch(r"\d+", row[i_parry].strip())
+                if not (sm and pm):
+                    continue
+                computed = gc.parry(int(sm.group(1)), cr)
+                declared = int(pm.group(0))
+                if declared != computed:
+                    findings.append((
+                        "WARNING", f"defenses/parry/{row[0]}",
+                        f"Parry {declared}, computed {computed} from skill "
+                        f"{sm.group(1)}{' +1 CR' if cr else ''} — weapon or "
+                        f"style bonus may explain"))
+    for row in sheet.table("Active Defenses")[1:]:
+        if len(row) < 2 or not row[0]:
+            continue
+        label = row[0].lower()
+        dm = re.match(r"\d+", row[1].strip())
+        if not dm:
+            continue
+        declared = int(dm.group(0))
+        if "dodge" in label and attrs.get("speed") is not None:
+            computed = gc.enc_dodge(attrs["speed"], 0, cr)
+            if declared != computed:
+                findings.append((
+                    "INFO", "defenses/dodge",
+                    f"Dodge {declared}, unencumbered computed {computed} — "
+                    "may reflect current encumbrance"))
+        elif "block" in label:
+            shield = None
+            for srow in sheet.table("Skills")[1:]:
+                if srow and "shield" in srow[0].lower():
+                    m = TRAILING_INT_RE.search(srow[-1])
+                    if m:
+                        shield = int(m.group(1))
+            if shield is not None:
+                computed = gc.block(shield, cr)
+                if declared != computed:
+                    findings.append((
+                        "WARNING", "defenses/block",
+                        f"Block {declared}, computed {computed} from "
+                        f"Shield {shield}{' +1 CR' if cr else ''}"))
+    return findings

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -170,6 +170,10 @@ def _close(actual, expected):
     return abs(actual - expected) <= max(1.0, expected * 0.02)
 
 
+def _cell(row, i):
+    return row[i] if 0 <= i < len(row) else None
+
+
 def check_encumbrance(sheet):
     findings = []
     attrs = read_attributes(sheet)
@@ -196,20 +200,20 @@ def check_encumbrance(sheet):
             continue
         level, maxwt = expected[name]
         if i_wt >= 0:
-            declared = parse_weight(row[i_wt])
+            declared = parse_weight(_cell(row, i_wt))
             if declared is not None and not _close(declared, maxwt):
                 findings.append(("WARNING", f"encumbrance/{row[0]}",
                                  f"max {declared:g} lb, computed {maxwt:g} lb "
                                  f"(BL {bl:g})"))
         if i_mv >= 0 and bm is not None:
-            declared = parse_cost(row[i_mv])
+            declared = parse_cost(_cell(row, i_mv))
             computed = gc.enc_move(bm, level)
             if declared is not None and declared != computed:
                 findings.append(("WARNING", f"encumbrance/{row[0]}",
                                  f"Move {declared}, computed {computed} "
                                  f"(BM {bm})"))
         if i_dg >= 0 and speed is not None:
-            declared = parse_cost(row[i_dg])
+            declared = parse_cost(_cell(row, i_dg))
             computed = gc.enc_dodge(speed, level, cr)
             if declared is not None and declared != computed:
                 findings.append(("WARNING", f"encumbrance/{row[0]}",

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""GURPS 4e sheet arithmetic checks: lift, encumbrance, load, defenses,
+points, damage.
+
+Read-only companion to vault_check.py for a single PC markdown sheet.
+Verifies the sheet's own numbers against Basic Set formulas and reports
+deltas; interpretation stays with the GM (Talents and bespoke perks
+legitimately shift values, so findings are advisory). Stdlib only.
+
+Usage:
+  gurps_check.py SHEET.md [attributes|encumbrance|load|defenses|points|damage|all]
+
+Output: labelled sections, `# count: N` headers, one finding per line
+as `LEVEL<TAB>locus<TAB>message`.
+
+Levels: ERROR (arithmetic contradiction), WARNING (mismatch the GM
+should look at), INFO (context, e.g. missing sections limiting a check).
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gurps_calc as gc            # noqa: E402
+from schema_rules import extract_frontmatter  # noqa: E402
+
+HEADING_RE = re.compile(r"^(#{2,3})\s+(.+?)\s*$", re.M)
+WEIGHT_RE = re.compile(r"(\d+(?:\.\d+)?)")
+COST_RE = re.compile(r"[\[\(]?\s*([+\-−]?\d+)\s*[\]\)]?")
+LEVEL_ALIASES = {"extra-heavy": "x-heavy", "extra heavy": "x-heavy",
+                 "xheavy": "x-heavy", "very heavy": "x-heavy"}
+# Mirrors the fence convention in schema_rules.extract_frontmatter
+# (anchored at file start, CRLF-tolerant, closing fence at newline or
+# EOF) so the fm dict and the body strip agree on the block boundary.
+FRONTMATTER_BLOCK_RE = re.compile(r"\A---\r?\n.*?\r?\n---(?:\r?\n|$)",
+                                  re.DOTALL)
+
+
+class Sheet:
+    def __init__(self, text: str):
+        self.fm = extract_frontmatter(text) or {}
+        body = FRONTMATTER_BLOCK_RE.sub("", text, count=1)
+        self._sections = []           # (title_lower, level, body)
+        matches = list(HEADING_RE.finditer(body))
+        for i, m in enumerate(matches):
+            level = len(m.group(1))
+            end = len(body)
+            for later in matches[i + 1:]:
+                if len(later.group(1)) <= level:
+                    end = later.start()
+                    break
+            self._sections.append(
+                (m.group(2).strip().lower(), level, body[m.end():end]))
+
+    def section(self, title: str):
+        t = title.strip().lower()
+        for name, _level, sec_body in self._sections:
+            if name == t:
+                return sec_body
+        return None
+
+    def table(self, title: str):
+        sec_body = self.section(title)
+        if sec_body is None:
+            return []
+        rows = []
+        for line in sec_body.splitlines():
+            line = line.strip()
+            if not (line.startswith("|") and line.endswith("|")):
+                if rows:
+                    break             # table ended
+                continue
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            if all(re.fullmatch(r":?-{2,}:?", c) for c in cells if c):
+                continue              # separator row
+            rows.append(cells)
+        return rows
+
+
+def parse_weight(s):
+    if s is None:
+        return None
+    cleaned = str(s).replace(",", "")
+    for junk in ("≤", "≈", "~", "<", ">"):
+        cleaned = cleaned.replace(junk, "")
+    m = WEIGHT_RE.search(cleaned)
+    return float(m.group(1)) if m else None
+
+
+def parse_cost(s):
+    if s is None:
+        return None
+    m = COST_RE.search(str(s).replace("−", "-"))
+    return int(m.group(1)) if m else None
+
+
+def col(headers, *needles):
+    lower = [h.lower() for h in headers]
+    for i, h in enumerate(lower):
+        if any(n in h for n in needles):
+            return i
+    return -1
+
+
+def norm_level(s):
+    base = re.sub(r"\([^)]*\)", "", str(s))
+    base = re.sub(r"[*←]|\(current\)", "", base, flags=re.I)
+    base = re.sub(r"\s+", " ", base).strip().lower()
+    return LEVEL_ALIASES.get(base, base)

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -399,3 +399,57 @@ def check_points(sheet):
                          "no cost data found for: " + ", ".join(missing) +
                          " — sums are partial"))
     return findings
+
+
+FORMULA_RE = re.compile(r"\b(sw|thr)\s*(?:([+\-−])\s*(\d+))?", re.I)
+DICE_IN_TEXT_RE = re.compile(r"\b(\d+)\s*d\s*(?:([+\-−])\s*(\d+))?")
+
+
+def _resolve_formula(st, kind, sign, num):
+    dice, adds = (gc.swing(st) if kind.lower() == "sw" else gc.thrust(st))
+    if num:
+        n = int(num)
+        adds += -n if sign in ("-", "−") else n
+    return dice, adds
+
+
+def check_damage(sheet):
+    attrs = read_attributes(sheet)
+    if attrs is None:
+        return [("INFO", "damage", "no attributes; check skipped")]
+    st = attrs["st"]
+    thr, sw = gc.thrust(st), gc.swing(st)
+    findings = [("INFO", "damage",
+                 f"ST {st}: thr {gc.fmt_dice(*thr)}, sw {gc.fmt_dice(*sw)} "
+                 "(B16)")]
+    rows = sheet.table("Melee Weapons")
+    if len(rows) < 2:
+        return findings
+    i_dmg = col(rows[0], "damage")
+    if i_dmg < 0:
+        return findings
+    for row in rows[1:]:
+        if len(row) <= i_dmg or not row[0]:
+            continue
+        cell = _cell(row, i_dmg)
+        fm_m = FORMULA_RE.search(cell)
+        if not fm_m:
+            continue
+        dice, adds = _resolve_formula(st, *fm_m.groups())
+        d_m = DICE_IN_TEXT_RE.search(cell)
+        locus = f"damage/{row[0]}"
+        if d_m:
+            d_adds = int(d_m.group(3) or 0)
+            if d_m.group(2) in ("-", "−"):
+                d_adds = -d_adds
+            if (gc.dice_adds(int(d_m.group(1)), d_adds)
+                    != gc.dice_adds(dice, adds)):
+                findings.append(("WARNING", locus,
+                                 f"lists {d_m.group(0).strip()}, "
+                                 f"{fm_m.group(0).strip()} resolves to "
+                                 f"{gc.fmt_dice(dice, adds)} at ST {st}"))
+        else:
+            findings.append(("INFO", locus,
+                             f"{fm_m.group(0).strip()} resolves to "
+                             f"{gc.fmt_dice(dice, adds)} at ST {st}"))
+    return findings

--- a/skills/shared/scripts/gurps_check.py
+++ b/skills/shared/scripts/gurps_check.py
@@ -220,3 +220,53 @@ def check_encumbrance(sheet):
                                  f"Dodge {declared}, computed {computed}"
                                  f"{' (with Combat Reflexes)' if cr else ''}"))
     return findings
+
+
+ENC_LINE_RE = re.compile(r"\bEnc(?:umbrance)?\*{0,2}\s*:\s*\*{0,2}\s*([^\n]+)",
+                         re.I)
+
+
+def declared_enc(sheet):
+    body = sheet.section("Current Status")
+    if not body:
+        return None
+    m = ENC_LINE_RE.search(body)
+    return m.group(1).strip() if m else None
+
+
+def check_load(sheet):
+    attrs = read_attributes(sheet)
+    if attrs is None:
+        return [("INFO", "load", "no attributes; check skipped")]
+    rows = sheet.table("Equipment")
+    if len(rows) < 2:
+        return [("INFO", "load", "no Equipment table found; check skipped")]
+    headers = rows[0]
+    i_wt, i_loc = col(headers, "weight"), col(headers, "location")
+    if i_wt < 0:
+        return [("INFO", "load", "Equipment table has no Weight column")]
+    total = 0.0
+    for row in rows[1:]:
+        if i_loc >= 0:
+            loc = _cell(row, i_loc)
+            if loc is not None and loc.strip().lower() not in ("carried", "worn"):
+                continue
+        w = parse_weight(_cell(row, i_wt))
+        if w is not None:
+            total += w
+    bl = gc.basic_lift(attrs["st"])
+    computed_name = gc.ENC_LEVELS[-1][0]
+    for name, _level, maxwt in gc.enc_max_weights(bl):
+        if total <= maxwt:
+            computed_name = name
+            break
+    declared = declared_enc(sheet)
+    if declared is None:
+        return [("INFO", "load",
+                 f"carried+worn {total:g} lb -> {computed_name} (BL {bl:g}); "
+                 "no Enc: line in Current Status to compare")]
+    if norm_level(declared) != computed_name.lower():
+        return [("WARNING", "load",
+                 f"Current Status says Enc {declared} but carried+worn "
+                 f"{total:g} lb computes to {computed_name} (BL {bl:g})")]
+    return []

--- a/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-generation.md
@@ -339,6 +339,23 @@ Dodge. Always calculate this for combat characters.
 - [ ] Character has GM hooks (enemies, duties, secrets)
 - [ ] Character has reasons to work with the party
 
+**Arithmetic Verification:**
+
+Once the sheet is built, run the bundled checker to confirm the
+math holds:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/gurps_check.py" "path/to/PC.md"
+```
+
+It re-derives Basic Lift, the encumbrance table, carried load
+against the Current Status Enc line, Move/Dodge, secondary
+characteristics, Parry/Block, the point budget, and thrust/swing
+damage (B15–B17, B269, B375–B376). Findings are advisory — a
+WARNING is a delta to explain (a Talent or weapon bonus is a
+perfectly good reason), not an automatic error. Fix any genuine
+arithmetic mistake before presenting the sheet.
+
 ## Character Sheet Output Format
 
 ```text

--- a/skills/ttrpg-expert/systems/gurps-4e/character-sheet.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-sheet.md
@@ -241,3 +241,20 @@ common ranges, defensive options, and tactical notes.*
 | **TOTAL** | **0** |
 | **Budget** | |
 | **Unspent** | |
+
+## Sheet Verification
+
+*After filling in or editing this sheet, run the bundled checker
+to confirm the arithmetic:*
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/gurps_check.py" "path/to/this-sheet.md"
+```
+
+*It verifies Basic Lift, the encumbrance table, carried load
+against the recorded encumbrance line, Move/Dodge, secondary
+characteristics, Parry/Block, the point total, and thrust/swing
+damage (B15–B17, B269, B375–B376). Findings are advisory —
+WARNINGs are deltas to explain (a Talent or weapon bonus is a
+fine reason), not automatic errors. Fix real arithmetic errors
+before finalizing.*

--- a/skills/ttrpg-expert/systems/gurps-4e/character-sheet.md
+++ b/skills/ttrpg-expert/systems/gurps-4e/character-sheet.md
@@ -244,15 +244,19 @@ common ranges, defensive options, and tactical notes.*
 
 ## Sheet Verification
 
-*After filling in or editing this sheet, run the bundled checker
-to confirm the arithmetic:*
+*Once the character lives in the vault as a PC entity file (the
+`pc-gurps-4e.md` template), verify its arithmetic with the
+bundled checker:*
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/gurps_check.py" "path/to/this-sheet.md"
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/gurps_check.py" "path/to/PC.md"
 ```
 
-*It verifies Basic Lift, the encumbrance table, carried load
-against the recorded encumbrance line, Move/Dodge, secondary
+*The checker parses the vault format — bare headings like "Melee
+Weapons" and "Points Summary", and a "Current Status" block with
+an Enc: line — not this reference sheet's layout, so run it
+against the PC's vault file. It verifies Basic Lift, the
+encumbrance table, carried load, Move/Dodge, secondary
 characteristics, Parry/Block, the point total, and thrust/swing
 damage (B15–B17, B269, B375–B376). Findings are advisory —
 WARNINGs are deltas to explain (a Talent or weapon bonus is a

--- a/tests/fixtures/gurps-pcs/clean.md
+++ b/tests/fixtures/gurps-pcs/clean.md
@@ -1,0 +1,79 @@
+---
+type: pc
+point_total: 113
+status: active
+---
+
+# Clean Sheet
+
+## Stat Sheet
+
+### Primary Attributes
+
+| Attribute | Score | Cost |
+|-----------|-------|------|
+| ST | 12 | [20] |
+| DX | 12 | [40] |
+| IQ | 11 | [20] |
+| HT | 11 | [10] |
+
+### Secondary Characteristics
+
+| Characteristic | Value |
+|----------------|-------|
+| HP | 12 |
+| Will | 11 |
+| Per | 11 |
+| FP | 11 |
+| Basic Speed | 5.75 |
+| Basic Move | 5 |
+
+## Advantages & Perks
+
+| Name | Cost | Notes |
+|------|------|-------|
+| Combat Reflexes | 15 | +1 active defenses |
+
+## Skills
+
+| Name | Difficulty | Points | Effective |
+|------|-----------|--------|-----------|
+| Shortsword | DX/A | [8] | 14 |
+
+## Melee Weapons
+
+| Weapon | Skill | Damage | Reach | Parry |
+|--------|-------|--------|-------|-------|
+| Shortsword | Shortsword 14 | sw+1 cut (2d-1 cut) | 1 | 11 |
+
+## Points Summary
+
+| Category | Points |
+|----------|--------|
+| Attributes | 90 |
+| Advantages & Perks | 15 |
+| Skills | 8 |
+| **Total** | **113** |
+
+## Equipment
+
+| Item | Weight | Cost | Location | Notes |
+|------|--------|------|----------|-------|
+| Shortsword | 2 lb | $400 | Carried | sw+1 cut |
+| Leather Armor | 20 lb | $340 | Worn | DR 2 |
+
+### Encumbrance
+
+| Level | Max Weight | Move | Dodge |
+|-------|-----------|------|-------|
+| None (0) | 29 lb | 5 | 9 |
+| Light (1) | 58 lb | 4 | 8 |
+| Medium (2) | 87 lb | 3 | 7 |
+| Heavy (3) | 174 lb | 2 | 6 |
+| X-Heavy (4) | 290 lb | 1 | 5 |
+
+## Current Status
+
+**Location:** Test harness.
+**Condition:** Unharmed.
+**Enc:** None (0)

--- a/tests/fixtures/gurps-pcs/flawed.md
+++ b/tests/fixtures/gurps-pcs/flawed.md
@@ -1,0 +1,90 @@
+---
+type: pc
+player_name: Test Player
+point_total: 150
+status: active
+---
+
+# Karl Brenner
+
+**150 points** | TL3
+
+---
+
+## Stat Sheet
+
+### Primary Attributes
+
+| Attribute | Score | Modifier | Cost |
+|-----------|-------|----------|------|
+| ST | 11 | — | [10] |
+| DX | 13 | — | [60] |
+| IQ | 12 | — | [40] |
+| HT | 11 | — | [10] |
+
+### Secondary Characteristics
+
+| Characteristic | Value |
+|----------------|-------|
+| HP | 11 |
+| Will | 12 |
+| Per | 12 |
+| FP | 11 |
+| Basic Speed | 6.0 |
+| Basic Move | 6 |
+
+---
+
+## Skills
+
+| Name | Difficulty | Relative Level | Points | Effective |
+|------|-----------|----------------|--------|-----------|
+| Broadsword | DX/A | DX+2 | [8] | 15 |
+| Shield | DX/E | DX+2 | [4] | 15 |
+| Stealth | DX/A | DX+0 | [2] | 13 |
+| Tactics | IQ/H | IQ+0 | [4] | 12 |
+
+---
+
+## Melee Weapons
+
+| Weapon | Skill | Damage | Reach | Parry |
+|--------|-------|--------|-------|-------|
+| Broadsword | Broadsword 15 | 2d cut | 1 | 11 |
+| Punch | DX 13 | 1d-2 cr | C | 8 |
+
+---
+
+## Combat Action Chains
+
+| # | Chain | Key Rolls | Outcome |
+|---|-------|-----------|---------|
+| 1 | Shield Rush and Strike | Shield 15, Broadsword 15 | Block incoming attack, follow with sword strike |
+| 2 | Cautious Advance | Tactics 12, Broadsword 15 | Maneuver into flanking position and attack |
+
+---
+
+## Current Status
+
+**Condition:** Unharmed.
+**Location:** The market district.
+
+---
+
+## Equipment
+
+| Item | Weight | Cost | Location | Notes |
+|------|--------|------|----------|-------|
+| Broadsword | 3 lb | $600 | Carried | sw+1 cut or thr+1 cr |
+| Large Shield | 15 lb | $90 | Carried | DB+2 |
+| Mail Hauberk | 25 lb | $230 | Worn | DR 4 torso |
+
+### Encumbrance
+
+| Level | Max Weight | Move | Dodge |
+|-------|-----------|------|-------|
+| None (0) | 22 lb | 6 | 9 |
+| Light (1) | 44 lb | 4 | 8 |
+| Medium (2) | 66 lb | 3 | 7 |
+| Heavy (3) | 132 lb | 2 | 6 |
+| Extra-Heavy (4) | 220 lb | 1 | 5 |

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -321,6 +321,30 @@ check("thr-1 vs 1d-2 passes (both 2 adds)",
 check("affliction line skipped",
       any("Zapper" in f[1] for f in dmg), False)
 
+# Word-boundary guard: "Thrown"/"Sword" must not match as thr/sw, while
+# bare "sw" (formula, no adds, no dice) still resolves as an INFO.
+_DMG2 = _KARLISH + """
+## Melee Weapons
+
+| Weapon | Skill | Damage | Reach | Parry |
+|--------|-------|--------|-------|-------|
+| Broadsword | Broadsword 15 | sw+1 cut (2d cut) | 1 | 10 |
+| Javelin | Spear 13 | Thrown weapon, 1d cut | 1 | 9 |
+| Gladius | Shortsword 14 | Special, see Short Sword skill | 1 | 10 |
+| Whip | Whip 12 | sw cut | 1,2 | 8 |
+"""
+
+dmg2 = gk.check_damage(gk.Sheet(_DMG2))
+check("Thrown weapon row produces no finding",
+      any("Javelin" in f[1] for f in dmg2), False)
+check("Short Sword prose row produces no finding",
+      any("Gladius" in f[1] for f in dmg2), False)
+check("sw+1 vs 2d still flagged after boundary fix",
+      any(f[0] == "WARNING" and "Broadsword" in f[1] for f in dmg2), True)
+check("bare sw resolves as formula-only INFO at ST 11",
+      any(f[0] == "INFO" and "Whip" in f[1] and "1d+1" in f[2]
+          for f in dmg2), True)
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -135,6 +135,56 @@ check("col finds header", gk.col(["Level", "Max Weight", "Move"], "weight"), 1)
 check("norm_level strips marker+paren", gk.norm_level("Light (1) ←"), "light")
 check("norm_level extra-heavy alias", gk.norm_level("Extra-Heavy (4)"), "x-heavy")
 
+_KARLISH = """---
+type: pc
+---
+
+# K
+
+## Stat Sheet
+
+### Primary Attributes
+
+| Attribute | Score | Cost |
+|-----------|-------|------|
+| ST | 11 | [10] |
+| DX | 13 | [60] |
+| IQ | 12 | [40] |
+| HT | 11 | [10] |
+
+### Secondary Characteristics
+
+| Characteristic | Value |
+|----------------|-------|
+| HP | 11 |
+| Will | 12 |
+| Per | 12 |
+| FP | 11 |
+| Basic Speed | 6.0 |
+| Basic Move | 6 |
+
+## Equipment
+
+### Encumbrance
+
+| Level | Max Weight | Move | Dodge |
+|-------|-----------|------|-------|
+| None (0) | 22 lb | 6 | 9 |
+| Light (1) | 44 lb | 4 | 8 |
+"""
+
+ksheet = gk.Sheet(_KARLISH)
+attrs = gk.read_attributes(ksheet)
+check("read ST", attrs["st"], 11)
+check("read speed", attrs["speed"], 6.0)
+check("no CR", gk.has_combat_reflexes(ksheet), False)
+check("attributes clean when bases match", gk.check_attributes(ksheet), [])
+enc_findings = gk.check_encumbrance(ksheet)
+check("enc flags BL-22 table rows (2 weight warnings)",
+      [f[0] for f in enc_findings], ["WARNING", "WARNING"])
+check("enc warning names computed BL",
+      "BL 24" in enc_findings[0][2], True)
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -83,6 +83,58 @@ check("B269: 2d+5 equiv 3d+1",
 check("B269: 1d+2 not equiv 2d",
       gc.dice_adds(1, 2) == gc.dice_adds(2, 0), False)
 
+import gurps_check as gk  # noqa: E402
+
+_SHEET_MD = """---
+type: pc
+point_total: 100
+---
+
+# Test
+
+## Stat Sheet
+
+### Primary Attributes
+
+| Attribute | Score | Cost |
+|-----------|-------|------|
+| ST | 12 | [20] |
+| DX | 12 | [40] |
+
+## Equipment
+
+| Item | Weight | Location |
+|------|--------|----------|
+| Sword | 2 lb | Carried |
+
+### Encumbrance
+
+| Level | Max Weight | Move | Dodge |
+|-------|-----------|------|-------|
+| None (0) | ≤29 lbs | 5 | 9 |
+
+## Current Status
+
+**Enc:** None (0)
+"""
+
+sheet = gk.Sheet(_SHEET_MD)
+check("fm point_total", sheet.fm.get("point_total"), "100")
+check("section lookup case-insensitive",
+      sheet.section("current status") is not None, True)
+check("stat table rows", sheet.table("Primary Attributes"),
+      [["Attribute", "Score", "Cost"], ["ST", "12", "[20]"], ["DX", "12", "[40]"]])
+check("enc subsection table first row",
+      sheet.table("Encumbrance")[1][0], "None (0)")
+check("parse_weight le-symbol", gk.parse_weight("≤29 lbs"), 29.0)
+check("parse_weight plain", gk.parse_weight("2 lb"), 2.0)
+check("parse_weight none", gk.parse_weight("—"), None)
+check("parse_cost bracket", gk.parse_cost("[20]"), 20)
+check("parse_cost unicode minus", gk.parse_cost("−25"), -25)
+check("col finds header", gk.col(["Level", "Max Weight", "Move"], "weight"), 1)
+check("norm_level strips marker+paren", gk.norm_level("Light (1) ←"), "light")
+check("norm_level extra-heavy alias", gk.norm_level("Extra-Heavy (4)"), "x-heavy")
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -267,6 +267,38 @@ blk_ok = gk.check_defenses(gk.Sheet(_ACTIVE.replace(
 check("matching block produces no block finding",
       [f[1] for f in blk_ok], ["defenses/dodge"])
 
+_POINTS = _KARLISH + """
+## Advantages & Perks
+
+| Name | Cost | Notes |
+|------|------|-------|
+| Combat Reflexes | 15 | |
+
+## Skills
+
+| Name | Difficulty | Points | Effective |
+|------|-----------|--------|-----------|
+| Broadsword | DX/A | [8] | 15 |
+| Shield | DX/E | [4] | 15 |
+
+## Points Summary
+
+| Category | Points |
+|----------|--------|
+| Attributes | 120 |
+| Advantages & Perks | 15 |
+| Skills | 14 |
+| **Total** | **149** |
+"""
+
+psheet = gk.Sheet(_POINTS)
+pts = gk.check_points(psheet)
+check("skills category mismatch flagged (12 summed vs 14 declared)",
+      any(f[0] == "WARNING" and "Skills" in f[1] and "12" in f[2]
+          for f in pts), True)
+check("attributes category matches (120), not flagged",
+      any("Attributes" in f[1] and f[0] == "WARNING" for f in pts), False)
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Regression tests for gurps_calc.py and gurps_check.py.
+
+Formula tests import gurps_calc directly; CLI tests run gurps_check.py
+against the committed fixtures in tests/fixtures/gurps-pcs/ and assert
+exact output. All page references are GURPS Basic Set 4e.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "skills" / "shared" / "scripts"
+FIXTURES = ROOT / "tests" / "fixtures" / "gurps-pcs"
+sys.path.insert(0, str(SCRIPTS))
+
+import gurps_calc as gc  # noqa: E402
+
+FAILURES = []
+
+
+def check(label, actual, expected):
+    if actual != expected:
+        FAILURES.append(f"{label}:\n  expected {expected!r}\n  got      {actual!r}")
+    else:
+        print(f"ok: {label}")
+
+
+# --- basic lift (B15) ---
+check("BL ST 10", gc.basic_lift(10), 20.0)
+check("BL ST 11", gc.basic_lift(11), 24.0)     # 24.2 -> nearest
+check("BL ST 12", gc.basic_lift(12), 29.0)     # 28.8 -> nearest
+check("BL ST 13", gc.basic_lift(13), 34.0)     # 33.8 -> nearest
+check("BL ST 7 keeps fraction", gc.basic_lift(7), 9.8)
+
+# --- encumbrance thresholds (B17) ---
+check("enc thresholds BL 34",
+      gc.enc_max_weights(34.0),
+      [("None", 0, 34.0), ("Light", 1, 68.0), ("Medium", 2, 102.0),
+       ("Heavy", 3, 204.0), ("X-Heavy", 4, 340.0)])
+
+# --- move / dodge per level (B17) ---
+check("move BM6 by level", [gc.enc_move(6, lv) for lv in range(5)], [6, 4, 3, 2, 1])
+check("move BM5 by level", [gc.enc_move(5, lv) for lv in range(5)], [5, 4, 3, 2, 1])
+check("move floor is 1", gc.enc_move(4, 4), 1)
+check("dodge speed 6.5 CR by level",
+      [gc.enc_dodge(6.5, lv, combat_reflexes=True) for lv in range(5)],
+      [10, 9, 8, 7, 6])
+check("dodge speed 6.0 no CR", gc.enc_dodge(6.0, 0), 9)
+
+# --- secondaries (B15-B17) ---
+check("secondaries 13/14/13/13",
+      gc.secondaries(13, 14, 13, 13),
+      {"hp": 13, "will": 13, "per": 13, "fp": 13, "speed": 6.75, "move": 6})
+
+# --- parry / block (B375-B376) ---
+check("parry skill 16 CR", gc.parry(16, combat_reflexes=True), 12)
+check("parry skill 15", gc.parry(15), 10)
+check("block skill 15 CR", gc.block(15, combat_reflexes=True), 11)
+
+if FAILURES:
+    print("\n".join(["", "FAILURES:"] + FAILURES))
+    sys.exit(1)
+print("all gurps checks passed")

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -185,6 +185,14 @@ check("enc flags BL-22 table rows (2 weight warnings)",
 check("enc warning names computed BL",
       "BL 24" in enc_findings[0][2], True)
 
+# Ragged row: recognized level with fewer cells than the header must not
+# raise; its weight warning still fires.
+_RAGGED = _KARLISH.replace("| Light (1) | 44 lb | 4 | 8 |",
+                           "| Light (1) | 44 lb |")
+ragged_findings = gk.check_encumbrance(gk.Sheet(_RAGGED))
+check("enc tolerates ragged row (2 weight warnings, no exception)",
+      [f[0] for f in ragged_findings], ["WARNING", "WARNING"])
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -235,6 +235,38 @@ check("both parry mismatches flagged",
 check("broadsword computed 10", "10" in dfd[0][2], True)
 check("punch computed 9", "9" in dfd[1][2], True)
 
+# Active Defenses table: dodge mismatch is INFO (sheets often list the
+# encumbered value), block mismatch is WARNING, non-numeric rows skipped.
+# Hand-computed: Speed 6.0, no CR -> unencumbered Dodge 9; Shield 15 ->
+# Block 3 + 15//2 = 10.
+_ACTIVE = _KARLISH + """
+## Skills
+
+| Name | Difficulty | Points | Effective |
+|------|-----------|--------|-----------|
+| Shield | DX/E | [4] | 15 |
+
+## Active Defenses
+
+| Defense | Score | Notes |
+|---------|-------|-------|
+| Dodge | 8 | current |
+| Block | 11 | with medium shield |
+| Parry (sword) | — | see melee |
+"""
+
+adf = gk.check_defenses(gk.Sheet(_ACTIVE))
+check("active defenses: one dodge INFO + one block WARNING, nothing else",
+      [(f[0], f[1]) for f in adf],
+      [("INFO", "defenses/dodge"), ("WARNING", "defenses/block")])
+check("dodge message shows computed 9", "9" in adf[0][2], True)
+check("block message shows computed 10", "10" in adf[1][2], True)
+
+blk_ok = gk.check_defenses(gk.Sheet(_ACTIVE.replace(
+    "| Block | 11 |", "| Block | 10 |")))
+check("matching block produces no block finding",
+      [f[1] for f in blk_ok], ["defenses/dodge"])
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -193,6 +193,32 @@ ragged_findings = gk.check_encumbrance(gk.Sheet(_RAGGED))
 check("enc tolerates ragged row (2 weight warnings, no exception)",
       [f[0] for f in ragged_findings], ["WARNING", "WARNING"])
 
+_LOADED = _KARLISH.replace(
+    "## Equipment\n",
+    "## Equipment\n\n"
+    "| Item | Weight | Cost | Location |\n"
+    "|------|--------|------|----------|\n"
+    "| Sword | 3 lb | $600 | Carried |\n"
+    "| Shield | 15 lb | $90 | Carried |\n"
+    "| Mail | 25 lb | $230 | Worn |\n"
+    "| Mule pack | 90 lb | $30 | Mule |\n",
+).replace(
+    "## Stat Sheet",
+    "## Current Status\n\n**Enc:** Medium (2)\n\n## Stat Sheet",
+)
+
+lsheet = gk.Sheet(_LOADED)
+load = gk.check_load(lsheet)
+check("load flags declared vs computed",
+      [f[0] for f in load], ["WARNING"])
+check("load message shows both levels and lbs",
+      "43" in load[0][2] and "Light" in load[0][2] and "Medium" in load[0][2],
+      True)
+
+nl = gk.check_load(gk.Sheet(_LOADED.replace("**Enc:** Medium (2)\n", "")))
+check("load INFO when no declared level",
+      (nl[0][0], "Light" in nl[0][2]), ("INFO", True))
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -59,6 +59,30 @@ check("parry skill 16 CR", gc.parry(16, combat_reflexes=True), 12)
 check("parry skill 15", gc.parry(15), 10)
 check("block skill 15 CR", gc.block(15, combat_reflexes=True), 11)
 
+# --- thrust/swing (B16 closed form; oracle = printed table / GCS) ---
+B16_ORACLE = {
+    1: ("1d-6", "1d-5"), 5: ("1d-4", "1d-3"), 8: ("1d-3", "1d-2"),
+    9: ("1d-2", "1d-1"), 10: ("1d-2", "1d"), 11: ("1d-1", "1d+1"),
+    12: ("1d-1", "1d+2"), 13: ("1d", "2d-1"), 14: ("1d", "2d"),
+    15: ("1d+1", "2d+1"), 17: ("1d+2", "3d-1"), 19: ("2d-1", "3d+1"),
+    20: ("2d-1", "3d+2"), 25: ("2d+2", "5d-1"), 27: ("3d-1", "5d+1"),
+    30: ("3d", "5d+2"),
+}
+for st, (thr_s, sw_s) in B16_ORACLE.items():
+    check(f"thrust ST {st}", gc.fmt_dice(*gc.thrust(st)), thr_s)
+    check(f"swing ST {st}", gc.fmt_dice(*gc.swing(st)), sw_s)
+
+# --- dice helpers / B269 equivalence ---
+check("parse 2d+1", gc.parse_dice("2d+1"), (2, 1))
+check("parse 3d-1", gc.parse_dice("3d-1"), (3, -1))
+check("parse 1d", gc.parse_dice("1d"), (1, 0))
+check("parse unicode minus", gc.parse_dice("3d−1"), (3, -1))
+check("parse garbage", gc.parse_dice("HT-3 aff"), None)
+check("B269: 2d+5 equiv 3d+1",
+      gc.dice_adds(2, 5) == gc.dice_adds(3, 1), True)
+check("B269: 1d+2 not equiv 2d",
+      gc.dice_adds(1, 2) == gc.dice_adds(2, 0), False)
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -345,6 +345,39 @@ check("bare sw resolves as formula-only INFO at ST 11",
       any(f[0] == "INFO" and "Whip" in f[1] and "1d+1" in f[2]
           for f in dmg2), True)
 
+# --- CLI against committed fixtures ---
+def run_check(fixture, *args):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "gurps_check.py"),
+         str(FIXTURES / fixture), *args],
+        capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        FAILURES.append(f"gurps_check {fixture}: rc={result.returncode} "
+                        f"stderr={result.stderr.strip()}")
+        return []
+    return result.stdout.strip().splitlines()
+
+
+clean_out = run_check("clean.md")
+clean_counts = [l for l in clean_out if l.startswith("# count:")]
+check("clean sheet: six sections emitted", len(clean_counts), 6)
+check("clean sheet: no WARNING or ERROR",
+      [l for l in clean_out if l.startswith(("WARNING", "ERROR"))], [])
+
+flawed_out = run_check("flawed.md")
+check("flawed: encumbrance weight warnings fire",
+      sum(1 for l in flawed_out
+          if l.startswith("WARNING\tencumbrance/")) >= 5, True)
+check("flawed: parry warnings fire",
+      sum(1 for l in flawed_out
+          if l.startswith("WARNING\tdefenses/parry/")), 2)
+check("flawed: load computes Light with no declared Enc",
+      any(l.startswith("INFO\tload") and "Light" in l for l in flawed_out),
+      True)
+check("single-section run emits one section",
+      [l for l in run_check("clean.md", "load") if l.startswith("[")],
+      ["[load]"])
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -299,6 +299,28 @@ check("skills category mismatch flagged (12 summed vs 14 declared)",
 check("attributes category matches (120), not flagged",
       any("Attributes" in f[1] and f[0] == "WARNING" for f in pts), False)
 
+_DMG = _KARLISH + """
+## Melee Weapons
+
+| Weapon | Skill | Damage | Reach | Parry |
+|--------|-------|--------|-------|-------|
+| Broadsword | Broadsword 15 | sw+1 cut (2d cut) | 1 | 10 |
+| Knife | Knife 13 | thr-1 imp (1d-2 imp) | C | 9 |
+| Zapper | Beam 14 | HT-3 aff | 8 | No |
+"""
+
+dsheet = gk.Sheet(_DMG)
+dmg = gk.check_damage(dsheet)
+check("damage INFO announces thr/sw for ST 11",
+      ("1d-1" in dmg[0][2] and "1d+1" in dmg[0][2], dmg[0][0]),
+      (True, "INFO"))
+check("sw+1 vs 2d flagged (1d+2 != 2d in adds-space)",
+      any(f[0] == "WARNING" and "Broadsword" in f[1] for f in dmg), True)
+check("thr-1 vs 1d-2 passes (both 2 adds)",
+      any("Knife" in f[1] and f[0] == "WARNING" for f in dmg), False)
+check("affliction line skipped",
+      any("Zapper" in f[1] for f in dmg), False)
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -416,6 +416,20 @@ check("single-section run emits one section",
       [l for l in run_check("clean.md", "load") if l.startswith("[")],
       ["[load]"])
 
+# Blank Location cells count as carried (CodeRabbit PR #74 finding)
+_BLANKLOC = _KARLISH.replace(
+    "## Equipment\n",
+    "## Equipment\n\n"
+    "| Item | Weight | Cost | Location |\n"
+    "|------|--------|------|----------|\n"
+    "| Sword | 3 lb | $600 | Carried |\n"
+    "| Pack | 20 lb | $10 | |\n"
+    "| Mule pack | 90 lb | $30 | Mule |\n",
+)
+blf = gk.check_load(gk.Sheet(_BLANKLOC))
+check("blank Location counts toward load (3+20=23, mule excluded)",
+      (blf[0][0], "23" in blf[0][2]), ("INFO", True))
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -345,6 +345,44 @@ check("bare sw resolves as formula-only INFO at ST 11",
       any(f[0] == "INFO" and "Whip" in f[1] and "1d+1" in f[2]
           for f in dmg2), True)
 
+# Parenthetical label qualifiers: the reference sheet template writes
+# "ST (Strength)", "HP (Hit Points)" etc. — these must resolve to the
+# bare attribute keys.
+_PAREN = """---
+type: pc
+---
+
+# P
+
+## Stat Sheet
+
+### Primary Attributes
+
+| Attribute | Score | Cost |
+|-----------|-------|------|
+| ST (Strength) | 12 | [20] |
+| DX (Dexterity) | 13 | [60] |
+| IQ (Intelligence) | 11 | [20] |
+| HT (Health) | 12 | [20] |
+
+### Secondary Characteristics
+
+| Characteristic | Score |
+|----------------|-------|
+| HP (Hit Points) | 12 |
+| Basic Speed | 6.25 |
+"""
+
+pattrs = gk.read_attributes(gk.Sheet(_PAREN))
+check("parenthetical labels parse", pattrs is not None, True)
+if pattrs is not None:
+    check("paren ST", pattrs["st"], 12)
+    check("paren DX", pattrs["dx"], 13)
+    check("paren IQ", pattrs["iq"], 11)
+    check("paren HT", pattrs["ht"], 12)
+    check("paren HP", pattrs["hp"], 12)
+    check("paren speed", pattrs["speed"], 6.25)
+
 # --- CLI against committed fixtures ---
 def run_check(fixture, *args):
     result = subprocess.run(

--- a/tests/test_gurps_check.py
+++ b/tests/test_gurps_check.py
@@ -219,6 +219,22 @@ nl = gk.check_load(gk.Sheet(_LOADED.replace("**Enc:** Medium (2)\n", "")))
 check("load INFO when no declared level",
       (nl[0][0], "Light" in nl[0][2]), ("INFO", True))
 
+_MELEE = _KARLISH + """
+## Melee Weapons
+
+| Weapon | Skill | Damage | Reach | Parry |
+|--------|-------|--------|-------|-------|
+| Broadsword | Broadsword 15 | 2d cut | 1 | 11 |
+| Punch | DX 13 | 1d-2 cr | C | 8 |
+"""
+
+msheet = gk.Sheet(_MELEE)
+dfd = gk.check_defenses(msheet)
+check("both parry mismatches flagged",
+      [f[0] for f in dfd], ["WARNING", "WARNING"])
+check("broadsword computed 10", "10" in dfd[0][2], True)
+check("punch computed 9", "9" in dfd[1][2], True)
+
 if FAILURES:
     print("\n".join(["", "FAILURES:"] + FAILURES))
     sys.exit(1)


### PR DESCRIPTION
## What

A bundled stdlib-Python utility that arithmetically verifies a GURPS 4e PC markdown sheet and reports advisory deltas — it never modifies the sheet. Two new scripts in `skills/shared/scripts/`:

- **`gurps_calc.py`** — pure formulas, no I/O: Basic Lift (B15), encumbrance thresholds/Move/Dodge (B17), secondary characteristics, Parry/Block (B375–B376), and thrust/swing damage as piecewise closed forms (B16) with B269 dice-equivalence (`2d+5` ≡ `3d+1`).
- **`gurps_check.py`** — sheet parser + six checks + CLI (`gurps_check.py SHEET.md [attributes|encumbrance|load|defenses|points|damage|all]`): secondaries vs attribute bases, encumbrance table vs computed BL, carried+worn load vs the Current Status `Enc:` line, Parry/Block/Dodge, a point-budget audit, and weapon damage formulas resolved and compared in adds-space. Output follows the `vault_check.py` conventions (`# count:` headers, `LEVEL<TAB>locus<TAB>message`, exit 0 with findings / 2 on unreadable input).

Findings are advisory by design — a Talent or weapon bonus legitimately explains a delta, so mismatches are WARNINGs to look at, not errors.

## Wiring

- ttrpg-expert's GURPS chargen reference gains an arithmetic-verification step; the character-sheet reference points at running the checker against the PC's vault-format file (its own display layout is not the parse target).
- CI: `tests/test_gurps_check.py` (formula tests incl. a 16-ST B16 oracle table + subprocess tests over two committed fixtures) added to lint.yml.

## Notes

- Damage closed forms were validated at development time against GCS's own progression implementation (ST 1–40 exact match). GCS is not a dependency — nothing imported, vendored, or copied.
- Copyright posture: formulas are computed, not transcribed; fixtures contain names, numbers, and short cites only.
- Real-world check: run against a live campaign PC, the load check correctly stays silent (65.5 lb at BL 34 = declared Light) and the points audit surfaced a genuine 10-point summary/section mismatch.

Plugin 1.8.10; no publish-tool changes.