### PR TITLE
Resolve Techniques level from Base/Current columns

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ docs/superpowers/
 docs/plans/
 .superpowers/
 
+# mobRPG integration prototype (private collaborator tooling, not for distribution)
+docs/prototypes/mobrpg/
+
 # Test results (run-specific artifacts)
 tests/compaction/
 tests/proof-runs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.14] — 2026-07-08
+
+### Fixed
+
+- **GURPS Techniques level renders from `Base`/`Current` columns**
+  (publish tool 1.7.1) — the Techniques table parser now resolves the
+  displayed level with the same column priority as Skills
+  (`Current` > `Effective` > `Base` > `Level`), so sheets using the
+  1.8.12-style header no longer publish a blank `Lvl` cell. The
+  Skills, Techniques, and Spells table parsers now share one
+  column-resolution helper so they can't drift apart, and the
+  frontmatter paths for all three share a matching level fallback
+  (`current` > `level` > `effective` > `base`, skipping blank
+  values). Legacy `Effective`/`Skill Level` sheets are unaffected.
+  (#78)
+
+---
+
 ## [1.8.13] — 2026-07-07
 
 ### Added

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -116,10 +116,38 @@ function parseSkillFootnotes(sectionHtml) {
   return map;
 }
 
+// Shared level-column resolution for Skills and Techniques tables.
+// 'current' and 'base' are the 1.8.12+ vault columns (Base = unencumbered,
+// Current = with encumbrance); pre-1.8.12 sheets have 'effective' only.
+// Displayed level priority: current > effective > base > plain 'level'
+// ('relative level' must not match the plain-'level' fallback).
+function resolveLevelColumns(header) {
+  const iEffective = header.findIndex(h => h.includes('effective'));
+  const iCurrent = header.findIndex(h => h.includes('current'));
+  const iBase = header.findIndex(h => h.includes('base'));
+  const iLevelFallback = header.findIndex(h => h.includes('level') && !h.includes('relative'));
+  const iLevel = iCurrent >= 0 ? iCurrent
+    : iEffective >= 0 ? iEffective
+      : iBase >= 0 ? iBase : iLevelFallback;
+  return { iLevel, iBase };
+}
+
+// Frontmatter counterpart of resolveLevelColumns, shared by the skills,
+// techniques, and spells fm paths. Explicit `current`/`level` keys win over
+// the legacy `effective`/`base` fallbacks; blank values fall through instead
+// of rendering an empty level.
+function resolveFmLevel(o) {
+  for (const k of ['current', 'level', 'effective', 'base']) {
+    const v = o[k];
+    if (v != null && String(v).trim() !== '') return String(v);
+  }
+  return '';
+}
+
 function parseSkills(model, sections, fm) {
   if (Array.isArray(fm.skills)) {
     model.skills = fm.skills.map(s => ({
-      name: String(s.name ?? ''), level: String(s.current ?? s.level ?? ''),
+      name: String(s.name ?? ''), level: resolveFmLevel(s),
       relative: s.relative || '',
       points: String(s.points ?? ''), parry: s.parry != null ? String(s.parry) : null,
       block: s.block != null ? String(s.block) : null,
@@ -132,24 +160,10 @@ function parseSkills(model, sections, fm) {
   if (!sec) return;
   const rows = parseTableRows(sec.html);
   const header = (rows[0] || []).map(h => h.toLowerCase());
-  // Detect columns explicitly by header substring.
-  // 'effective' must be checked before generic 'level' to avoid hitting 'relative level'.
   const iName = header.findIndex(h => h.includes('name')) >= 0
     ? header.findIndex(h => h.includes('name')) : 0;
-  // 'effective' takes priority over 'level'; 'relative level' must not match 'effective'
-  const iEffective = header.findIndex(h => h.includes('effective'));
-  // 'current' and 'base' are the 1.8.12+ vault columns (Base = unencumbered,
-  // Current = with encumbrance); pre-1.8.12 sheets have 'effective' only
-  const iCurrent = header.findIndex(h => h.includes('current'));
-  const iBase = header.findIndex(h => h.includes('base'));
-  // 'relative level' matches 'relative', not 'effective'/'base'/'current'
+  const { iLevel, iBase } = resolveLevelColumns(header);
   const iRel = header.findIndex(h => h.includes('relative'));
-  // Fall back to a plain 'level' col ('relative level' must not match)
-  const iLevelFallback = header.findIndex(h => h.includes('level') && !h.includes('relative'));
-  // Displayed level priority: current > effective > base > plain 'level'
-  const iLevel = iCurrent >= 0 ? iCurrent
-    : iEffective >= 0 ? iEffective
-      : iBase >= 0 ? iBase : iLevelFallback;
   const iPts = header.findIndex(h => h.includes('point'));
   for (const row of rows.slice(1)) {
     if (!row[iName]) continue;
@@ -366,7 +380,7 @@ function parseSocial(model, sections, fm) {
 function parseSpells(model, sections, fm) {
   if (Array.isArray(fm.spells)) {
     model.spells = fm.spells.map(s => ({
-      name: String(s.name ?? ''), level: String(s.level ?? ''), points: String(s.points ?? '0'),
+      name: String(s.name ?? ''), level: resolveFmLevel(s), points: String(s.points ?? '0'),
       markers: [], source: s.source || null,
     }));
     return;
@@ -376,7 +390,7 @@ function parseSpells(model, sections, fm) {
   const rows = parseTableRows(sec.html);
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = Math.max(0, header.findIndex(h => h.includes('name')));
-  const iLevel = header.findIndex(h => h.includes('level') || h.includes('effective'));
+  const { iLevel } = resolveLevelColumns(header);
   const iPts = header.findIndex(h => h.includes('point'));
   for (const row of rows.slice(1)) {
     if (!row[iName]) continue;
@@ -546,7 +560,7 @@ function parseTechniques(model, sections, fm) {
   if (Array.isArray(fm.techniques)) {
     model.techniques = fm.techniques.map(t => ({
       name: String(t.name ?? ''), def: t.default || t.def || '',
-      points: String(t.points ?? ''), level: String(t.level ?? t.effective ?? ''),
+      points: String(t.points ?? ''), level: resolveFmLevel(t),
       markers: [],
     }));
     return;
@@ -559,17 +573,17 @@ function parseTechniques(model, sections, fm) {
     ? header.findIndex(h => h.includes('name')) : 0;
   const iDef = header.findIndex(h => h.includes('default'));
   const iPts = header.findIndex(h => h.includes('point'));
-  const iEff = header.findIndex(h => h.includes('effective'));
+  const { iLevel } = resolveLevelColumns(header);
   for (const row of rows.slice(1)) {
     if (!row[iName]) continue;
     const { value: nameClean, markers: nameMarkers } = splitMarkers(row[iName]);
     const { name, source } = splitCitation(nameClean);
     const pts = stripCost(iPts >= 0 ? row[iPts] : '');
-    const eff = splitMarkers(iEff >= 0 ? row[iEff] : '');
+    const lv = splitMarkers(iLevel >= 0 ? row[iLevel] : '');
     model.techniques.push({
       name, def: iDef >= 0 ? row[iDef] : '',
-      points: pts.value, level: eff.value,
-      markers: [...nameMarkers, ...pts.markers, ...eff.markers], source: source || null,
+      points: pts.value, level: lv.value,
+      markers: [...nameMarkers, ...pts.markers, ...lv.markers], source: source || null,
     });
   }
 }

--- a/tools/publish/package-lock.json
+++ b/tools/publish/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gm-apprentice-publish",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3",

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/gurps/parse.test.js
+++ b/tools/publish/test/unit/gurps/parse.test.js
@@ -117,6 +117,94 @@ describe('parseGurps', () => {
   });
 });
 
+describe('parseGurps — Techniques level columns', () => {
+  it('reads Base/Current techniques columns: level = Current', () => {
+    const c = parseGurps({}, [{
+      title: 'Techniques', id: 'techniques',
+      html: '<table><tr><th>Name</th><th>Default</th><th>Points</th>' +
+            '<th>Base</th><th>Current</th></tr>' +
+            '<tr><td>Choke Hold</td><td>Judo-2</td><td>[3]</td><td>14</td><td>13</td></tr>' +
+            '<tr><td>Kicking</td><td>Karate-2</td><td>[3]</td><td>15</td><td>15</td></tr></table>',
+    }]);
+    const choke = c.techniques.find(t => t.name === 'Choke Hold');
+    assert.strictEqual(choke.level, '13');
+    assert.strictEqual(choke.def, 'Judo-2');
+    assert.strictEqual(choke.points, '3');
+  });
+
+  it('uses Base as the technique level when there is no Current column', () => {
+    const c = parseGurps({}, [{
+      title: 'Techniques', id: 'techniques',
+      html: '<table><tr><th>Name</th><th>Default</th><th>Points</th><th>Base</th></tr>' +
+            '<tr><td>Disarming</td><td>Broadsword</td><td>[2]</td><td>16</td></tr></table>',
+    }]);
+    assert.strictEqual(c.techniques[0].level, '16');
+  });
+
+  it('still reads the legacy Effective column', () => {
+    const c = parseGurps({}, [{
+      title: 'Techniques', id: 'techniques',
+      html: '<table><tr><th>Name</th><th>Default</th><th>Points</th><th>Effective</th></tr>' +
+            '<tr><td>Choke Hold</td><td>Judo-2</td><td>[3]</td><td>14</td></tr></table>',
+    }]);
+    assert.strictEqual(c.techniques[0].level, '14');
+  });
+
+  it('frontmatter techniques prefer current over level/effective', () => {
+    const c = parseGurps({ techniques: [
+      { name: 'Choke Hold', default: 'Judo-2', points: 3, current: 13, level: 14 },
+      { name: 'Kicking', default: 'Karate-2', points: 3, effective: 15 },
+    ] }, []);
+    assert.strictEqual(c.techniques[0].level, '13');
+    assert.strictEqual(c.techniques[1].level, '15');
+  });
+
+  it('blank frontmatter current falls through to the next level key', () => {
+    const c = parseGurps({ techniques: [
+      { name: 'Kicking', default: 'Karate-2', points: 3, current: '', level: 14 },
+    ] }, []);
+    assert.strictEqual(c.techniques[0].level, '14');
+  });
+});
+
+describe('parseGurps — Spells and frontmatter level fallbacks', () => {
+  it('reads Base/Current spells columns: level = Current', () => {
+    const c = parseGurps({}, [{
+      title: 'Spells', id: 'spells',
+      html: '<table><tr><th>Name</th><th>College</th><th>Points</th>' +
+            '<th>Base</th><th>Current</th></tr>' +
+            '<tr><td>Fireball</td><td>Fire</td><td>4</td><td>15</td><td>14</td></tr></table>',
+    }]);
+    assert.strictEqual(c.spells[0].level, '14');
+  });
+
+  it('still reads the legacy Skill Level spells column', () => {
+    const c = parseGurps({}, [{
+      title: 'Spells', id: 'spells',
+      html: '<table><tr><th>Name</th><th>College</th><th>Skill Level</th><th>Points</th></tr>' +
+            '<tr><td>Fireball</td><td>Fire</td><td>15</td><td>4</td></tr></table>',
+    }]);
+    assert.strictEqual(c.spells[0].level, '15');
+  });
+
+  it('frontmatter skills fall back to effective/base when current/level are absent', () => {
+    const c = parseGurps({ skills: [
+      { name: 'Broadsword', points: 4, effective: 14 },
+      { name: 'Judo', points: 4, base: 12 },
+    ] }, []);
+    assert.strictEqual(c.skills[0].level, '14');
+    assert.strictEqual(c.skills[1].level, '12');
+  });
+
+  it('frontmatter skills keep level over base, preserving the base subline', () => {
+    const c = parseGurps({ skills: [
+      { name: 'Climbing', points: 1, level: 10, base: 12 },
+    ] }, []);
+    assert.strictEqual(c.skills[0].level, '10');
+    assert.strictEqual(c.skills[0].base, '12');
+  });
+});
+
 // Fix 1: Equipment parser must not include subsection rows from ### Encumbrance
 describe('parseGurps — Equipment section', () => {
   const equipHtml =


### PR DESCRIPTION
## Summary

Fixes #78. The GURPS Techniques table parser only looked for an `Effective` header, so sheets using the 1.8.12-style `Base`/`Current` columns rendered a blank `Lvl` cell on the published sheet.

- The Skills, Techniques, and Spells table parsers now share one `resolveLevelColumns()` helper (`Current` > `Effective` > `Base` > plain `Level`, with the `Relative Level` guard), so the parsers can't drift apart again.
- The three frontmatter paths share a matching `resolveFmLevel()` fallback (`current` > `level` > `effective` > `base`) that also skips blank values, so an `effective`- or `base`-only frontmatter entry no longer renders a blank level.
- Legacy `Effective` / `Skill Level` sheets are unaffected (covered by regression tests).

Publish tool 1.7.0 → 1.7.1, plugin 1.8.13 → 1.8.14.

## Testing

- 9 new unit tests covering Base/Current, Base-only, legacy headers, and the frontmatter fallback chains for skills, techniques, and spells
- Full publish suite: 746 pass, 0 fail
- `scripts/validate_schema.py` and markdownlint pass
- Verified end-to-end: the repro table from #78 renders `14`/`15` in the Lvl column