### PR TITLE
Publish batch 2: excerpt safety, deep locations index, scifi theme, showcase

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/theme-showcase.yml
+++ b/.github/workflows/theme-showcase.yml
@@ -1,0 +1,47 @@
+name: Theme Showcase
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/publish/**'
+      - 'tests/benchmark-campaign/**'
+      - 'scripts/build-theme-showcase.mjs'
+      - '.github/workflows/theme-showcase.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build showcase
+        run: node scripts/build-theme-showcase.mjs --out showcase
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: showcase
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.13] — 2026-07-07
+
+### Added
+
+- **`scifi` theme preset** (publish tool 1.7.0) — worn space-noir:
+  rust-black background, K-star amber accent, terminal cyan secondary,
+  condensed technical headings, with a light "station work order"
+  variant. Aliases: `sci-fi`, `science-fiction`, `space`,
+  `space-opera`, `space-noir`. Section titles: "Star Charts" /
+  "Powers & Interests" / "Hardware & Equipment" / "Xenofauna".
+- **Theme showcase** — `scripts/build-theme-showcase.mjs` builds the
+  benchmark campaign once per preset; a new Pages workflow publishes
+  the gallery on pushes to main.
+- **NPC table avatars** — the NPC listing's Name column shows portrait
+  thumbnails with an initials fallback; sorting is unaffected.
+
+### Fixed
+
+- **Location card excerpts** no longer render raw markdown and can
+  never surface excluded-section (GM Notes) content — all card
+  excerpts and pull-quotes route through one shared helper that also
+  truncates cleanly at word boundaries with an ellipsis.
+- **Locations index renders the full hierarchy** — deep trees (depth
+  ≥ 2) now appear recursively inside their root cards instead of being
+  silently dropped; children of unpublished parents still float up as
+  roots, and empty region headings are gone.
+- **Relationship graphs exclude index pages** — authored section
+  indexes (e.g. `_World/index.md`) no longer wire every entity into
+  one hub.
+
 ## [1.8.12] — 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Location card excerpts** no longer render raw markdown and can
-  never surface excluded-section (GM Notes) content — all card
-  excerpts and pull-quotes route through one shared helper that also
-  truncates cleanly at word boundaries with an ellipsis.
+  never surface excluded-section (GM Notes) content — location
+  sub-location cards and the location/NPC/PC pull-quotes route
+  through one shared helper that also truncates cleanly at word
+  boundaries with an ellipsis.
 - **Locations index renders the full hierarchy** — deep trees (depth
   ≥ 2) now appear recursively inside their root cards instead of being
   silently dropped; children of unpublished parents still float up as

--- a/scripts/build-theme-showcase.mjs
+++ b/scripts/build-theme-showcase.mjs
@@ -24,6 +24,9 @@ const outArgIdx = process.argv.indexOf('--out');
 const outDir = path.resolve(outArgIdx >= 0 ? process.argv[outArgIdx + 1] : 'showcase');
 const sourceVault = path.join(repoRoot, 'tests/benchmark-campaign');
 
+if (outDir === path.parse(outDir).root) {
+  throw new Error(`Refusing to clean filesystem root: ${outDir}`);
+}
 fs.rmSync(outDir, { recursive: true, force: true });
 fs.mkdirSync(outDir, { recursive: true });
 

--- a/scripts/build-theme-showcase.mjs
+++ b/scripts/build-theme-showcase.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Build the theme showcase: the benchmark campaign rendered once per
+// theme preset, plus a gallery index. Local preview:
+//   node scripts/build-theme-showcase.mjs --out showcase
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { build } = require(path.join(repoRoot, 'tools/publish/lib/build.js'));
+
+const PRESETS = [
+  { id: 'fantasy',  name: 'Fantasy',  blurb: 'D&D, Pathfinder, classic fantasy', swatches: ['#1a1a2e', '#fbbf24', '#c8d6e5'] },
+  { id: 'horror',   name: 'Horror',   blurb: 'CoC, gothic horror, dark mystery', swatches: ['#1a1410', '#c9a55a', '#d4c5a9'] },
+  { id: 'military', name: 'Military', blurb: 'Tactical, modern ops',             swatches: ['#1a1f16', '#4ade80', '#bfc9b8'] },
+  { id: 'noir',     name: 'Noir',     blurb: 'Blades in the Dark, crime, heist', swatches: ['#0d0d0d', '#c084fc', '#b0b0b0'] },
+  { id: 'scifi',    name: 'Sci-fi',   blurb: 'Worn space-noir, hard SF, station crawls', swatches: ['#0d0b0a', '#f0a23a', '#3fd0d8'] },
+];
+
+const outArgIdx = process.argv.indexOf('--out');
+const outDir = path.resolve(outArgIdx >= 0 ? process.argv[outArgIdx + 1] : 'showcase');
+const sourceVault = path.join(repoRoot, 'tests/benchmark-campaign');
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+for (const preset of PRESETS) {
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), `showcase-${preset.id}-`));
+  const vaultDir = path.join(work, 'vault');
+  fs.cpSync(sourceVault, vaultDir, { recursive: true });
+  fs.writeFileSync(path.join(vaultDir, '_meta', 'vault-config.md'),
+    `---\npublish:\n  theme:\n    genre: "${preset.id}"\n---\n\n# Showcase config\n`);
+
+  const configPath = path.join(work, 'vault.config.json');
+  fs.writeFileSync(configPath, JSON.stringify({
+    siteTitle: `The Ashford Case — ${preset.name}`,
+    landingTagline: `gm-apprentice publish theme: ${preset.name}`,
+    siteUrl: 'https://antthelimey.github.io/gm-apprentice',
+    vaultPath: vaultDir,
+    outputDir: path.join(outDir, preset.id),
+    attachmentsDir: '_attachments',
+    folderMap: {
+      _Campaign: 'campaign', _World: 'world',
+      Adventures: 'adventures', Chapters: 'chapters', Clues: 'clues',
+      Factions: 'factions', Heritages: 'heritages',
+      Locations: 'locations', NPCs: 'characters/npcs',
+    },
+    excludeDirs: ['_meta', '_Templates', '_inbox'],
+    excludeSections: ['GM Notes', 'DM Notes', 'Player Notes', 'Source References'],
+  }, null, 2));
+
+  console.log(`\n=== Building ${preset.name} showcase ===`);
+  build({ configPath });
+  fs.rmSync(work, { recursive: true, force: true });
+}
+
+const cards = PRESETS.map(p => `    <a class="theme-card" href="${p.id}/index.html">
+      <div class="swatches">${p.swatches.map(c => `<span style="background:${c}"></span>`).join('')}</div>
+      <h2>${p.name}</h2>
+      <p>${p.blurb}</p>
+    </a>`).join('\n');
+
+fs.writeFileSync(path.join(outDir, 'index.html'), `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>gm-apprentice — Theme Showcase</title>
+<style>
+  body { margin: 0; font-family: system-ui, sans-serif; background: #14161a; color: #dfe4ea; }
+  main { max-width: 60rem; margin: 0 auto; padding: 3rem 1.5rem; }
+  h1 { font-size: 1.6rem; } p.lead { color: #9aa3ad; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: 1rem; margin-top: 2rem; }
+  .theme-card { display: block; padding: 1.25rem; border: 1px solid #2a2f36; border-radius: 0.5rem;
+    background: #1b1e23; color: inherit; text-decoration: none; }
+  .theme-card:hover { border-color: #4a5058; }
+  .theme-card h2 { margin: 0.75rem 0 0.25rem; font-size: 1.1rem; }
+  .theme-card p { margin: 0; color: #9aa3ad; font-size: 0.85rem; }
+  .swatches span { display: inline-block; width: 1.5rem; height: 1.5rem; border-radius: 0.25rem;
+    margin-right: 0.35rem; border: 1px solid #2a2f36; }
+</style>
+</head>
+<body>
+<main>
+  <h1>gm-apprentice — Theme Showcase</h1>
+  <p class="lead">The same benchmark campaign built once per theme preset.
+  Set <code>publish.theme.genre</code> in your vault's <code>_meta/vault-config.md</code>.</p>
+  <div class="grid">
+${cards}
+  </div>
+</main>
+</body>
+</html>
+`);
+
+console.log(`\nShowcase written to ${outDir}`);

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -37,10 +37,12 @@ any equivalent in `vault.config.json`.
 ### Section index titles
 
 Section index pages (Locations, Factions, Items, Creatures) use neutral
-titles by default. The `military` genre preset restyles them ("Theater of
-Operations", "Intelligence Briefing", "Armory & Acquisitions", "Bestiary");
-`fantasy` and `horror` use "Bestiary" for creatures. Override any of them
-in `_meta/vault-config.md`:
+titles by default. Genre presets restyle them: `military` gives "Theater
+of Operations", "Intelligence Briefing", "Armory & Acquisitions",
+"Bestiary"; `scifi` gives "Star Charts", "Powers & Interests",
+"Hardware & Equipment", "Xenofauna"; `fantasy` and `horror` use
+"Bestiary" for creatures. Override any of them in
+`_meta/vault-config.md`:
 
 ```yaml
 publish:
@@ -50,6 +52,16 @@ publish:
 ```
 
 Valid keys: `locations`, `factions`, `items`, `creatures`.
+
+### Theme genre presets
+
+`publish.theme.genre` accepts: `fantasy` (aliases: `adventure`),
+`horror` (`gothic`, `cthulhu`), `noir` (`industrial`, `heist`),
+`military` (`tactical`, `modern`), and `scifi` (`sci-fi`,
+`science-fiction`, `space`, `space-opera`, `space-noir`). A preset
+supplies the palette and fonts; a custom `publish.theme.palette`
+overrides the preset colors. A live gallery of all presets built over
+the same campaign is published from the repo's theme-showcase workflow.
 
 ## `vault.config.json` (in the site repo)
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -1,6 +1,6 @@
 ---
 # Stamped from plugin.json by build-skill-zips.sh — do not edit manually
-current_version: "1.8.12"
+current_version: "1.8.13"
 ---
 
 # Vault Migration Registry

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -3285,3 +3285,13 @@ details.rules-ref > summary::-webkit-details-marker { display: none; }
   .cat-points { --gc-points-bg: #eef1f5; }
   .cat-def    { --gc-def-bg:    #fdecec; }
 }
+
+/* NPC table row avatars */
+.npc-row-link { display: inline-flex; align-items: center; gap: 0.5rem; }
+.npc-row-avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 1.75rem; height: 1.75rem; border-radius: 50%;
+  overflow: hidden; flex-shrink: 0; background: var(--accent-dim);
+}
+.npc-row-avatar img.portrait { width: 100%; height: 100%; object-fit: cover; }
+.npc-row-initials { font-size: 0.65rem; font-weight: 700; color: var(--accent); }

--- a/tools/publish/css/themes/scifi.css
+++ b/tools/publish/css/themes/scifi.css
@@ -1,0 +1,37 @@
+/* Sci-fi / Space preset — worn space-noir
+   For: GURPS Space, Traveller-style hard SF, space-noir, station crawls
+   Rajdhani import is deliberate: the approved look uses it, and no
+   system stack reproduces a condensed technical face cross-platform. */
+@import url('https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;700&display=swap');
+
+:root {
+  --bg: #0d0b0a;
+  --bg-card: #171310;
+  --bg-header: #070605;
+  --bg-hero: #070605;
+  --text: #e6ddd2;
+  --text-muted: #8a8175;
+  --accent: #f0a23a;
+  --accent-dim: rgba(240, 162, 58, 0.12);
+  --border: #2e2620;
+  --danger: #ef4444;
+  --warning: #eab308;
+  --success: #3fd0d8;
+  --font-heading: "Rajdhani", "Avenir Next Condensed", "Arial Narrow", sans-serif;
+  --font-body: system-ui, -apple-system, sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f5efe4;
+    --bg-card: #fffaf0;
+    --bg-header: #14100c;
+    --bg-hero: #14100c;
+    --text: #241c14;
+    --text-muted: #6b5f4e;
+    --accent: #b06d10;
+    --accent-dim: rgba(176, 109, 16, 0.08);
+    --border: #d8cbb4;
+    --success: #0e7c85;
+  }
+}

--- a/tools/publish/lib/excerpt.js
+++ b/tools/publish/lib/excerpt.js
@@ -1,0 +1,40 @@
+// Shared excerpt extraction for listing cards and pull-quotes.
+// Accepts raw markdown OR rendered HTML. Excluded sections are cut
+// BEFORE any other processing so an excerpt can never surface GM-only
+// content, even on sparse entities whose only prose is secret.
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+
+function excerptFromMarkdown(source, opts = {}) {
+  const excludeSections = (opts.excludeSections || []).map(s => String(s).toLowerCase());
+  const limit = opts.limit || 200;
+
+  const kept = [];
+  for (const line of String(source || '').split('\n')) {
+    const h = line.match(HEADING_RE);
+    if (h && excludeSections.includes(h[2].trim().toLowerCase())) break;
+    if (h) continue;                                   // drop heading lines
+    const t = line.trim();
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(t)) continue;    // horizontal rules
+    if (t.startsWith('|')) continue;                   // table rows
+    let cleaned = line.replace(/^\s*>\s?/, '');        // blockquote marker
+    cleaned = cleaned.replace(/^\s*\[!\w+\][-+]?\s*$/, ''); // bare callout tag
+    kept.push(cleaned);
+  }
+
+  let text = kept.join('\n');
+  text = text.replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2');
+  text = text.replace(/\[\[([^\]]+)\]\]/g, (_, t) => t.replace(/_/g, ' '));
+  text = text.replace(/[*_`]+/g, '');
+  text = text.replace(/<[^>]+>/g, ' ');
+  text = text.replace(/\s+/g, ' ').trim();
+
+  const match = text.match(/^(.+?[.!?])\s/);
+  if (match) return match[1];
+  if (text.length <= limit) return text;
+  const cut = text.slice(0, limit);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd() + '…';
+}
+
+module.exports = { excerptFromMarkdown };

--- a/tools/publish/lib/excerpt.js
+++ b/tools/publish/lib/excerpt.js
@@ -10,16 +10,27 @@ const HEADING_RE = /^\s*(#{1,6})\s+(.+?)\s*$/;
 
 // Normalizes a captured heading's text before comparing it against
 // excludeSections, so decorations that don't change the heading's identity
-// (closing-hash, {#anchor}, emphasis markers, trailing colon) can't defeat
-// the exclusion match.
+// (closing-hash, {#anchor}, emphasis markers, trailing colon/dashes) can't defeat
+// the exclusion match. Strips iteratively to handle composed decorations in any order.
 function normalizeHeadingText(text) {
-  return text
-    .replace(/\s*\{#[^}]*\}\s*$/, '')  // heading-id anchor, e.g. {#gm-notes}
-    .replace(/\s*#+\s*$/, '')          // closing-hash decoration, e.g. "## Title ##"
-    .replace(/:\s*$/, '')              // trailing colon
-    .replace(/[*_`]+/g, '')            // emphasis / code markers
-    .trim()
-    .toLowerCase();
+  let normalized = text;
+  let changed = true;
+  let iterations = 0;
+  const maxIterations = 10;
+
+  while (changed && iterations < maxIterations) {
+    const before = normalized;
+    normalized = normalized
+      .replace(/\s*\{#[^}]*\}\s*$/, '')   // heading-id anchor, e.g. {#gm-notes}
+      .replace(/\s*#+\s*$/, '')           // closing-hash decoration, e.g. "## Title ##"
+      .replace(/[:–—-]\s*$/, '')          // trailing colon, en-dash, em-dash, or hyphen
+      .replace(/[*_`]+/g, '')             // emphasis / code markers
+      .trim();
+    changed = before !== normalized;
+    iterations++;
+  }
+
+  return normalized.toLowerCase();
 }
 
 function excerptFromMarkdown(source, opts = {}) {

--- a/tools/publish/lib/excerpt.js
+++ b/tools/publish/lib/excerpt.js
@@ -3,16 +3,33 @@
 // BEFORE any other processing so an excerpt can never surface GM-only
 // content, even on sparse entities whose only prose is secret.
 
-const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+// Leading whitespace is intentionally unbounded (not just CommonMark's 3-space
+// limit) so tab-indented headings from pasted text are still recognized as
+// headings and stripped from the excerpt, never leaked as literal "##" prose.
+const HEADING_RE = /^\s*(#{1,6})\s+(.+?)\s*$/;
+
+// Normalizes a captured heading's text before comparing it against
+// excludeSections, so decorations that don't change the heading's identity
+// (closing-hash, {#anchor}, emphasis markers, trailing colon) can't defeat
+// the exclusion match.
+function normalizeHeadingText(text) {
+  return text
+    .replace(/\s*\{#[^}]*\}\s*$/, '')  // heading-id anchor, e.g. {#gm-notes}
+    .replace(/\s*#+\s*$/, '')          // closing-hash decoration, e.g. "## Title ##"
+    .replace(/:\s*$/, '')              // trailing colon
+    .replace(/[*_`]+/g, '')            // emphasis / code markers
+    .trim()
+    .toLowerCase();
+}
 
 function excerptFromMarkdown(source, opts = {}) {
-  const excludeSections = (opts.excludeSections || []).map(s => String(s).toLowerCase());
+  const excludeSections = (opts.excludeSections || []).map(s => String(s).trim().toLowerCase());
   const limit = opts.limit || 200;
 
   const kept = [];
   for (const line of String(source || '').split('\n')) {
     const h = line.match(HEADING_RE);
-    if (h && excludeSections.includes(h[2].trim().toLowerCase())) break;
+    if (h && excludeSections.includes(normalizeHeadingText(h[2]))) break;
     if (h) continue;                                   // drop heading lines
     const t = line.trim();
     if (/^(-{3,}|\*{3,}|_{3,})$/.test(t)) continue;    // horizontal rules

--- a/tools/publish/lib/relationship-graph.js
+++ b/tools/publish/lib/relationship-graph.js
@@ -10,7 +10,15 @@ const SHAPE_MAP = {
   item: 'diamond',
 };
 
+// Section-index pages (source file index.md -> scanner title 'index')
+// link to everything by design; including them wires the whole vault
+// into one hub, so graphs exclude them as nodes, sources, and targets.
+function isIndexTitle(title) {
+  return String(title).toLowerCase() === 'index';
+}
+
 function buildRelationshipGraph(centerTitle, pages, backlinks) {
+  if (isIndexTitle(centerTitle)) return { nodes: [], edges: [] };
   const pageMap = {};
   for (const p of pages) {
     pageMap[p.title] = p;
@@ -56,11 +64,12 @@ function buildRelationshipGraph(centerTitle, pages, backlinks) {
     }
     const bl = backlinks[title] || [];
     for (const b of bl) {
+      if (isIndexTitle(b.title)) continue;
       if (!rels.some(r => r.target === b.title)) {
         rels.push({ target: b.title, type: 'mentioned_in' });
       }
     }
-    return rels;
+    return rels.filter(r => !isIndexTitle(r.target));
   }
 
   addNode(centerTitle, 0);

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -59,27 +59,33 @@ function buildPillFilters(pages, dir) {
 }
 
 function buildLocationTree(pages) {
-  const byTitle = {};
-  for (const p of pages) byTitle[p.title] = { page: p, children: [] };
-
+  const nodes = pages.map(p => ({ page: p, children: [] }));
+  const lookup = {};
+  for (const n of nodes) lookup[n.page.title] = n;
+  for (const n of nodes) {
+    if (!(n.page.displayTitle in lookup)) lookup[n.page.displayTitle] = n;
+  }
   const roots = [];
-  for (const p of pages) {
-    const parentRef = p.frontmatter.parent_location;
+  for (const n of nodes) {
+    const parentRef = n.page.frontmatter.parent_location;
     if (parentRef) {
       const parentTitle = String(parentRef).replace(/\[\[|\]\]/g, '').trim();
-      if (byTitle[parentTitle]) {
-        byTitle[parentTitle].children.push(byTitle[p.title]);
+      const parentNode = lookup[parentTitle];
+      if (parentNode && parentNode !== n) {
+        parentNode.children.push(n);
         continue;
       }
     }
-    roots.push(byTitle[p.title]);
+    roots.push(n);
   }
   return roots;
 }
 
 function renderLocationTreeHTML(nodes, depth, indexDir) {
   if (nodes.length === 0) return '';
-  const items = nodes.map(node => {
+  const items = nodes.slice()
+    .sort((a, b) => a.page.displayTitle.localeCompare(b.page.displayTitle))
+    .map(node => {
     const p = node.page;
     const childrenHtml = node.children.length > 0
       ? `<div class="location-tree-children">${renderLocationTreeHTML(node.children, depth + 1, indexDir)}</div>`
@@ -93,43 +99,21 @@ function renderLocationTreeHTML(nodes, depth, indexDir) {
 }
 
 function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_attachments') {
+  const roots = buildLocationTree(pages);
+
+  // Group ROOT cards: by the (unpublished) parent name if one was
+  // declared, else by location_type, else "Other" — same region
+  // semantics as before, but only true roots get cards now.
   const byRegion = {};
-  const childOf = new Set();
-
-  for (const p of pages) {
-    const parentRef = p.frontmatter.parent_location;
-    if (parentRef) {
-      const parentTitle = String(parentRef).replace(/\[\[|\]\]/g, '').trim();
-      const parentPage = pages.find(pg => pg.title === parentTitle || pg.displayTitle === parentTitle);
-      if (parentPage) {
-        childOf.add(p.title);
-      }
-    }
-  }
-
-  for (const p of pages) {
-    if (childOf.has(p.title)) continue;
+  for (const node of roots) {
+    const p = node.page;
     const parentRef = p.frontmatter.parent_location;
     const locType = String(p.frontmatter.location_type || '').trim();
     const region = parentRef
       ? String(parentRef).replace(/\[\[|\]\]/g, '').trim()
       : (locType || 'Other');
     if (!byRegion[region]) byRegion[region] = [];
-    byRegion[region].push(p);
-  }
-
-  for (const p of pages) {
-    if (!childOf.has(p.title)) continue;
-    const parentRef = p.frontmatter.parent_location;
-    const parentTitle = String(parentRef).replace(/\[\[|\]\]/g, '').trim();
-    const parentPage = pages.find(pg => pg.title === parentTitle || pg.displayTitle === parentTitle);
-    if (parentPage) {
-      const parentRegionRef = parentPage.frontmatter.parent_location;
-      const parentRegion = parentRegionRef
-        ? String(parentRegionRef).replace(/\[\[|\]\]/g, '').trim()
-        : 'Other';
-      if (!byRegion[parentRegion]) byRegion[parentRegion] = [];
-    }
+    byRegion[region].push(node);
   }
 
   const regionOrder = Object.keys(byRegion).sort((a, b) => {
@@ -138,24 +122,15 @@ function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_
     return byRegion[b].length - byRegion[a].length;
   });
 
-  function getChildren(parentTitle) {
-    return pages.filter(p => {
-      const ref = String(p.frontmatter.parent_location || '').replace(/\[\[|\]\]/g, '').trim();
-      return ref === parentTitle;
-    });
-  }
-
-  function renderLocationCard(p, children) {
+  function renderLocationCard(node) {
+    const p = node.page;
     const fm = p.frontmatter;
     const locType = fm.location_type || '';
     const firstSeen = fm.first_appearance || fm.createdSession || '';
     const firstSeenClean = String(firstSeen).replace(/\[\[|\]\]/g, '').trim();
 
-    const childrenHtml = children.length > 0
-      ? `<div class="loc-children">${children.map(c => {
-          const cType = c.frontmatter.location_type || '';
-          return `<a href="${escapeHtml(relHref(c, indexDir))}" class="loc-child"><span class="loc-child-name">${escapeHtml(c.displayTitle)}</span>${cType ? `<span class="loc-child-type">${escapeHtml(cType)}</span>` : ''}</a>`;
-        }).join('\n')}</div>`
+    const childrenHtml = node.children.length > 0
+      ? `<div class="loc-children">${renderLocationTreeHTML(node.children, 0, indexDir)}</div>`
       : '';
 
     const thumb = portraitImg(fm, indexDir + '/index.html', imageMap, attachmentsDir);
@@ -174,10 +149,9 @@ function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_
   }
 
   const sections = regionOrder.map(region => {
-    const regionPages = byRegion[region];
-    const cards = regionPages
-      .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle))
-      .map(p => renderLocationCard(p, getChildren(p.title)))
+    const cards = byRegion[region]
+      .sort((a, b) => a.page.displayTitle.localeCompare(b.page.displayTitle))
+      .map(node => renderLocationCard(node))
       .join('\n');
 
     return `<section class="loc-region">
@@ -808,4 +782,4 @@ ${bodyContent}`;
   });
 }
 
-module.exports = { indexTemplate, buildPillFilters, buildLocationTree };
+module.exports = { indexTemplate, buildPillFilters, buildLocationTree, renderLocationsPage };

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -3,6 +3,7 @@ const mdRenderer = new MarkdownIt({ html: false, typographer: true });
 const { escapeHtml, relativePath, resolveWikiLinks } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg, getCanonStatus } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
+const { getInitials } = require('./landing-data');
 
 const GENRE_SECTION_TITLES = {
   military: {
@@ -566,7 +567,7 @@ function sessionSortKey(str) {
   return m ? Number(m[1]) : 0;
 }
 
-function renderNPCTable(pages, dir) {
+function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachments') {
   const sorted = pages
     .filter(p => p.frontmatter.type === 'npc')
     .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle));
@@ -606,9 +607,13 @@ function renderNPCTable(pages, dir) {
     const firstApp = cleanRef(fm.first_appearance || '');
     const lastSession = cleanRef(fm.asOfSession || fm.lastUpdated || '');
     const canonStatus = getCanonStatus(fm) || '';
+    const avatar = portraitImg(fm, dir + '/index.html', imageMap, attachmentsDir);
+    const avatarHtml = avatar
+      ? `<span class="npc-row-avatar">${avatar}</span>`
+      : `<span class="npc-row-avatar npc-row-initials" aria-hidden="true">${escapeHtml(getInitials(p.displayTitle))}</span>`;
 
     return `<tr data-entity-type="npc" data-entity-name="${escapeHtml(p.displayTitle)}" data-entity-status="${escapeHtml(status)}" data-session="${escapeHtml(lastSession)}">
-  <td><a href="${escapeHtml(relHref(p, dir))}">${escapeHtml(p.displayTitle)}</a></td>
+  <td data-sort="${escapeHtml(p.displayTitle.toLowerCase())}"><a class="npc-row-link" href="${escapeHtml(relHref(p, dir))}">${avatarHtml}${escapeHtml(p.displayTitle)}</a></td>
   <td>${escapeHtml(occupation)}</td>
   <td><span class="status-badge status-${escapeHtml(status.replace(/\s+/g, '-').toLowerCase())}">${escapeHtml(status ? status.charAt(0).toUpperCase() + status.slice(1) : '')}</span></td>
   <td>${escapeHtml(firstApp)}</td>
@@ -671,7 +676,7 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
 
   let bodyContent;
   if (isNPCs) {
-    bodyContent = renderNPCTable(pages, dir);
+    bodyContent = renderNPCTable(pages, dir, imageMap, attachmentsDir);
   } else if (isChapters) {
     bodyContent = renderChapterList(pages, dir);
   } else if (isCreatures) {

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -14,6 +14,12 @@ const GENRE_SECTION_TITLES = {
   },
   fantasy: { creatures: 'Bestiary' },
   horror: { creatures: 'Bestiary' },
+  scifi: {
+    locations: 'Star Charts',
+    factions: 'Powers & Interests',
+    items: 'Hardware & Equipment',
+    creatures: 'Xenofauna',
+  },
 };
 
 const DEFAULT_SECTION_TITLES = {

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -172,6 +172,15 @@ const EXPLORE_DESCRIPTIONS = {
     creatures: 'Unknown threats and anomalies.',
     events: 'Operations, engagements, and incidents.',
   },
+  scifi: {
+    characters: 'Crews, fixers, and the corporate machines they answer to.',
+    locations: 'Stations, systems, and the lanes between them.',
+    story: 'The job, the truth, and the fallout, session by session.',
+    factions: 'Corporations, syndicates, and powers in the dark.',
+    items: 'Hardware, ships, and tech best kept off the manifest.',
+    creatures: 'What the void holds — known and otherwise.',
+    events: 'Contacts, incidents, and points of no return.',
+  },
 };
 
 const DEFAULT_DESCRIPTIONS = {

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -3,12 +3,7 @@ const { baseShell, cssPath, rootPath, canonStatusBadge, portraitImg, clientScrip
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { getInitials } = require('./landing-data');
-
-function extractFirstSentence(html) {
-  const stripped = (html || '').replace(/<[^>]+>/g, '').trim();
-  const match = stripped.match(/^(.+?[.!?])\s/);
-  return match ? match[1] : stripped.slice(0, 200);
-}
+const { excerptFromMarkdown } = require('../excerpt');
 
 function matchesRef(refValue, title) {
   if (!refValue) return false;
@@ -62,7 +57,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
 
   // --- Zone 2: Atmosphere pull-quote ---
   const pullQuote = processedContent.html
-    ? `<div class="pull-quote">${escapeHtml(extractFirstSentence(processedContent.html))}</div>`
+    ? `<div class="pull-quote">${escapeHtml(excerptFromMarkdown(processedContent.html))}</div>`
     : '';
 
   // --- Zone 3: Body content ---
@@ -76,7 +71,9 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   if (childLocations.length > 0) {
     const cards = childLocations.map(child => {
       const href = relativeHref(page.outputPath, child.outputPath);
-      const excerpt = extractFirstSentence(child.markdown || '').replace(/<[^>]+>/g, '');
+      const excerpt = excerptFromMarkdown(
+        child.publishedMarkdown != null ? child.publishedMarkdown : (child.markdown || ''),
+        { excludeSections: (publishConfig && publishConfig.exclude_sections) || [] });
       return `<a class="entity-card" href="${href}">
   <h4>${escapeHtml(child.displayTitle)}</h4>
   ${excerpt ? `<div class="card-excerpt">${escapeHtml(excerpt)}</div>` : ''}

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -57,7 +57,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
 
   // --- Zone 2: Atmosphere pull-quote ---
   const pullQuote = processedContent.html
-    ? `<div class="pull-quote">${escapeHtml(excerptFromMarkdown(processedContent.html))}</div>`
+    ? `<div class="pull-quote">${excerptFromMarkdown(processedContent.html)}</div>`
     : '';
 
   // --- Zone 3: Body content ---

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -3,12 +3,7 @@ const { baseShell, cssPath, rootPath, canonStatusBadge, portraitImg, clientScrip
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { getInitials } = require('./landing-data');
-
-function extractFirstSentence(html) {
-  const stripped = (html || '').replace(/<[^>]+>/g, '').trim();
-  const match = stripped.match(/^(.+?[.!?])\s/);
-  return match ? match[1] : stripped.slice(0, 200);
-}
+const { excerptFromMarkdown } = require('../excerpt');
 
 function npcTemplate(page, processedContent, navFor, config, imageMap, context) {
   const { pages, linkMap, publishConfig } = context || {};
@@ -51,7 +46,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
 
   // --- Zone 2: First impression quote ---
   const pullQuote = processedContent.html
-    ? `<div class="pull-quote">${extractFirstSentence(processedContent.html)}</div>`
+    ? `<div class="pull-quote">${excerptFromMarkdown(processedContent.html)}</div>`
     : '';
 
   // --- Zone 3: Body content ---

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -2,6 +2,7 @@ const { escapeHtml, relativePath, relativeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
+const { excerptFromMarkdown } = require('../excerpt');
 
 const DEFAULT_META_FIELDS = ['occupation', 'age', 'nationality'];
 
@@ -17,12 +18,6 @@ function renderMetaSpans(fm) {
     .filter(field => fm[field] != null && fm[field] !== '')
     .map(field => `<span><span class="label">${escapeHtml(formatLabel(field))}</span> ${escapeHtml(String(fm[field]))}</span>`)
     .join('\n    ');
-}
-
-function extractFirstSentence(html) {
-  const stripped = (html || '').replace(/<[^>]+>/g, '').trim();
-  const match = stripped.match(/^(.+?[.!?])\s/);
-  return match ? match[1] : stripped.slice(0, 200);
 }
 
 const EQUIPMENT_SECTION_TITLES = new Set(['equipment', 'gear', 'inventory', 'weapons', 'armour', 'armor', 'items', 'possessions', 'melee weapons', 'ranged weapons', 'encumbrance']);
@@ -177,7 +172,7 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
     const traitsText = Array.isArray(fm.key_traits) ? fm.key_traits.join(', ') : String(fm.key_traits);
     epithet = `<div class="pull-quote">${escapeHtml(traitsText)}</div>`;
   } else if (processedContent.html) {
-    epithet = `<div class="pull-quote">${extractFirstSentence(processedContent.html)}</div>`;
+    epithet = `<div class="pull-quote">${excerptFromMarkdown(processedContent.html)}</div>`;
   }
 
   // Read system HTML before filtering so the filter can react to what was actually rendered.

--- a/tools/publish/lib/theme.js
+++ b/tools/publish/lib/theme.js
@@ -82,11 +82,12 @@ function generateThemeCSS(config) {
   const fonts = config.fonts || {};
 
   // When a genre preset is active and no custom palette was provided,
-  // emit only font overrides — the preset CSS handles colors.
+  // preset CSS owns colors AND fonts; only explicitly-chosen (non-generic)
+  // fonts override the preset.
   if (!palette && config.genre && resolveGenrePreset(config.genre)) {
     const fontVars = [];
-    if (fonts.heading) fontVars.push(`  --font-heading: ${cssFontValue(fonts.heading, 'serif')};`);
-    if (fonts.body) fontVars.push(`  --font-body: ${cssFontValue(fonts.body, 'sans-serif')};`);
+    if (fonts.heading && !GENERIC_FAMILIES.has(fonts.heading)) fontVars.push(`  --font-heading: ${cssFontValue(fonts.heading, 'serif')};`);
+    if (fonts.body && !GENERIC_FAMILIES.has(fonts.body)) fontVars.push(`  --font-body: ${cssFontValue(fonts.body, 'sans-serif')};`);
     if (fontVars.length === 0) return '/* Genre preset active — no overrides */\n';
     const fontsImport = googleFontsImport(fonts);
     return `${fontsImport}:root {\n${fontVars.join('\n')}\n}\n`;

--- a/tools/publish/lib/theme.js
+++ b/tools/publish/lib/theme.js
@@ -10,9 +10,15 @@ const GENRE_ALIASES = {
   military: 'military',
   tactical: 'military',
   modern: 'military',
+  scifi: 'scifi',
+  'sci-fi': 'scifi',
+  'science-fiction': 'scifi',
+  space: 'scifi',
+  'space-opera': 'scifi',
+  'space-noir': 'scifi',
 };
 
-const VALID_PRESETS = new Set(['horror', 'fantasy', 'noir', 'military']);
+const VALID_PRESETS = new Set(['horror', 'fantasy', 'noir', 'military', 'scifi']);
 
 const GENERIC_FAMILIES = new Set([
   'system-ui', 'sans-serif', 'serif', 'monospace', 'cursive', 'fantasy',

--- a/tools/publish/package-lock.json
+++ b/tools/publish/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gm-apprentice-publish",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3",

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -715,10 +715,13 @@ describe('build integration', () => {
     });
 
     it('generates theme.css', () => {
+      // This fixture's vault-config sets theme.genre: horror with no explicit
+      // fonts, so the preset CSS owns colors and fonts — theme.css should
+      // carry no overrides rather than clobbering the preset with defaults.
       const themePath = path.join(outputDir, 'docs', 'css', 'theme.css');
       assert.ok(fs.existsSync(themePath));
       const css = fs.readFileSync(themePath, 'utf-8');
-      assert.ok(css.includes(':root'));
+      assert.strictEqual(css, '/* Genre preset active — no overrides */\n');
     });
   });
 

--- a/tools/publish/test/integration/theme-showcase.test.js
+++ b/tools/publish/test/integration/theme-showcase.test.js
@@ -1,0 +1,35 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+describe('theme showcase build', () => {
+  const repoRoot = path.join(__dirname, '..', '..', '..', '..');
+  const script = path.join(repoRoot, 'scripts', 'build-theme-showcase.mjs');
+  let outDir;
+
+  before(() => {
+    outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-showcase-'));
+    execFileSync('node', [script, '--out', outDir], { stdio: 'pipe' });
+  });
+
+  after(() => { fs.rmSync(outDir, { recursive: true, force: true }); });
+
+  it('builds one site per preset plus the gallery index', () => {
+    for (const preset of ['fantasy', 'horror', 'military', 'noir', 'scifi']) {
+      assert.ok(fs.existsSync(path.join(outDir, preset, 'index.html')), preset);
+      assert.ok(fs.existsSync(path.join(outDir, preset, 'css', 'themes', `${preset}.css`)),
+        `${preset} theme css copied`);
+    }
+    assert.ok(fs.existsSync(path.join(outDir, 'index.html')), 'gallery index');
+  });
+
+  it('gallery index links every preset', () => {
+    const html = fs.readFileSync(path.join(outDir, 'index.html'), 'utf-8');
+    for (const preset of ['fantasy', 'horror', 'military', 'noir', 'scifi']) {
+      assert.ok(html.includes(`href="${preset}/index.html"`), preset);
+    }
+  });
+});

--- a/tools/publish/test/unit/excerpt.test.js
+++ b/tools/publish/test/unit/excerpt.test.js
@@ -1,0 +1,60 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { excerptFromMarkdown } = require('../../lib/excerpt');
+
+describe('excerptFromMarkdown', () => {
+  it('returns the first prose sentence, skipping heading lines', () => {
+    const md = '## Overview\n\nA rusted mining station orbits the dim star. It hums.\n';
+    assert.strictEqual(
+      excerptFromMarkdown(md),
+      'A rusted mining station orbits the dim star.');
+  });
+
+  it('never reads past an excluded section heading', () => {
+    const md = '## GM Notes\n\nThe director is secretly a construct built by the syndicate to watch the gate.\n';
+    assert.strictEqual(
+      excerptFromMarkdown(md, { excludeSections: ['GM Notes'] }), '');
+  });
+
+  it('excluded-section match is case-insensitive and mid-document', () => {
+    const md = 'Intro line without punctuation\n\n## gm notes\n\nSecret secret secret.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('Secret'), 'must not leak excluded content');
+    assert.ok(out.startsWith('Intro line'), 'keeps pre-exclusion prose');
+  });
+
+  it('drops callout markers but keeps quoted prose', () => {
+    const md = '> [!info]\n> The docks never sleep. Cargo moves at all hours.\n';
+    assert.strictEqual(
+      excerptFromMarkdown(md), 'The docks never sleep.');
+  });
+
+  it('resolves wiki-links to their labels', () => {
+    const md = 'The crew reports to [[MacMillian_Corp|the Company]] every cycle without fail always.\n';
+    const out = excerptFromMarkdown(md);
+    assert.ok(out.includes('the Company'));
+    assert.ok(!out.includes('[['));
+  });
+
+  it('fallback truncates at a word boundary with an ellipsis', () => {
+    const words = 'word '.repeat(60).trim();           // 299 chars, no sentence end
+    const out = excerptFromMarkdown(words, { limit: 50 });
+    assert.ok(out.length <= 51, `got length ${out.length}`);
+    assert.ok(out.endsWith('…'));
+    assert.ok(!out.endsWith(' …'), 'no dangling space before ellipsis');
+  });
+
+  it('short text without sentence end returns as-is, no ellipsis', () => {
+    assert.strictEqual(excerptFromMarkdown('Just a fragment'), 'Just a fragment');
+  });
+
+  it('accepts rendered HTML input (tags stripped, sentence found)', () => {
+    const html = '<p>The station <strong>groans</strong> under load. More text.</p>';
+    assert.strictEqual(excerptFromMarkdown(html), 'The station groans under load.');
+  });
+
+  it('skips table rows and horizontal rules', () => {
+    const md = '| a | b |\n|---|---|\n\n---\n\nReal prose starts here. And continues.\n';
+    assert.strictEqual(excerptFromMarkdown(md), 'Real prose starts here.');
+  });
+});

--- a/tools/publish/test/unit/excerpt.test.js
+++ b/tools/publish/test/unit/excerpt.test.js
@@ -57,4 +57,46 @@ describe('excerptFromMarkdown', () => {
     const md = '| a | b |\n|---|---|\n\n---\n\nReal prose starts here. And continues.\n';
     assert.strictEqual(excerptFromMarkdown(md), 'Real prose starts here.');
   });
+
+  it('matches an excluded heading with closing-hash decoration', () => {
+    const md = '## GM Notes ##\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+    assert.ok(!out.includes('##'), 'must not leak the literal heading markup');
+  });
+
+  it('matches an excluded heading with a heading-id anchor', () => {
+    const md = '## GM Notes {#gm-notes}\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+  });
+
+  it('matches an excluded heading with a trailing colon', () => {
+    const md = '## GM Notes:\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+  });
+
+  it('matches an excluded heading with emphasized heading text', () => {
+    const md = '## **GM Notes**\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+  });
+
+  it('recognizes indented and tab-indented headings as headings', () => {
+    const spaceIndented = '  ## GM Notes\n\nThe director is secretly a construct built by the syndicate.\n';
+    const tabIndented = '\t## GM Notes\n\nThe director is secretly a construct built by the syndicate.\n';
+    const outSpace = excerptFromMarkdown(spaceIndented, { excludeSections: ['GM Notes'] });
+    const outTab = excerptFromMarkdown(tabIndented, { excludeSections: ['GM Notes'] });
+    assert.ok(!outSpace.includes('construct'), 'must not leak excluded content (space-indented)');
+    assert.ok(!outSpace.includes('#'), 'must not leak the literal heading markup (space-indented)');
+    assert.ok(!outTab.includes('construct'), 'must not leak excluded content (tab-indented)');
+    assert.ok(!outTab.includes('#'), 'must not leak the literal heading markup (tab-indented)');
+  });
+
+  it('trims excludeSections entries before matching', () => {
+    const md = '## GM Notes\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: [' GM Notes '] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+  });
 });

--- a/tools/publish/test/unit/excerpt.test.js
+++ b/tools/publish/test/unit/excerpt.test.js
@@ -99,4 +99,16 @@ describe('excerptFromMarkdown', () => {
     const out = excerptFromMarkdown(md, { excludeSections: [' GM Notes '] });
     assert.ok(!out.includes('construct'), 'must not leak excluded content');
   });
+
+  it('matches an excluded heading with composed anchor and closing-hash decorations', () => {
+    const md = '## GM Notes {#gm-notes} ##\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+  });
+
+  it('matches an excluded heading with an em-dash suffix', () => {
+    const md = '## GM Notes —\n\nThe director is secretly a construct built by the syndicate.\n';
+    const out = excerptFromMarkdown(md, { excludeSections: ['GM Notes'] });
+    assert.ok(!out.includes('construct'), 'must not leak excluded content');
+  });
 });

--- a/tools/publish/test/unit/index-filters.test.js
+++ b/tools/publish/test/unit/index-filters.test.js
@@ -114,6 +114,21 @@ describe('indexTemplate — section titles', () => {
     assert.ok(html.includes('Star Charts'));
     assert.ok(!html.includes('Theater of Operations'));
   });
+
+  it('scifi genre preset drives section titles', () => {
+    const scifiConfig = { theme: {}, _genrePreset: 'scifi' };
+    const locHtml = indexTemplate('locations', 'Locations', [locPage], navFor, config, scifiConfig);
+    assert.ok(locHtml.includes('Star Charts'));
+
+    const factionsHtml = indexTemplate('factions', 'Factions & Organizations', [], navFor, config, scifiConfig);
+    assert.ok(factionsHtml.includes('Powers &amp; Interests'));
+
+    const itemsHtml = indexTemplate('items', 'Items & Artifacts', [], navFor, config, scifiConfig);
+    assert.ok(itemsHtml.includes('Hardware &amp; Equipment'));
+
+    const creaturesHtml = indexTemplate('creatures', 'Creatures', [], navFor, config, scifiConfig);
+    assert.ok(creaturesHtml.includes('Xenofauna'));
+  });
 });
 
 describe('indexTemplate — canon_status field on index pages', () => {

--- a/tools/publish/test/unit/index-filters.test.js
+++ b/tools/publish/test/unit/index-filters.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { indexTemplate, buildPillFilters, buildLocationTree } = require('../../lib/templates/index-page');
+const { indexTemplate, buildPillFilters, buildLocationTree, renderLocationsPage } = require('../../lib/templates/index-page');
 
 describe('buildPillFilters', () => {
   it('returns pills for unique sub-types', () => {
@@ -264,5 +264,71 @@ describe('indexTemplate — grouping fallbacks', () => {
     const html = indexTemplate('factions', 'Factions & Organizations', [page], navFor, config, publishConfig);
     assert.ok(html.includes('Military Units'));
     assert.ok(!html.includes('intel-section-title">Corporations'));
+  });
+});
+
+describe('renderLocationsPage deep hierarchies', () => {
+  function loc(title, parent, type) {
+    return {
+      title, displayTitle: title.replace(/_/g, ' '),
+      outputPath: `locations/${title.toLowerCase().replace(/_/g, '-')}.html`,
+      frontmatter: { type: 'location',
+        ...(parent ? { parent_location: `[[${parent}]]` } : {}),
+        ...(type ? { location_type: type } : {}) },
+      markdown: '',
+    };
+  }
+  const deep = [
+    loc('Republic', null, 'polity'),
+    loc('Sector_7G', 'Republic', 'sector'),
+    loc('Thides_System', 'Sector_7G', 'system'),
+    loc('Station_IV', 'Thides_System', 'station'),
+    loc('Entertainment_District', 'Station_IV', 'district'),
+    loc('Nova_Nexus', 'Entertainment_District', 'venue'),
+  ];
+
+  it('every published location appears exactly once at any depth', () => {
+    const html = renderLocationsPage(deep, 'locations');
+    for (const p of deep) {
+      const hits = html.split(`>${p.displayTitle}</a>`).length - 1;
+      assert.strictEqual(hits, 1, `${p.displayTitle} should appear exactly once`);
+    }
+  });
+
+  it('depth >= 2 renders nested inside the root card', () => {
+    const html = renderLocationsPage(deep, 'locations');
+    assert.ok(html.includes('location-tree-children'), 'recursive nesting present');
+    assert.ok(html.indexOf('Nova Nexus') > html.indexOf('Republic'));
+  });
+
+  it('children of an unpublished parent float up as roots', () => {
+    const orphans = [
+      loc('Thides_System', 'Secret_Sector', 'system'),
+      loc('Station_IV', 'Thides_System', 'station'),
+    ];
+    const html = renderLocationsPage(orphans, 'locations');
+    assert.strictEqual(html.split('loc-card').length - 1 >= 1, true);
+    assert.ok(html.includes('Thides System'));
+    assert.ok(html.includes('Station IV'));
+  });
+
+  it('no empty region sections are emitted', () => {
+    const html = renderLocationsPage(deep, 'locations');
+    assert.ok(!/loc-region-grid"><\/div>/.test(html), 'no empty region grids');
+  });
+
+  it('parent_location matching works via displayTitle too', () => {
+    const pages = [
+      { title: 'Eris_System', displayTitle: 'Eris System',
+        outputPath: 'locations/eris-system.html',
+        frontmatter: { type: 'location' }, markdown: '' },
+      { title: 'Eris_IV', displayTitle: 'Eris IV',
+        outputPath: 'locations/eris-iv.html',
+        frontmatter: { type: 'location', parent_location: '[[Eris System]]' },
+        markdown: '' },
+    ];
+    const tree = buildLocationTree(pages);
+    assert.strictEqual(tree.length, 1);
+    assert.strictEqual(tree[0].children.length, 1);
   });
 });

--- a/tools/publish/test/unit/index-filters.test.js
+++ b/tools/publish/test/unit/index-filters.test.js
@@ -332,3 +332,36 @@ describe('renderLocationsPage deep hierarchies', () => {
     assert.strictEqual(tree[0].children.length, 1);
   });
 });
+
+describe('NPC table avatars', () => {
+  const navFor = () => '<nav></nav>';
+  const config = { siteTitle: 'Test' };
+  const publishConfig = { theme: {} };
+
+  const npc = (title, portrait) => ({
+    title, displayTitle: title.replace(/_/g, ' '),
+    outputPath: `characters/npcs/${title.toLowerCase()}.html`,
+    frontmatter: { type: 'npc', ...(portrait ? { portrait } : {}) },
+    markdown: '',
+  });
+  const imageMap = { 'kessler.png': { relPath: 'kessler.png' } };
+
+  it('renders a portrait thumbnail in the Name cell when available', () => {
+    const html = indexTemplate('characters/npcs', 'NPCs',
+      [npc('Kessler', '_attachments/kessler.png')], navFor, config, publishConfig, imageMap);
+    assert.ok(/npc-row-avatar[^]*?images\/kessler\.png/.test(html));
+  });
+
+  it('falls back to initials when no portrait', () => {
+    const html = indexTemplate('characters/npcs', 'NPCs',
+      [npc('Karl_Brenner')], navFor, config, publishConfig, imageMap);
+    assert.ok(html.includes('npc-row-initials'));
+    assert.ok(html.includes('>KB<'));
+  });
+
+  it('name cell carries a data-sort key so avatars do not break sorting', () => {
+    const html = indexTemplate('characters/npcs', 'NPCs',
+      [npc('Karl_Brenner')], navFor, config, publishConfig, imageMap);
+    assert.ok(html.includes('data-sort="karl brenner"'));
+  });
+});

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -453,4 +453,10 @@ describe('getExploreDescriptions', () => {
     const result = getExploreDescriptions(null, {});
     assert.ok(result.characters);
   });
+
+  it('scifi genre supplies explore descriptions', () => {
+    const d = getExploreDescriptions('scifi', {});
+    assert.ok(d.locations.includes('Stations'));
+    assert.ok(d.factions.includes('Corporations'));
+  });
 });

--- a/tools/publish/test/unit/relationship-graph.test.js
+++ b/tools/publish/test/unit/relationship-graph.test.js
@@ -45,3 +45,44 @@ describe('buildRelationshipGraph', () => {
     assert.strictEqual(tower.shape, 'rounded-square');
   });
 });
+
+describe('index-page exclusion', () => {
+  const pages = [
+    { title: 'Hero', displayTitle: 'Hero', outputPath: 'pcs/hero.html',
+      frontmatter: { type: 'pc', relationships: [{ target: '[[Villain]]', type: 'nemesis' }] } },
+    { title: 'Villain', displayTitle: 'Villain', outputPath: 'npcs/villain.html',
+      frontmatter: { type: 'npc' } },
+    { title: 'index', displayTitle: 'World Index', outputPath: 'world/index.html',
+      frontmatter: { type: 'wiki' } },
+  ];
+  // the index page mentions everyone -> backlink entries from 'index'
+  const backlinks = {
+    Hero: [{ title: 'index', displayTitle: 'World Index', outputPath: 'world/index.html', type: 'wiki' }],
+    Villain: [{ title: 'index', displayTitle: 'World Index', outputPath: 'world/index.html', type: 'wiki' }],
+  };
+
+  it('backlinks from an index page create no edges or nodes', () => {
+    const graph = buildRelationshipGraph('Hero', pages, backlinks);
+    assert.ok(!graph.nodes.some(n => n.id === 'index'));
+    assert.ok(!graph.edges.some(e => e.from === 'index' || e.to === 'index'));
+  });
+
+  it('frontmatter relationships targeting an index page are dropped', () => {
+    const withRel = pages.map(p => p.title === 'Hero'
+      ? { ...p, frontmatter: { ...p.frontmatter,
+          relationships: [{ target: '[[Villain]]', type: 'nemesis' }, { target: '[[index]]', type: 'listed_in' }] } }
+      : p);
+    const graph = buildRelationshipGraph('Hero', withRel, {});
+    assert.ok(!graph.nodes.some(n => n.id === 'index'));
+  });
+
+  it('an index page as center yields an empty graph', () => {
+    const graph = buildRelationshipGraph('index', pages, backlinks);
+    assert.deepStrictEqual(graph, { nodes: [], edges: [] });
+  });
+
+  it('normal entity edges are unaffected', () => {
+    const graph = buildRelationshipGraph('Hero', pages, backlinks);
+    assert.ok(graph.edges.some(e => e.from === 'Hero' && e.to === 'Villain'));
+  });
+});

--- a/tools/publish/test/unit/templates.test.js
+++ b/tools/publish/test/unit/templates.test.js
@@ -530,3 +530,42 @@ describe('DIR_LABELS section coverage', () => {
     assert.strictEqual(DIR_LABELS['world'], 'World');
   });
 });
+
+describe('location sub-location card excerpts (shared helper)', () => {
+  const { locationTemplate } = require('../../lib/templates/location');
+  const mockNavFor = () => '';
+  const mockConfig = { siteTitle: 'Test', attachmentsDir: '_attachments' };
+
+  const parent = {
+    title: 'Sector_7G', displayTitle: 'Sector 7-G',
+    outputPath: 'locations/sector-7g.html',
+    frontmatter: { type: 'location' }, markdown: '',
+  };
+  const sparseChild = {
+    title: 'Nova_Nexus', displayTitle: 'Nova Nexus',
+    outputPath: 'locations/nova-nexus.html',
+    frontmatter: { type: 'location', parent_location: '[[Sector_7G]]' },
+    markdown: '## Overview\n\n## GM Notes\n\nThe owner launders syndicate money through the bar.\n',
+  };
+  const proseChild = {
+    title: 'Docking_Ring', displayTitle: 'Docking Ring',
+    outputPath: 'locations/docking-ring.html',
+    frontmatter: { type: 'location', parent_location: '[[Sector_7G]]' },
+    markdown: '## Overview\n\nCargo moves at all hours here. Nobody asks questions.\n',
+  };
+  const ctx = { pages: [parent, sparseChild, proseChild], linkMap: {},
+    publishConfig: { exclude_sections: ['GM Notes'], _backlinks: {} } };
+
+  it('renders a clean prose excerpt without markdown markers', () => {
+    const html = locationTemplate(parent, { html: '<p>x</p>', relationships: '' },
+      mockNavFor, mockConfig, {}, ctx);
+    assert.ok(html.includes('Cargo moves at all hours here.'));
+    assert.ok(!html.includes('## Overview'), 'no raw heading in excerpt');
+  });
+
+  it('sparse child with only GM-Notes prose leaks nothing', () => {
+    const html = locationTemplate(parent, { html: '<p>x</p>', relationships: '' },
+      mockNavFor, mockConfig, {}, ctx);
+    assert.ok(!html.includes('launders'), 'GM-only content must not surface');
+  });
+});

--- a/tools/publish/test/unit/theme.test.js
+++ b/tools/publish/test/unit/theme.test.js
@@ -73,4 +73,25 @@ describe('generateThemeCSS', () => {
     const css = generateThemeCSS({ genre: 'horror' });
     assert.ok(!css.includes('#1a1410'));
   });
+
+  it('does not let default generic fonts clobber a genre preset', () => {
+    const css = generateThemeCSS({
+      fonts: { heading: 'system-ui', body: 'system-ui' },
+      genre: 'scifi',
+      palette: null,
+    });
+    assert.strictEqual(css, '/* Genre preset active — no overrides */\n');
+  });
+
+  it('lets an explicit non-generic font override a genre preset, per-property', () => {
+    const css = generateThemeCSS({
+      fonts: { heading: 'Cinzel', body: 'system-ui' },
+      genre: 'fantasy',
+      palette: null,
+    });
+    assert.ok(css.includes("--font-heading: 'Cinzel', serif"));
+    assert.ok(css.includes('fonts.googleapis.com'));
+    assert.ok(css.includes('Cinzel'));
+    assert.ok(!css.includes('--font-body'));
+  });
 });

--- a/tools/publish/test/unit/theme.test.js
+++ b/tools/publish/test/unit/theme.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { generateThemeCSS, resolveGenrePreset, GENRE_ALIASES } = require('../../lib/theme');
+const { generateThemeCSS, resolveGenrePreset, GENRE_ALIASES, VALID_PRESETS } = require('../../lib/theme');
 
 describe('resolveGenrePreset', () => {
   it('returns preset filename for exact genre match', () => {
@@ -24,6 +24,21 @@ describe('resolveGenrePreset', () => {
     assert.strictEqual(resolveGenrePreset('steampunk'), null);
     assert.strictEqual(resolveGenrePreset(null), null);
     assert.strictEqual(resolveGenrePreset(undefined), null);
+  });
+
+  it('resolves scifi aliases', () => {
+    for (const alias of ['scifi', 'sci-fi', 'science-fiction', 'space', 'space-opera', 'space-noir']) {
+      assert.strictEqual(resolveGenrePreset(alias), 'scifi', alias);
+    }
+  });
+
+  it('scifi is a valid preset with a css file', () => {
+    const fs = require('fs');
+    const path = require('path');
+    assert.ok(VALID_PRESETS.has('scifi'));
+    const css = fs.readFileSync(path.join(__dirname, '../../css/themes/scifi.css'), 'utf-8');
+    assert.ok(css.includes('--accent: #f0a23a'), 'K-star amber accent');
+    assert.ok(css.includes('prefers-color-scheme: light'), 'light variant present');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the two hand-off defects from the space-game vault pass, adds three requested improvements, ships a `scifi` theme preset, and stands up a GitHub Pages theme showcase. Publish tool 1.7.0, plugin 1.8.13.

- **Card excerpts are spoiler-safe and clean** — location sub-location cards and the location/NPC/PC pull-quotes route through one shared helper (`lib/excerpt.js`) that cuts the source at any excluded-section heading before all other processing (hardened against decorated/indented headings), strips markdown markers, and truncates at word boundaries with an ellipsis. The old raw-markdown excerpt path could walk into `## GM Notes` on sparse entities.
- **Locations index renders the full hierarchy** — root cards (with portraits) now contain the complete recursive descendant tree; depth ≥ 2 locations were previously dropped entirely (57 of 67 in the reporting vault). Children of unpublished parents still float up as roots; empty region headings are gone. Type badges render at every level.
- **NPC table avatars** — portrait thumbnails with initials fallback in the Name column; sorting is unaffected (`data-sort` carries the name).
- **Relationship graphs exclude index pages** — authored section indexes (e.g. `_World/index.md`) no longer wire every entity into one hub via backlinks.
- **`scifi` theme preset** — worn space-noir: rust-black background, K-star amber accent, terminal cyan secondary, Rajdhani condensed headings, light "station work order" variant. Aliases: `sci-fi`, `science-fiction`, `space`, `space-opera`, `space-noir`. Section titles: Star Charts / Powers & Interests / Hardware & Equipment / Xenofauna, plus genre-flavored landing Explore copy.
- **Preset font fix** — the generated `theme.css` was unconditionally emitting `system-ui` font overrides after the preset stylesheet, silently clobbering every preset's fonts (fantasy's Palatino and noir's Fira Code never actually rendered). It now emits only explicitly-chosen non-generic fonts; the custom-palette path is unchanged.
- **Theme showcase** — `scripts/build-theme-showcase.mjs` builds the benchmark campaign once per preset with a gallery index; a new workflow deploys it to GitHub Pages on main pushes (requires one-time Pages enablement with `build_type: workflow`).

## Testing

- Publish tool suite: 737/737 passing (698 baseline + 39 new, including a live end-to-end showcase build)
- Locations renderer verified against adversarial inputs (completeness fuzz over 3,000 random hierarchies, XSS probes)
- `python3 scripts/validate_schema.py` — 41 files clean; markdownlint — 317 files clean
- `./scripts/build-skill-zips.sh` — 9 valid zips, no absolute paths
- skill-creator quick_validate on publish-site — valid