### PR TITLE
Fix the nine open publish-site issues

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.16] — 2026-07-09
+
+Publish tool 1.9.0. Fixes the eight open publish-site issues.
+
+### Added
+
+- **Obsidian callouts render as styled callouts.** `> [!type] Title`
+  blockquotes become `<div class="callout callout-{type}">` with a title
+  row, instead of leaking the literal `[!type]` marker as body text. A
+  shared markdown renderer (`lib/markdown.js`) now backs both the page
+  and index-page renderers. (#86a)
+- **Aggregate `characters/index.html`.** The homepage "Characters" card
+  pointed at a page that was never generated; the index now exists and
+  lists PCs and NPCs together. (#84)
+- **Warning for unmatched manifest entries.** A Publishing entry that
+  resolves to no scanned vault file now prints a warning instead of
+  silently dropping the page. (#80)
+
+### Fixed
+
+- **HTML comments no longer reach the published site.** `<!-- ... -->`
+  was HTML-escaped and printed as visible body text, leaking private
+  authoring notes (including "needs GM confirmation" flags) onto
+  player-facing pages. Comments are now stripped before render, outside
+  fenced code blocks, with a warning on an unclosed comment. (#85)
+- **Manifest Publishing entries tolerate inline comments.** `- [x] path
+  — note` silently published nothing, because the whole line was matched
+  against the vault path. The comment is now stripped, matching how the
+  Excluded section is annotated. (#80)
+- **Image embeds render as images.** `![[Some Image.png]]` produced a
+  markdown link with an unencoded space, which markdown-it could not
+  parse, so it fell through as literal text and the typographer rewrote
+  the leading `../` into `…/`. Destinations are now percent-encoded, in
+  embeds and in portrait `src` attributes alike. (#86b)
+- **Wikilinks in frontmatter fields resolve.** `summary:`, `occupation:`
+  and friends leaked literal `[[…]]` while the same links resolved in
+  body prose. (#86c)
+- **Inline embeds are deduped against the frontmatter portrait.** An
+  `![[X.png]]` embed that resolves to the page's `portrait:` is skipped,
+  so authors can keep the embed for Obsidian's reading view without
+  publishing the image twice. (#88)
+- **Pull-quote excerpts are sanitized.** They no longer include section
+  headings, raw image markdown, HTML comments (whole or truncated), or
+  callout markers, and de-linking a wikilink no longer leaves a stray
+  space ("Magellan 's"). (#87)
+- **Timeline nav link and `events/` redirect point at the real page.**
+  Both hard-coded a root `timeline.html` that is only written when dated
+  events exist; with an authored timeline elsewhere (e.g.
+  `campaign/timeline.html`) the global nav dangled on nearly every page.
+  The target is now computed once, and `events/` gets a real index when
+  no timeline exists at all. (#83)
+- **GURPS `parseTechniques()` no longer merges sub-tables.** Descriptive
+  helper tables under a `###` subheading were force-fit into the
+  Name/Default/Lvl/Pts grid. Techniques, Skills and Spells now read only
+  tables above the first subheading. (#82)
+- A missing image embed no longer emits a visible `<!-- image not found -->`
+  paragraph; it is dropped, with a build warning.
+- PC sheets resolve image embeds before wikilinks, so an `![[image.png]]`
+  on a character sheet is no longer flattened to literal text.
+- A non-image transclusion (`![[Some Note]]`) degrades to a link instead
+  of becoming an `<img>` whose `src` points at an HTML page.
+- `world_domain` pages render their `portrait:` frontmatter, which every
+  other entity template already did.
+- Unclosed `<!-- gm-only -->`, `<!-- spoiler -->` and comment markers now
+  print the build warning they always recorded; it was being discarded.
+- `<!-- ... -->` inside a `~~~` fenced block containing a nested ```` ``` ````
+  line is no longer stripped.
+
+### Changed
+
+- Pull-quote excerpts derive from a page's published markdown rather than
+  from its rendered HTML — the same source backlinks, search and recency
+  already read, and the reason the sanitization above is not a regex pass
+  over the renderer's own output. `publishedSource()` is now a single
+  shared helper instead of four near-identical copies.
+
 ## [1.8.15] — 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ Publish tool 1.9.0. Fixes the eight open publish-site issues.
   `campaign/timeline.html`) the global nav dangled on nearly every page.
   The target is now computed once, and `events/` gets a real index when
   no timeline exists at all. (#83)
+- **The NPC listing's session filter no longer treats `lastUpdated` as a
+  session.** It fell back to that field when `asOfSession` was empty, so a
+  maintenance date (`2026-07-05`) appeared in the "filter by session"
+  dropdown and was sorted against `Session N`. An entity with no
+  `asOfSession` is simply not session-filterable, and an ISO date written
+  directly into `asOfSession` is ignored. (#89)
 - **GURPS `parseTechniques()` no longer merges sub-tables.** Descriptive
   helper tables under a `###` subheading were force-fit into the
   Name/Default/Lvl/Pts grid. Techniques, Skills and Spells now read only
@@ -77,6 +83,9 @@ Publish tool 1.9.0. Fixes the eight open publish-site issues.
 
 ### Changed
 
+- The NPC listing's last column is now headed **As of Session** rather than
+  "Last Updated". It always showed `asOfSession` first and was sorted and
+  filtered as a session; the header was the part that was wrong.
 - Pull-quote excerpts derive from a page's published markdown rather than
   from its rendered HTML — the same source backlinks, search and recency
   already read, and the reason the sanitization above is not a regex pass

--- a/docs/portrait-rendering-obsidian.md
+++ b/docs/portrait-rendering-obsidian.md
@@ -11,6 +11,10 @@ portrait field shows up as plain text metadata in the Properties panel —
 the user never sees the actual image when viewing the note unless they
 manually embed it in the body with `![[filename]]`.
 
+Keeping that manual `![[filename]]` embed is safe: when it resolves to the
+same file as the entity's `portrait:` frontmatter, the publish tool skips
+the inline copy so the published page shows the image once, not twice.
+
 ## Desired Behaviour
 
 When a user opens any entity file that has a portrait value, the image

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -12,6 +12,11 @@ All campaign content falls into three categories:
 - Files with `source: "prep"` that have no played counterpart
 - H2 sections listed in `exclude_sections` (default: `["GM Notes"]`)
 - Content between `<!-- gm-only -->` / `<!-- /gm-only -->` markers
+- **Every other `<!-- ... -->` comment.** Private authoring notes
+  (`<!-- UNVERIFIED: … -->`, change logs, import provenance) are
+  stripped before render and never reach the site. Comments inside
+  fenced code blocks are preserved. An unclosed `<!--` strips to end
+  of file and prints a build warning.
 - Frontmatter fields in `exclude_fields` (default:
   `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`)
 
@@ -139,6 +144,8 @@ needs_decision: 2
 - `## Publishing` — files to include in the build. Each entry
   is a checked checkbox with a vault-relative path:
   `- [x] Characters/NPCs/Friendly Merchant.md`
+  Optionally annotated with an inline reason, like Excluded:
+  `- [x] Documents/House Rules.md — the party's own notes`
 
 - `## Excluded` — files to exclude. Also uses checked checkboxes.
   Optionally annotated with a reason:
@@ -152,7 +159,10 @@ needs_decision: 2
 
 **Path format:** All paths are vault-relative using forward
 slashes (e.g. `Characters/NPCs/Alice.md`). Never use absolute
-filesystem paths.
+filesystem paths. An inline `— comment` after the path is ignored;
+an em dash inside the filename itself is preserved. A Publishing
+entry that matches no vault file prints a build warning rather
+than silently dropping the page.
 
 **Example manifest:**
 

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -3339,3 +3339,32 @@ details.rules-ref > summary::-webkit-details-marker { display: none; }
 }
 .npc-row-avatar img.portrait { width: 100%; height: 100%; object-fit: cover; }
 .npc-row-initials { font-size: 0.65rem; font-weight: 700; color: var(--accent); }
+
+/* --- Obsidian callouts (> [!type] Title) --- */
+.callout {
+  --callout-color: var(--accent);
+  margin: 1.25rem 0;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--callout-color);
+  border-radius: 0 0.375rem 0.375rem 0;
+  background: var(--bg-card);
+}
+.callout-title {
+  font-weight: 700;
+  color: var(--callout-color);
+  margin-bottom: 0.25rem;
+}
+.callout-title:last-child { margin-bottom: 0; }
+.callout > p { margin: 0.5rem 0 0; }
+.callout > p:last-child { margin-bottom: 0; }
+
+.callout-warning, .callout-caution, .callout-attention { --callout-color: var(--warning); }
+.callout-danger, .callout-error, .callout-bug, .callout-failure, .callout-missing {
+  --callout-color: var(--danger);
+}
+.callout-success, .callout-check, .callout-done, .callout-tip, .callout-hint {
+  --callout-color: var(--success);
+}
+.callout-quote, .callout-cite, .callout-abstract, .callout-summary, .callout-example {
+  --callout-color: var(--text-muted);
+}

--- a/tools/publish/lib/backlinks.js
+++ b/tools/publish/lib/backlinks.js
@@ -1,3 +1,4 @@
+const { publishedSource } = require('./processor');
 const WIKI_LINK_RE = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 
 function buildBacklinks(pages) {
@@ -6,7 +7,7 @@ function buildBacklinks(pages) {
   for (const page of pages) {
     // Prefer the published view (gm-only blocks + excluded sections stripped) so a mention
     // that only appears in non-published content never creates a public backlink (B6).
-    const md = page.publishedMarkdown != null ? page.publishedMarkdown : (page.markdown || '');
+    const md = publishedSource(page);
     const seen = new Set();
     let match;
     WIKI_LINK_RE.lastIndex = 0;

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
-const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, filterFields, resolveImageEmbeds, resolveWikiLinks, relativeHref, escapeHtml } = require('./processor');
+const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest } = require('./manifest');
@@ -136,6 +136,22 @@ function build(options = {}) {
   // is visible here too. Use corpus to reach excluded *pages* (e.g. the overview), not to recover
   // fields stripped from a *published* page.
   const corpus = pages.slice();
+
+  function vaultRelPathOf(page) {
+    return path.relative(config.vaultPath, page.sourcePath).split(path.sep).join('/');
+  }
+
+  // A Publishing entry that matches no scanned file silently removes nothing and publishes
+  // nothing — the page just never appears. Say so, so a typo can't blackhole a page.
+  if (manifest) {
+    const scanned = new Set(corpus.map(vaultRelPathOf));
+    for (const entry of manifest.publishing) {
+      if (!scanned.has(entry)) {
+        console.warn(`  WARNING: manifest lists "${entry}" but no such page was scanned`);
+      }
+    }
+  }
+
   pairStoryFiles(pages, config.vaultPath);
 
   // Exclude DRAFT entities when configured (after pairing so story files resolve)
@@ -175,10 +191,7 @@ function build(options = {}) {
     // If manifest explicitly lists an auto-excluded file, re-add it
     if (manifest) {
       const allowSet = new Set(manifest.publishing);
-      const reincluded = autoExcludedPages.filter(page => {
-        const vaultRelPath = path.relative(config.vaultPath, page.sourcePath).split(path.sep).join('/');
-        return allowSet.has(vaultRelPath);
-      });
+      const reincluded = autoExcludedPages.filter(page => allowSet.has(vaultRelPathOf(page)));
       if (reincluded.length > 0) {
         pages = pages.concat(reincluded);
         console.log(`Manifest override: re-included ${reincluded.length} auto-excluded file(s)`);
@@ -190,11 +203,7 @@ function build(options = {}) {
   if (manifest && publishConfig.mode === 'player') {
     const allowSet = new Set(manifest.publishing);
     const beforeCount = pages.length;
-    pages = pages.filter(page => {
-      const vaultRelPath = path.relative(config.vaultPath, page.sourcePath);
-      const posixPath = vaultRelPath.split(path.sep).join('/');
-      return allowSet.has(posixPath);
-    });
+    pages = pages.filter(page => allowSet.has(vaultRelPathOf(page)));
     console.log(`Manifest filter: ${beforeCount} → ${pages.length} pages`);
   }
 
@@ -279,10 +288,24 @@ function build(options = {}) {
 
   // Apply field filtering after link map is built (aliases/canon_status needed for redirect resolution)
   for (const page of pages) {
-    const vaultRelPath = path.relative(config.vaultPath, page.sourcePath).split(path.sep).join('/');
-    const overridesForFile = fieldOverrides[vaultRelPath] || {};
+    const overridesForFile = fieldOverrides[vaultRelPathOf(page)] || {};
     page.frontmatter = filterFields(page.frontmatter, excludeFields, overridesForFile);
   }
+
+  // Where the timeline actually lives. Decided after field filtering — so an excluded
+  // `in_game_date` can't resurrect a timeline the GM meant to suppress — but before the nav
+  // is built, so the nav link and the events/ redirect can't disagree with the renderer.
+  // A root timeline.html is generated only when dated events exist; failing that, an
+  // authored Timeline page (which a folderMap may place anywhere, e.g.
+  // campaign/timeline.html) is the real target. With neither, Events keeps its own index.
+  const { buildTimelineData, renderTimelineHTML, renderTimelineStrip } = require('./timeline');
+  const timelineData = buildTimelineData(pages);
+  const generatesTimeline = timelineData.events.length > 0;
+  const authoredTimeline = pages.find(p => p.frontmatter.type === 'timeline')
+    || pages.find(p => p.outputPath.split('/').pop() === 'timeline.html');
+  const timelineHref = generatesTimeline
+    ? 'timeline.html'
+    : (authoredTimeline ? authoredTimeline.outputPath : null);
 
   const imageMap = scanAttachments(config);
   console.log(`Found ${Object.keys(imageMap).length} image files`);
@@ -335,7 +358,7 @@ function build(options = {}) {
 
   write404();
 
-  const navFor = generateNav(pages, { hasStory });
+  const navFor = generateNav(pages, { hasStory, timelineHref });
 
   // Render each page
   const usedImages = new Set();
@@ -348,6 +371,11 @@ function build(options = {}) {
         if (basename && imageMap[basename]) usedImages.add(basename);
       }
       const processed = processContent(page, linkMap, excludeSections, imageMap, { usedImages });
+      // An unclosed <!-- comment --> or gm-only marker strips the rest of the page to EOF.
+      // That is the right behavior (never leak the block), but it must not be silent.
+      for (const warning of processed.warnings || []) {
+        console.warn(`  WARNING: ${page.outputPath}: ${warning}`);
+      }
       let html;
 
       switch (page.frontmatter.type) {
@@ -357,9 +385,20 @@ function build(options = {}) {
           filtered = typeof gmResult === 'string' ? gmResult : gmResult.text;
           const spoilerResult = stripSpoiler(filtered);
           filtered = typeof spoilerResult === 'string' ? spoilerResult : spoilerResult.text;
+          const commentResult = stripHtmlComments(filtered);
+          if (commentResult.warnings) {
+            for (const warning of commentResult.warnings) {
+              console.warn(`  WARNING: ${page.outputPath}: ${warning}`);
+            }
+          }
+          filtered = typeof commentResult === 'string' ? commentResult : commentResult.text;
           filtered = filterSections(filtered, excludeSections);
+          // Images before wikilinks: resolveWikiLinks' `[[…]]` pattern also matches the inner
+          // brackets of an `![[image.png]]` embed and would flatten it to literal text.
+          filtered = resolveImageEmbeds(filtered, imageMap, page.outputPath, usedImages, {
+            portraitBasename: portraitBasename(page.frontmatter),
+          });
           filtered = resolveWikiLinks(filtered, linkMap, page.outputPath);
-          filtered = resolveImageEmbeds(filtered, imageMap, page.outputPath, usedImages);
           const sections = extractSections(filtered);
 
           let storyHtml;
@@ -416,7 +455,7 @@ function build(options = {}) {
           html = heritageTemplate(page, processed, navFor, config, imageMap, { publishConfig, linkMap });
           break;
         case 'world_domain':
-          html = worldDomainTemplate(page, processed, navFor, config, { publishConfig });
+          html = worldDomainTemplate(page, processed, navFor, config, imageMap, { publishConfig, linkMap });
           break;
         default: {
           let extraSidebar = {};
@@ -503,14 +542,15 @@ function build(options = {}) {
       console.log(`  wrote ${dir}/index.html (redirect → ${pcRedirectTarget})`);
       continue;
     }
-    if (dir === 'events') {
-      const depth = dir.split('/').length;
-      const rel = '../'.repeat(depth) + 'timeline.html';
+    // Redirect events/ at the timeline only when one exists; with no timeline the redirect
+    // would dangle, so fall through and give events its own index.
+    if (dir === 'events' && timelineHref) {
+      const rel = relativePath(dir, timelineHref);
       const redirectHtml = `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=${rel}"><link rel="canonical" href="${rel}"></head><body><a href="${rel}">Timeline</a></body></html>`;
       const outPath = path.join(outputDir, dir, 'index.html');
       ensureDir(outPath);
       fs.writeFileSync(outPath, redirectHtml);
-      console.log(`  wrote ${dir}/index.html (redirect → timeline.html)`);
+      console.log(`  wrote ${dir}/index.html (redirect → ${timelineHref})`);
       continue;
     }
     let dirPages = [];
@@ -532,11 +572,9 @@ function build(options = {}) {
   }
 
   // Timeline page
-  const { buildTimelineData, renderTimelineHTML, renderTimelineStrip } = require('./timeline');
   const { timelineTemplate } = require('./templates/timeline-page');
 
-  const timelineData = buildTimelineData(pages);
-  if (timelineData.events.length > 0) {
+  if (generatesTimeline) {
     const fullTimelineContent = renderTimelineHTML(timelineData);
     const timelineHtml = timelineTemplate(fullTimelineContent, navFor, config, publishConfig);
     const timelinePath = path.join(outputDir, 'timeline.html');

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -115,6 +115,15 @@ function build(options = {}) {
     console.log('  wrote 404.html');
   }
 
+  // An unclosed <!-- comment -->, gm-only or spoiler marker strips the rest of the file to
+  // EOF. That is the right behavior — never leak the block — but it must not be silent, or
+  // an author who forgot a `-->` loses the tail of the page with no signal.
+  function logWarnings(outputPath, warnings) {
+    for (const warning of warnings || []) {
+      console.warn(`  WARNING: ${outputPath}: ${warning}`);
+    }
+  }
+
   function copyImages(imageMap) {
     for (const entry of Object.values(imageMap)) {
       const dest = path.join(outputDir, 'images', entry.relPath);
@@ -371,11 +380,7 @@ function build(options = {}) {
         if (basename && imageMap[basename]) usedImages.add(basename);
       }
       const processed = processContent(page, linkMap, excludeSections, imageMap, { usedImages });
-      // An unclosed <!-- comment --> or gm-only marker strips the rest of the page to EOF.
-      // That is the right behavior (never leak the block), but it must not be silent.
-      for (const warning of processed.warnings || []) {
-        console.warn(`  WARNING: ${page.outputPath}: ${warning}`);
-      }
+      logWarnings(page.outputPath, processed.warnings);
       let html;
 
       switch (page.frontmatter.type) {
@@ -385,12 +390,9 @@ function build(options = {}) {
           filtered = typeof gmResult === 'string' ? gmResult : gmResult.text;
           const spoilerResult = stripSpoiler(filtered);
           filtered = typeof spoilerResult === 'string' ? spoilerResult : spoilerResult.text;
+          // Not logged here: processContent above ran this same strip chain over the same
+          // markdown, and its warnings were already reported.
           const commentResult = stripHtmlComments(filtered);
-          if (commentResult.warnings) {
-            for (const warning of commentResult.warnings) {
-              console.warn(`  WARNING: ${page.outputPath}: ${warning}`);
-            }
-          }
           filtered = typeof commentResult === 'string' ? commentResult : commentResult.text;
           filtered = filterSections(filtered, excludeSections);
           // Images before wikilinks: resolveWikiLinks' `[[…]]` pattern also matches the inner
@@ -409,6 +411,7 @@ function build(options = {}) {
               outputPath: page.outputPath,
             };
             const storyProcessed = processContent(storyPage, linkMap, excludeSections, imageMap, { usedImages });
+            logWarnings(page.outputPath, storyProcessed.warnings);
             storyHtml = storyProcessed.html && storyProcessed.html.trim() ? storyProcessed.html : undefined;
           }
 
@@ -608,6 +611,7 @@ function build(options = {}) {
       const outputPath = `story/characters/${slugify(pc.title)}.html`;
       const storyObj = { markdown: pc.storyMarkdown, frontmatter: {}, outputPath };
       const processed = processContent(storyObj, linkMap, excludeSections, imageMap, { usedImages });
+      logWarnings(outputPath, processed.warnings);
       const story = {
         title: pc.displayTitle, outputPath, html: processed.html,
         sheetOutputPath: pc.outputPath, group: characterStoryGroup(pc.frontmatter),

--- a/tools/publish/lib/excerpt.js
+++ b/tools/publish/lib/excerpt.js
@@ -33,12 +33,46 @@ function normalizeHeadingText(text) {
   return normalized.toLowerCase();
 }
 
+// Elements whose text is structure, not prose, and must never reach a pull-quote:
+// section headings, callout titles, tables, and figure captions.
+const HTML_BLOCKS_TO_DROP = [
+  /<h[1-6][^>]*>[\s\S]*?<\/h[1-6]>/gi,
+  /<div[^>]*class="[^"]*callout-title[^"]*"[^>]*>[\s\S]*?<\/div>/gi,
+  /<table[\s\S]*?<\/table>/gi,
+  /<figcaption[\s\S]*?<\/figcaption>/gi,
+];
+
+// Tags that end a block of prose. Turning them into newlines (rather than letting the
+// generic tag strip below eat them) keeps "…load.</p><p>More…" from fusing into one word,
+// while inline tags close up cleanly so `<a>Magellan</a>'s` stays "Magellan's".
+const BLOCK_BOUNDARY_RE = /<\/(p|div|li|ul|ol|blockquote|h[1-6]|tr|td|th|section|article)\s*>|<br\s*\/?>/gi;
+
+function stripHtml(text) {
+  let out = text;
+  for (const re of HTML_BLOCKS_TO_DROP) out = out.replace(re, '\n');
+  out = out.replace(/<img[^>]*>/gi, '');
+  out = out.replace(BLOCK_BOUNDARY_RE, '\n');
+  out = out.replace(/<[^>]+>/g, '');
+  return out;
+}
+
 function excerptFromMarkdown(source, opts = {}) {
   const excludeSections = (opts.excludeSections || []).map(s => String(s).trim().toLowerCase());
   const limit = opts.limit || 200;
 
+  // Comments carry private authoring notes, and the length cap can truncate one mid-marker.
+  // Drop them first — in raw and already-escaped form, closed or running to end of input —
+  // before anything else looks at the text.
+  let working = String(source || '')
+    .replace(/<!--[\s\S]*?(?:-->|$)/g, '')
+    .replace(/&lt;!--[\s\S]*?(?:--&gt;|$)/g, '');
+
+  // Fenced code (including ```dataview) is never prose.
+  working = working.replace(/^[ \t]*(```|~~~)[\s\S]*?(?:^[ \t]*\1[ \t]*$|$)/gm, '');
+  working = stripHtml(working);
+
   const kept = [];
-  for (const line of String(source || '').split('\n')) {
+  for (const line of working.split('\n')) {
     const h = line.match(HEADING_RE);
     if (h && excludeSections.includes(normalizeHeadingText(h[2]))) break;
     if (h) continue;                                   // drop heading lines
@@ -46,15 +80,18 @@ function excerptFromMarkdown(source, opts = {}) {
     if (/^(-{3,}|\*{3,}|_{3,})$/.test(t)) continue;    // horizontal rules
     if (t.startsWith('|')) continue;                   // table rows
     let cleaned = line.replace(/^\s*>\s?/, '');        // blockquote marker
-    cleaned = cleaned.replace(/^\s*\[!\w+\][-+]?\s*$/, ''); // bare callout tag
+    // A callout marker line is metadata, never prose — drop the whole line, title included.
+    // The type pattern must match markdown.js CALLOUT_RE, which allows hyphens.
+    cleaned = cleaned.replace(/^\s*\[![A-Za-z][\w-]*\][-+]?.*$/, '');
     kept.push(cleaned);
   }
 
   let text = kept.join('\n');
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, '');    // image markdown
+  text = text.replace(/!\[\[[^\]]*\]\]/g, '');         // unresolved Obsidian image embed
   text = text.replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2');
   text = text.replace(/\[\[([^\]]+)\]\]/g, (_, t) => t.replace(/_/g, ' '));
   text = text.replace(/[*_`]+/g, '');
-  text = text.replace(/<[^>]+>/g, ' ');
   text = text.replace(/\s+/g, ' ').trim();
 
   const match = text.match(/^(.+?[.!?])\s/);

--- a/tools/publish/lib/manifest.js
+++ b/tools/publish/lib/manifest.js
@@ -2,6 +2,24 @@ const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 
+// Manifest entries are vault-relative paths, optionally annotated with an inline
+// `— comment` (the Excluded section uses these throughout). Keep only the path, so an
+// annotated Publishing entry still matches a scanned file instead of silently
+// blackholing the page.
+//
+// The path is anchored on its file extension rather than split on the first dash: vault
+// filenames legitimately contain " — " ("Items/Six — Field Sundries.md"), and splitting on
+// the dash would truncate them into the very blackhole this exists to prevent. The lazy
+// prefix stops at the first extension that leaves only a comment (or nothing) behind, so
+// both "Six — Field Sundries.md" and "Foo.md — see Bar.md" resolve correctly.
+const ENTRY_RE = /^(.*?\.\w+)(?:\s+(?:—|–|--)\s+.*)?$/;
+
+function stripInlineComment(entry) {
+  const trimmed = String(entry).trim();
+  const match = ENTRY_RE.exec(trimmed);
+  return match ? match[1] : trimmed;
+}
+
 function parseManifest(markdown) {
   const { data, content } = matter(markdown);
   const publishing = [];
@@ -25,14 +43,14 @@ function parseManifest(markdown) {
 
     if (currentSection === 'publishing') {
       const match = line.match(checkedPattern);
-      if (match) publishing.push(match[1].trim());
+      if (match) publishing.push(stripInlineComment(match[1]));
     }
 
     if (currentSection === 'needs_decision') {
       const unchecked = line.match(uncheckedPattern);
-      if (unchecked) needsDecision.push(unchecked[1].trim());
+      if (unchecked) needsDecision.push(stripInlineComment(unchecked[1]));
       const checked = line.match(checkedPattern);
-      if (checked) resolved.push(checked[1].trim());
+      if (checked) resolved.push(stripInlineComment(checked[1]));
     }
   }
 
@@ -51,4 +69,4 @@ function loadManifest(vaultPath) {
   return parseManifest(raw);
 }
 
-module.exports = { parseManifest, loadManifest };
+module.exports = { parseManifest, loadManifest, stripInlineComment };

--- a/tools/publish/lib/markdown.js
+++ b/tools/publish/lib/markdown.js
@@ -1,0 +1,77 @@
+const MarkdownIt = require('markdown-it');
+
+// Obsidian callout: `> [!type] Optional Title` on the first line of a blockquote,
+// with the rest of the quote as the body. The type may carry a fold marker (`+`/`-`),
+// which affects Obsidian's reading view only and is ignored here.
+const CALLOUT_RE = /^\[!([A-Za-z][\w-]*)\][+-]?[ \t]*([^\n]*)(?:\n([\s\S]*))?$/;
+
+// Rewrites callout blockquotes into `<div class="callout callout-{type}">` with a
+// title div, so the `[!type]` marker never survives as literal body text.
+//
+// Registered after markdown-it's `inline` rule and therefore before `replacements` /
+// `smartquotes`: the inline tokens this rule re-parses still get typographer treatment.
+function calloutPlugin(md) {
+  md.core.ruler.after('inline', 'obsidian_callout', function callouts(state) {
+    const tokens = state.tokens;
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i].type !== 'blockquote_open') continue;
+
+      const pOpen = tokens[i + 1];
+      const inline = tokens[i + 2];
+      const pClose = tokens[i + 3];
+      if (!pOpen || pOpen.type !== 'paragraph_open') continue;
+      if (!inline || inline.type !== 'inline') continue;
+      if (!pClose || pClose.type !== 'paragraph_close') continue;
+
+      const match = CALLOUT_RE.exec(inline.content);
+      if (!match) continue;
+
+      // Find this blockquote's own close, not a nested one's.
+      let depth = 0;
+      let closeIndex = -1;
+      for (let j = i; j < tokens.length; j++) {
+        if (tokens[j].type === 'blockquote_open') depth++;
+        else if (tokens[j].type === 'blockquote_close') {
+          depth--;
+          if (depth === 0) { closeIndex = j; break; }
+        }
+      }
+      if (closeIndex === -1) continue;
+
+      const type = match[1].toLowerCase();
+      // Obsidian falls back to the callout type as its own title when none is given.
+      const title = match[2].trim() || type.charAt(0).toUpperCase() + type.slice(1);
+      const body = match[3] || '';
+
+      tokens[i].tag = 'div';
+      tokens[i].attrJoin('class', `callout callout-${type}`);
+      tokens[closeIndex].tag = 'div';
+
+      pOpen.tag = 'div';
+      pOpen.attrJoin('class', 'callout-title');
+      pClose.tag = 'div';
+      inline.content = title;
+      inline.children = [];
+      state.md.inline.parse(title, state.md, state.env, inline.children);
+
+      // A callout written as one lazy paragraph (`> [!info] Title` then `> prose` with no
+      // blank line) parses into a single inline token. Split the prose back out so it
+      // renders as body rather than being swallowed by the title.
+      if (body.trim()) {
+        const bodyOpen = new state.Token('paragraph_open', 'p', 1);
+        const bodyInline = new state.Token('inline', '', 0);
+        bodyInline.content = body;
+        bodyInline.children = [];
+        state.md.inline.parse(body, state.md, state.env, bodyInline.children);
+        const bodyClose = new state.Token('paragraph_close', 'p', -1);
+        tokens.splice(i + 4, 0, bodyOpen, bodyInline, bodyClose);
+      }
+    }
+  });
+}
+
+function createRenderer() {
+  return new MarkdownIt({ html: false, typographer: true }).use(calloutPlugin);
+}
+
+module.exports = { createRenderer, calloutPlugin };

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -1,5 +1,5 @@
-const MarkdownIt = require('markdown-it');
-const md = new MarkdownIt({ html: false, typographer: true });
+const { createRenderer } = require('./markdown');
+const md = createRenderer();
 
 function escapeHtml(str) {
   return String(str || '')
@@ -49,7 +49,11 @@ function relativeHref(fromOutputPath, toOutputPath) {
 }
 
 function resolveWikiLinks(markdown, linkMap, currentOutputPath) {
-  return markdown.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (match, target, displayText) => {
+  // The leading `!` of a non-image transclusion (`![[Backstory]]`) is consumed and dropped,
+  // degrading it to an ordinary link. Leaving it would pair with the `[text](path)` emitted
+  // below into `![text](path)` — an <img> whose src points at an HTML page. Image embeds
+  // resolve earlier, in resolveImageEmbeds, so nothing reaching here should stay an image.
+  return markdown.replace(/!?\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (match, target, displayText) => {
     // Without an explicit |alias, humanize the slug (Lord_Percival_Harcourt → Lord Percival
     // Harcourt) so neither resolved link text nor unresolved plain text shows raw underscores.
     const display = displayText || humanizeName(target);
@@ -155,6 +159,64 @@ function stripSpoiler(markdown) {
   return stripMarkedBlocks(markdown, 'spoiler');
 }
 
+// Remove every `<!-- ... -->` comment, including multi-line ones, outside fenced code
+// blocks. Authors keep private notes (UNVERIFIED flags, change logs, import provenance)
+// as comments; the renderer runs with `html: false`, so anything left here is escaped and
+// printed as visible body text. Must run AFTER stripGmOnly/stripSpoiler, whose block
+// markers are themselves comments.
+//
+// A line that holds nothing but a comment is dropped rather than blanked: a blank line
+// would split the paragraph the comment was sitting inside.
+function stripHtmlComments(markdown) {
+  const lines = String(markdown || '').split('\n');
+  const result = [];
+  const warnings = [];
+  // Track which marker opened the fence: a ``` line inside a ~~~ block is content, not a
+  // close, and must not toggle the fence off and expose the rest of the block to stripping.
+  let fenceMarker = null;
+  let inComment = false;
+
+  for (const line of lines) {
+    const fence = inComment ? null : /^\s*(```|~~~)/.exec(line);
+    if (fence) {
+      if (fenceMarker === null) fenceMarker = fence[1];
+      else if (fenceMarker === fence[1]) fenceMarker = null;
+    }
+    // Inside a fence, or on the line that opened or closed one: pass through verbatim.
+    if (fenceMarker !== null || fence) {
+      result.push(line);
+      continue;
+    }
+
+    let kept = '';
+    let i = 0;
+    while (i < line.length) {
+      if (inComment) {
+        const end = line.indexOf('-->', i);
+        if (end === -1) { i = line.length; break; }
+        inComment = false;
+        i = end + 3;
+      } else {
+        const start = line.indexOf('<!--', i);
+        if (start === -1) { kept += line.slice(i); break; }
+        kept += line.slice(i, start);
+        inComment = true;
+        i = start + 4;
+      }
+    }
+
+    if (kept.trim() === '' && line.trim() !== '') continue;
+    result.push(kept);
+  }
+
+  if (inComment) {
+    warnings.push('unclosed <!-- comment --> — content stripped to end of file');
+  }
+
+  const text = result.join('\n');
+  return warnings.length > 0 ? { text, warnings } : text;
+}
+
 // Strip a single leading H1 from the markdown body. Templates inject their own H1
 // from the page title, so the author's `# Title` line at the top would render as a duplicate.
 function stripLeadingH1(markdown) {
@@ -195,24 +257,78 @@ function renderRelationships(frontmatter, linkMap, currentOutputPath) {
 
 const IMAGE_EXT_REGEX = /\.(jpe?g|png|webp|gif|svg)$/i;
 
-function resolveImageEmbeds(markdown, imageMap, currentOutputPath, usedImages) {
+// Percent-encode each path segment. A destination containing a raw space — which vault
+// attachments routinely do ("Chrome Jockey.png") — is not a valid markdown link, so
+// markdown-it emits the whole `![alt](path)` as literal text and the typographer then
+// rewrites the leading `../` into a `…/` ellipsis. Parens are encoded too: markdown-it
+// only tolerates balanced ones inside a destination.
+function encodeImageUrl(imagePath) {
+  return String(imagePath)
+    .split('/')
+    .map(segment => encodeURIComponent(segment).replace(/\(/g, '%28').replace(/\)/g, '%29'))
+    .join('/');
+}
+
+function resolveImageEmbeds(markdown, imageMap, currentOutputPath, usedImages, options = {}) {
+  // The entity's `portrait:` frontmatter. An inline embed of the same file exists so the
+  // image shows in Obsidian's reading view; on the site the portrait already displays it,
+  // so the inline copy is dropped rather than duplicated.
+  //
+  // Safe because every entity template renders `portrait:` (world-domain.js was the last
+  // holdout). A new template that skips the portrait must not be given a portraitBasename.
+  const portrait = options.portraitBasename;
+  const dedupeBasename = portrait && imageMap[portrait] ? portrait.toLowerCase() : null;
+
   // Match ![[filename.ext]] or ![[filename.ext|alt text]]
   return markdown.replace(/!\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]/g, (match, target, alt) => {
     const basename = target.trim();
     if (!IMAGE_EXT_REGEX.test(basename)) return match; // not an image, leave as-is
 
     const entry = imageMap[basename];
-    if (!entry) return `<!-- image not found: ${basename} -->`;
+    if (!entry) {
+      console.warn(`processor: image embed not found — "${basename}" (${currentOutputPath})`);
+      return '';
+    }
 
     if (usedImages) usedImages.add(basename);
+    if (dedupeBasename && basename.toLowerCase() === dedupeBasename) return '';
 
     // Output goes to docs/images/{relPath}. Compute relative path from current page.
     const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));
     const imgPath = 'images/' + entry.relPath;
-    const relativeImgPath = relativePath(currentDir, imgPath);
-    const altText = alt || basename.replace(IMAGE_EXT_REGEX, '').replace(/[-_]/g, ' ');
+    const relativeImgPath = encodeImageUrl(relativePath(currentDir, imgPath));
+    const rawAlt = alt || basename.replace(IMAGE_EXT_REGEX, '').replace(/[-_]/g, ' ');
+    const altText = rawAlt.replace(/[[\]]/g, '\\$&');
     return `![${altText}](${relativeImgPath})`;
   });
+}
+
+// Render a frontmatter-derived display value (summary, occupation, …) as HTML, resolving
+// any `[[wikilink]]` it carries the way body prose does. Everything else is escaped.
+function renderMetaValue(raw, linkMap = {}, currentOutputPath = '') {
+  const text = String(raw == null ? '' : raw);
+  const out = [];
+  const pattern = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+  let last = 0;
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    out.push(escapeHtml(text.slice(last, match.index)));
+    const { target, label } = parseWikiRef(match[0]);
+    const targetPath = linkMap[target];
+    out.push(targetPath
+      ? `<a href="${relativeHref(currentOutputPath, targetPath)}" class="entity-link">${escapeHtml(label)}</a>`
+      : escapeHtml(label));
+    last = match.index + match[0].length;
+  }
+  out.push(escapeHtml(text.slice(last)));
+  return out.join('');
+}
+
+// Plain-text form of the above, for values rendered inside an enclosing <a> (card
+// subtitles, landing tiles) where a nested anchor would be invalid HTML.
+function plainMetaValue(raw) {
+  return String(raw == null ? '' : raw)
+    .replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (m) => parseWikiRef(m).label);
 }
 
 function separateBoldLabelLines(markdown) {
@@ -233,6 +349,20 @@ function separateBoldLabelLines(markdown) {
   return result.join('\n');
 }
 
+// A page's reader-visible source: the gm-only/spoiler/excluded-section-stripped view that
+// build.js precomputes, falling back to raw markdown for pages it never saw (story units,
+// test doubles). Everything derived from prose — backlinks, search, recency, excerpts —
+// must read through this, or unpublished content leaks into a derived widget (B6).
+function publishedSource(page) {
+  if (!page) return '';
+  return page.publishedMarkdown != null ? page.publishedMarkdown : (page.markdown || '');
+}
+
+function portraitBasename(frontmatter) {
+  const portrait = frontmatter && frontmatter.portrait;
+  return portrait ? String(portrait).split('/').pop() : null;
+}
+
 function processContent(page, linkMap, excludeSections, imageMap = {}, options = {}) {
   let markdown = page.markdown.replace(/\r/g, '');
   const warnings = [];
@@ -251,10 +381,19 @@ function processContent(page, linkMap, excludeSections, imageMap = {}, options =
   } else {
     markdown = spoilerResult;
   }
+  const commentResult = stripHtmlComments(markdown);
+  if (commentResult.warnings) {
+    warnings.push(...commentResult.warnings);
+    markdown = commentResult.text;
+  } else {
+    markdown = commentResult;
+  }
   markdown = stripLeadingH1(markdown);
   markdown = filterSections(markdown, excludeSections);
   markdown = separateBoldLabelLines(markdown);
-  markdown = resolveImageEmbeds(markdown, imageMap, page.outputPath, options.usedImages);
+  markdown = resolveImageEmbeds(markdown, imageMap, page.outputPath, options.usedImages, {
+    portraitBasename: portraitBasename(page.frontmatter),
+  });
   markdown = resolveWikiLinks(markdown, linkMap, page.outputPath);
   const html = md.render(markdown);
   const relationships = renderRelationships(page.frontmatter, linkMap, page.outputPath);
@@ -295,4 +434,4 @@ function filterFields(frontmatter, excludeFields = [], overrides = {}) {
   return filtered;
 }
 
-module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, filterFields };
+module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields };

--- a/tools/publish/lib/recency.js
+++ b/tools/publish/lib/recency.js
@@ -1,3 +1,4 @@
+const { publishedSource } = require('./processor');
 const WIKI_LINK_RE = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 const TERMINAL_STATUSES = new Set(['dead', 'deceased', 'destroyed', 'kia', 'dissolved']);
 // A session counts as "played" once it has been run — including the post-wrap-up, pre-reconcile
@@ -6,10 +7,7 @@ const PLAYED_STATUSES = new Set(['played', 'reviewed', 'wrap-up']);
 
 // Mentions/recency must reflect only what readers can see, so prefer each page's published
 // view (gm-only + excluded sections stripped) over its raw markdown when available (B6).
-function publishedText(page) {
-  if (!page) return '';
-  return page.publishedMarkdown != null ? page.publishedMarkdown : (page.markdown || '');
-}
+const publishedText = publishedSource;
 
 function extractMentions(markdown) {
   const mentions = new Set();

--- a/tools/publish/lib/search-index.js
+++ b/tools/publish/lib/search-index.js
@@ -1,3 +1,4 @@
+const { publishedSource } = require('./processor');
 const lunr = require('lunr');
 
 function stripMarkdown(md) {
@@ -17,10 +18,7 @@ function getSubtitle(fm) {
 
 // Search results must reflect only what readers can see, so prefer each page's published
 // view (gm-only + spoiler content stripped) over its raw markdown when available.
-function publishedText(page) {
-  if (!page) return '';
-  return page.publishedMarkdown != null ? page.publishedMarkdown : (page.markdown || '');
-}
+const publishedText = publishedSource;
 
 function buildSearchIndex(pages) {
   const documents = {};

--- a/tools/publish/lib/story-spine.js
+++ b/tools/publish/lib/story-spine.js
@@ -1,14 +1,11 @@
 const path = require('path');
-const { extractSections, parseWikiRef, resolveWikiLinks } = require('./processor');
+const { extractSections, parseWikiRef, resolveWikiLinks, publishedSource } = require('./processor');
 const { slugify } = require('./scanner');
 
 const RECAP_TITLES = ['narrative recap', 'recap'];
 
 // The gm-only/excluded-stripped view if present (set by build.js), else raw markdown.
-function publishedOf(page) {
-  if (!page) return '';
-  return page.publishedMarkdown != null ? page.publishedMarkdown : (page.markdown || '');
-}
+const publishedOf = publishedSource;
 
 // Find the recap section of a page. Returns { title, html } or null.
 // Heading match is a case-insensitive CONTAINS, because real vaults decorate the title

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -1,7 +1,10 @@
-const { relativePath, escapeHtml } = require('../processor');
+const { relativePath, escapeHtml, encodeImageUrl } = require('../processor');
 
 const DIR_LABELS = {
   'campaign': 'Campaign',
+  // Aggregate index over PCs + NPCs. The landing page's "Characters" card targets it, and
+  // the two sub-indexes below still get their own pages.
+  'characters': 'Characters',
   'characters/pcs': 'Player Characters',
   'characters/npcs': 'NPCs',
   'factions': 'Factions & Organizations',
@@ -165,7 +168,10 @@ function portraitImg(frontmatter, outputPath, imageMap, attachmentsDir) {
 
   const currentDir = outputPath.substring(0, outputPath.lastIndexOf('/'));
   const imgPath = 'images/' + relPath;
-  const relativeImgPath = relativePath(currentDir, imgPath);
+  // Attachment filenames routinely carry spaces and non-ASCII ("Vita Ó Taidhg.png"), which
+  // are not valid in a URL. Templates that lift this src back out of the tag (hero banners)
+  // inherit the encoding.
+  const relativeImgPath = encodeImageUrl(relativePath(currentDir, imgPath));
   const alt = escapeHtml(frontmatter.aliases?.[0] || basename.replace(/\.[^.]+$/, ''));
   return `<img src="${relativeImgPath}" alt="${alt}" class="portrait">`;
 }

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -1,4 +1,4 @@
-const { parseTableRows, findSectionByTitle, extractSubsectionHtml } = require('./tables');
+const { parseTableRows, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings } = require('./tables');
 const { splitMarkers, stripCost } = require('./render');
 
 const PRIMARY = ['ST', 'DX', 'IQ', 'HT'];
@@ -158,7 +158,7 @@ function parseSkills(model, sections, fm) {
   }
   const sec = findSectionByTitle(sections, 'skills');
   if (!sec) return;
-  const rows = parseTableRows(sec.html);
+  const rows = parseTableRows(topLevelHtml(sec.html));
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = header.findIndex(h => h.includes('name')) >= 0
     ? header.findIndex(h => h.includes('name')) : 0;
@@ -387,7 +387,7 @@ function parseSpells(model, sections, fm) {
   }
   const sec = findSectionByTitle(sections, 'spells');
   if (!sec) return;
-  const rows = parseTableRows(sec.html);
+  const rows = parseTableRows(topLevelHtml(sec.html));
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = Math.max(0, header.findIndex(h => h.includes('name')));
   const { iLevel } = resolveLevelColumns(header);
@@ -567,7 +567,7 @@ function parseTechniques(model, sections, fm) {
   }
   const sec = findSectionByTitle(sections, 'techniques');
   if (!sec) return;
-  const rows = parseTableRows(sec.html);
+  const rows = parseTableRows(topLevelHtml(sec.html));
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = header.findIndex(h => h.includes('name')) >= 0
     ? header.findIndex(h => h.includes('name')) : 0;
@@ -673,8 +673,9 @@ function parseEquipment(model, sections, fm) {
   const sec = findSectionByTitle(sections, 'equipment');
   if (sec) {
     // Restrict to HTML before the first <h3> so ### Encumbrance / ### Load-Outs rows
-    // are not flattened into the item list.
-    const topHtml = sec.html.split(/<h3[ >]/i)[0];
+    // are not flattened into the item list. No topLevelHtml() fallback here: those
+    // subsections hold real tables that must never be read as items.
+    const topHtml = aboveSubheadings(sec.html);
     const rows = parseTableRows(topHtml);
     const header = (rows[0] || []).map(h => h.toLowerCase());
     const idx = n => header.findIndex(h => h.includes(n));

--- a/tools/publish/lib/templates/gurps/tables.js
+++ b/tools/publish/lib/templates/gurps/tables.js
@@ -14,6 +14,23 @@ function parseTableRows(html) {
   return rows;
 }
 
+// The part of a section that precedes its first `### ` subheading.
+function aboveSubheadings(sectionHtml) {
+  return String(sectionHtml || '').split(/<h3[ >]/i)[0];
+}
+
+// A section's own tables. Sheets keep descriptive helper tables under `###` subheadings;
+// those carry a foreign column schema and must not be flattened into the machine-readable
+// table. Falls back to the whole section when nothing above the first subheading holds a
+// table, so a sheet whose only table sits under a `###` still parses.
+//
+// Not for Equipment: its `### Load-Outs` / `### Encumbrance` subsections hold real tables
+// that must never be read as items, so it wants aboveSubheadings() with no fallback.
+function topLevelHtml(sectionHtml) {
+  const top = aboveSubheadings(sectionHtml);
+  return /<table[ >]/i.test(top) ? top : sectionHtml;
+}
+
 function findSectionByTitle(sections, ...titles) {
   const lower = titles.map(t => t.toLowerCase());
   return sections.find(s => lower.includes(s.title.toLowerCase()));
@@ -33,4 +50,4 @@ function extractSubsectionHtml(sectionHtml, subsectionTitle) {
   return match ? match[1] : '';
 }
 
-module.exports = { parseTableRows, findSectionByTitle, extractSubsectionHtml };
+module.exports = { parseTableRows, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings };

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -1,6 +1,6 @@
-const MarkdownIt = require('markdown-it');
-const mdRenderer = new MarkdownIt({ html: false, typographer: true });
-const { escapeHtml, relativePath, resolveWikiLinks } = require('../processor');
+const { createRenderer } = require('../markdown');
+const mdRenderer = createRenderer();
+const { escapeHtml, relativePath, resolveWikiLinks, renderMetaValue, plainMetaValue } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg, getCanonStatus } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
@@ -573,7 +573,7 @@ function sessionSortKey(str) {
   return m ? Number(m[1]) : 0;
 }
 
-function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachments') {
+function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachments', linkMap = {}) {
   const sorted = pages
     .filter(p => p.frontmatter.type === 'npc')
     .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle));
@@ -620,7 +620,7 @@ function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachment
 
     return `<tr data-entity-type="npc" data-entity-name="${escapeHtml(p.displayTitle)}" data-entity-status="${escapeHtml(status)}" data-session="${escapeHtml(lastSession)}">
   <td data-sort="${escapeHtml(p.displayTitle.toLowerCase())}"><a class="npc-row-link" href="${escapeHtml(relHref(p, dir))}">${avatarHtml}${escapeHtml(p.displayTitle)}</a></td>
-  <td>${escapeHtml(occupation)}</td>
+  <td>${renderMetaValue(occupation, linkMap, dir + '/index.html')}</td>
   <td><span class="status-badge status-${escapeHtml(status.replace(/\s+/g, '-').toLowerCase())}">${escapeHtml(status ? status.charAt(0).toUpperCase() + status.slice(1) : '')}</span></td>
   <td>${escapeHtml(firstApp)}</td>
   <td data-sort="${sessionSortKey(lastSession)}">${escapeHtml(lastSession)}</td>
@@ -682,7 +682,7 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
 
   let bodyContent;
   if (isNPCs) {
-    bodyContent = renderNPCTable(pages, dir, imageMap, attachmentsDir);
+    bodyContent = renderNPCTable(pages, dir, imageMap, attachmentsDir, (publishConfig || {})._linkMap || {});
   } else if (isChapters) {
     bodyContent = renderChapterList(pages, dir);
   } else if (isCreatures) {
@@ -708,7 +708,9 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
       const portraitHtml = isCharacters && cardImg
         ? `<div class="npc-icon" style="${avatarShape}">${cardImg}</div>`
         : '';
-      const subtitle = fm.occupation || fm.location_type || fm.faction_type || fm.factionType || '';
+      // Plain text, not renderMetaValue: this sits inside the enclosing <a class="entity-card">,
+      // where a resolved wikilink would nest one anchor inside another.
+      const subtitle = plainMetaValue(fm.occupation || fm.location_type || fm.faction_type || fm.factionType || '');
       return `<a class="entity-card" href="${escapeHtml(relHref(p, dir))}"
   data-entity-type="${escapeHtml(entityType || '')}"
   data-entity-name="${escapeHtml(p.displayTitle)}"

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -573,6 +573,18 @@ function sessionSortKey(str) {
   return m ? Number(m[1]) : 0;
 }
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}/;
+
+// The session an entity's state was confirmed accurate as of. Never falls back to
+// `lastUpdated`: that is a maintenance timestamp the tool writes into its own templates,
+// and reading it back as a session put bare dates in the "filter by session" dropdown and
+// sorted them against `Session N`. A date written directly into asOfSession is rejected for
+// the same reason. An entity with no session simply isn't session-filterable.
+function sessionRef(frontmatter) {
+  const value = cleanRef(frontmatter.asOfSession);
+  return ISO_DATE_RE.test(value) ? '' : value;
+}
+
 function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachments', linkMap = {}) {
   const sorted = pages
     .filter(p => p.frontmatter.type === 'npc')
@@ -584,7 +596,7 @@ function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachment
   const sessionPills = new Set();
   for (const p of sorted) {
     if (p.frontmatter.status) statusPills.add(p.frontmatter.status);
-    const session = cleanRef(p.frontmatter.asOfSession || p.frontmatter.lastUpdated || '');
+    const session = sessionRef(p.frontmatter);
     if (session) sessionPills.add(session);
   }
 
@@ -611,7 +623,7 @@ function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachment
     const occupation = fm.occupation || '';
     const status = fm.status || '';
     const firstApp = cleanRef(fm.first_appearance || '');
-    const lastSession = cleanRef(fm.asOfSession || fm.lastUpdated || '');
+    const lastSession = sessionRef(fm);
     const canonStatus = getCanonStatus(fm) || '';
     const avatar = portraitImg(fm, dir + '/index.html', imageMap, attachmentsDir);
     const avatarHtml = avatar
@@ -637,7 +649,7 @@ function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachment
   <th data-sort-col="occupation">Role</th>
   <th data-sort-col="status">Status</th>
   <th data-sort-col="first">First Appearance</th>
-  <th data-sort-col="session">Last Updated</th>
+  <th data-sort-col="session">As of Session</th>
   <th data-sort-col="canon">Canon Status</th>
 </tr>
 </thead>

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -1,4 +1,4 @@
-const { escapeHtml } = require('../processor');
+const { escapeHtml, plainMetaValue } = require('../processor');
 const { baseShell, cssPath, rootPath, DIR_LABELS, portraitImg, canonStatusBadge, clientScripts } = require('./base');
 const {
   getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs,
@@ -111,7 +111,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
       const portraitHtml = portraitTag
         ? `<div class="pc-portrait">${portraitTag}</div>`
         : `<div class="pc-portrait">${escapeHtml(initials)}</div>`;
-      const occupation = fm.occupation ? `<div class="pc-traits">${escapeHtml(fm.occupation)}</div>` : '';
+      const occupation = fm.occupation ? `<div class="pc-traits">${escapeHtml(plainMetaValue(fm.occupation))}</div>` : '';
       const traits = fm.key_traits
         ? `<div class="pc-traits">${escapeHtml(Array.isArray(fm.key_traits) ? fm.key_traits.join(', ') : String(fm.key_traits))}</div>`
         : '';
@@ -154,7 +154,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
       const iconHtml = portraitTag
         ? `<div class="npc-icon">${portraitTag}</div>`
         : `<div class="npc-icon">${escapeHtml(initials)}</div>`;
-      const role = fm.occupation ? `<div class="npc-role">${escapeHtml(fm.occupation)}</div>` : '';
+      const role = fm.occupation ? `<div class="npc-role">${escapeHtml(plainMetaValue(fm.occupation))}</div>` : '';
       return `<a class="npc-card" href="${escapeHtml(page.outputPath)}">
   ${iconHtml}
   <div><h4>${escapeHtml(page.displayTitle)}</h4>${role}</div>

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativeHref, parseWikiRef } = require('../processor');
+const { escapeHtml, relativeHref, parseWikiRef, publishedSource } = require('../processor');
 const { baseShell, cssPath, rootPath, canonStatusBadge, portraitImg, clientScripts } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
@@ -56,9 +56,8 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   }
 
   // --- Zone 2: Atmosphere pull-quote ---
-  const pullQuote = processedContent.html
-    ? `<div class="pull-quote">${excerptFromMarkdown(processedContent.html)}</div>`
-    : '';
+  const quoteText = excerptFromMarkdown(publishedSource(page));
+  const pullQuote = quoteText ? `<div class="pull-quote">${escapeHtml(quoteText)}</div>` : '';
 
   // --- Zone 3: Body content ---
   const bodyContent = processedContent.html || '';
@@ -71,8 +70,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   if (childLocations.length > 0) {
     const cards = childLocations.map(child => {
       const href = relativeHref(page.outputPath, child.outputPath);
-      const excerpt = excerptFromMarkdown(
-        child.publishedMarkdown != null ? child.publishedMarkdown : (child.markdown || ''),
+      const excerpt = excerptFromMarkdown(publishedSource(child),
         { excludeSections: (publishConfig && publishConfig.exclude_sections) || [] });
       return `<a class="entity-card" href="${href}">
   <h4>${escapeHtml(child.displayTitle)}</h4>

--- a/tools/publish/lib/templates/nav.js
+++ b/tools/publish/lib/templates/nav.js
@@ -24,14 +24,19 @@ const NAV_GROUPS = [
   },
 ];
 
-function generateNavGroups(pages) {
+function generateNavGroups(pages, options = {}) {
   const populated = new Set();
   for (const page of pages) {
     populated.add(page.outputDir);
   }
 
   const pcRoster = pages.find(p => p.frontmatter && p.frontmatter.type === 'pc_roster');
-  const overrides = { events: 'timeline.html' };
+  // Only aim the Events link at the timeline when a timeline page is actually written, and
+  // at wherever it is written. The timeline is generated at the root only when dated events
+  // exist; otherwise it may be an authored page under its own folder — or absent, in which
+  // case Events falls through to its own index.
+  const overrides = {};
+  if (options.timelineHref) overrides.events = options.timelineHref;
   if (pcRoster) overrides['characters/pcs'] = pcRoster.outputPath;
 
   return NAV_GROUPS
@@ -54,7 +59,7 @@ function generateNavGroups(pages) {
 }
 
 function renderTopNav(pages, currentOutputPath, config, options = {}) {
-  const groups = generateNavGroups(pages);
+  const groups = generateNavGroups(pages, options);
   const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));
 
   const hasStoryGroup = groups.some(g => g.name === 'Story');

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativeHref } = require('../processor');
+const { escapeHtml, relativeHref, renderMetaValue, publishedSource } = require('../processor');
 const { baseShell, cssPath, rootPath, canonStatusBadge, portraitImg, clientScripts } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
@@ -16,11 +16,12 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
   // --- Zone 1: Portrait header banner ---
   const hasPortrait = fm.portrait && imageMap && imageMap[String(fm.portrait).split('/').pop()];
   const metaParts = [];
-  if (fm.occupation) metaParts.push(`<span><span class="label">Role</span> ${escapeHtml(fm.occupation)}</span>`);
-  if (fm.nationality) metaParts.push(`<span><span class="label">Nationality</span> ${escapeHtml(fm.nationality)}</span>`);
+  const meta = v => renderMetaValue(v, linkMap || {}, page.outputPath);
+  if (fm.occupation) metaParts.push(`<span><span class="label">Role</span> ${meta(fm.occupation)}</span>`);
+  if (fm.nationality) metaParts.push(`<span><span class="label">Nationality</span> ${meta(fm.nationality)}</span>`);
   if (fm.status) metaParts.push(`<span><span class="label">Status</span> ${escapeHtml(fm.status)}</span>`);
   if (fm.age) metaParts.push(`<span><span class="label">Age</span> ${escapeHtml(String(fm.age))}</span>`);
-  if (fm.rank) metaParts.push(`<span><span class="label">Rank</span> ${escapeHtml(fm.rank)}</span>`);
+  if (fm.rank) metaParts.push(`<span><span class="label">Rank</span> ${meta(fm.rank)}</span>`);
   const metaHtml = metaParts.join('\n');
 
   let heroBanner;
@@ -45,9 +46,11 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
   }
 
   // --- Zone 2: First impression quote ---
-  const pullQuote = processedContent.html
-    ? `<div class="pull-quote">${excerptFromMarkdown(processedContent.html)}</div>`
-    : '';
+  // Excerpt from the published markdown, not the rendered HTML: the source already has
+  // gm-only blocks and excluded sections cut, and taking prose from markdown avoids
+  // re-parsing the renderer's own output to find the sentence.
+  const quoteText = excerptFromMarkdown(publishedSource(page));
+  const pullQuote = quoteText ? `<div class="pull-quote">${escapeHtml(quoteText)}</div>` : '';
 
   // --- Zone 3: Body content ---
   const bodyContent = processedContent.html || '';

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath, relativeHref } = require('../processor');
+const { escapeHtml, relativePath, relativeHref, publishedSource } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
@@ -171,8 +171,9 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
   if (fm.key_traits) {
     const traitsText = Array.isArray(fm.key_traits) ? fm.key_traits.join(', ') : String(fm.key_traits);
     epithet = `<div class="pull-quote">${escapeHtml(traitsText)}</div>`;
-  } else if (processedContent.html) {
-    epithet = `<div class="pull-quote">${excerptFromMarkdown(processedContent.html)}</div>`;
+  } else {
+    const quoteText = excerptFromMarkdown(publishedSource(page));
+    if (quoteText) epithet = `<div class="pull-quote">${escapeHtml(quoteText)}</div>`;
   }
 
   // Read system HTML before filtering so the filter can react to what was actually rendered.

--- a/tools/publish/lib/templates/world-domain.js
+++ b/tools/publish/lib/templates/world-domain.js
@@ -1,26 +1,32 @@
-const { escapeHtml } = require('../processor');
-const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge } = require('./base');
+const { escapeHtml, renderMetaValue } = require('../processor');
+const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge, portraitImg } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 
-function worldDomainTemplate(page, processedContent, navFor, config, context) {
+function worldDomainTemplate(page, processedContent, navFor, config, imageMap, context) {
   const fm = page.frontmatter;
   const publishConfig = (context || {}).publishConfig || {};
+  const linkMap = (context || {}).linkMap || publishConfig._linkMap || {};
+  const meta = v => renderMetaValue(v, linkMap, page.outputPath);
 
   let rulesSidebar = '';
   const publishRules = fm.publish_rules !== false;
   if (publishRules && fm.rules && Array.isArray(fm.rules) && fm.rules.length > 0) {
     const rulesHtml = fm.rules.map(r => {
-      const desc = escapeHtml(r.rule || r.id || '');
+      const desc = meta(r.rule || r.id || '');
       return `<li>${desc}</li>`;
     }).join('\n');
     rulesSidebar = `<aside class="world-rules-sidebar"><h3>World Rules</h3><ul>${rulesHtml}</ul></aside>`;
   }
 
   const summaryHtml = fm.summary
-    ? `<p class="world-domain-summary">${escapeHtml(fm.summary)}</p>`
+    ? `<p class="world-domain-summary">${meta(fm.summary)}</p>`
     : '';
 
-  const headerHtml = `<h1>${escapeHtml(page.displayTitle)}${canonStatusBadge(fm)}</h1>${summaryHtml}`;
+  // Render `portrait:` like every other entity template. That invariant is what lets the
+  // processor safely drop an inline embed of the same image as a duplicate (#88).
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+
+  const headerHtml = `<h1>${escapeHtml(page.displayTitle)}${canonStatusBadge(fm)}</h1>${summaryHtml}${portrait}`;
 
   const crumbs = generateBreadcrumbs(page.outputPath, {});
   const breadcrumbsHtml = renderBreadcrumbs(crumbs);

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/fixtures/authored-timeline/Events/Undated Event.md
+++ b/tools/publish/test/fixtures/authored-timeline/Events/Undated Event.md
@@ -1,0 +1,8 @@
+---
+type: event
+event_type: Battle
+---
+
+# Undated Event
+
+An event with no date, so no root timeline is generated for it.

--- a/tools/publish/test/fixtures/authored-timeline/_Campaign/Timeline.md
+++ b/tools/publish/test/fixtures/authored-timeline/_Campaign/Timeline.md
@@ -1,0 +1,7 @@
+---
+type: timeline
+---
+
+# Timeline
+
+The hand-authored campaign timeline.

--- a/tools/publish/test/fixtures/minimal/Locations/Test Location.md
+++ b/tools/publish/test/fixtures/minimal/Locations/Test Location.md
@@ -6,4 +6,9 @@ security_level: Low
 
 # Test Location
 
+<!-- UNVERIFIED: needs GM confirmation before this reaches players. -->
+
 A test location.
+
+> [!info] Reconstruction Note
+> The record here is partial.

--- a/tools/publish/test/fixtures/no-timeline/Events/Undated Event.md
+++ b/tools/publish/test/fixtures/no-timeline/Events/Undated Event.md
@@ -1,0 +1,8 @@
+---
+type: event
+event_type: Battle
+---
+
+# Undated Event
+
+No dates anywhere, and no authored timeline page.

--- a/tools/publish/test/fixtures/with-manifest/_meta/publish-manifest.md
+++ b/tools/publish/test/fixtures/with-manifest/_meta/publish-manifest.md
@@ -11,7 +11,8 @@ needs_decision: 0
 ## Publishing (2 files)
 
 - [x] Characters/NPCs/Public NPC.md
-- [x] Locations/Tavern.md
+- [x] Locations/Tavern.md — the party's home base (inline comments must not blackhole a page)
+- [x] Locations/Typo In This Path.md
 
 ## Excluded (2 files)
 

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -648,6 +648,95 @@ describe('build integration', () => {
     });
   });
 
+  describe('minimal fixture — regressions', () => {
+    let outputDir;
+    let configPath;
+
+    before(() => {
+      outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-regress-'));
+      configPath = path.join(outputDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath: path.join(fixturesDir, 'minimal'),
+        outputDir: path.join(outputDir, 'docs'),
+        attachmentsDir: '_attachments',
+        siteTitle: 'Regression Test',
+        siteUrl: 'https://example.github.io/t',
+        excludeDirs: ['_meta'],
+        excludeSections: [],
+        folderMap: {
+          '_Campaign': 'campaign',
+          'Characters/PCs': 'characters/pcs',
+          'Characters/NPCs': 'characters/npcs',
+          'Locations': 'locations',
+        },
+      }, null, 2));
+      build({ configPath });
+    });
+
+    after(() => {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    });
+
+    it('generates the aggregate characters index the homepage card links to (issue #84)', () => {
+      const indexPath = path.join(outputDir, 'docs', 'characters', 'index.html');
+      assert.ok(fs.existsSync(indexPath), 'characters/index.html must exist');
+      const html = fs.readFileSync(indexPath, 'utf-8');
+      assert.ok(html.includes('Test PC'), 'aggregate index lists PCs');
+      assert.ok(html.includes('Test NPC'), 'aggregate index lists NPCs');
+
+      const landing = fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
+      if (landing.includes('href="characters/index.html"')) {
+        assert.ok(fs.existsSync(indexPath), 'homepage Characters card must not dangle');
+      }
+    });
+
+    it('strips HTML comments instead of printing them (issue #85)', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'locations', 'test-location.html'), 'utf-8');
+      assert.ok(!html.includes('UNVERIFIED'), 'private authoring note must not reach the page');
+      assert.ok(!html.includes('&lt;!--'));
+      assert.ok(html.includes('A test location.'));
+    });
+
+    it('renders Obsidian callouts as callouts (issue #86a)', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'locations', 'test-location.html'), 'utf-8');
+      assert.ok(html.includes('class="callout callout-info"'));
+      assert.ok(html.includes('<div class="callout-title">Reconstruction Note</div>'));
+      assert.ok(!html.includes('[!info]'));
+    });
+  });
+
+  describe('manifest publishing backstop (issue #80)', () => {
+    it('warns when a Publishing entry matches no scanned page', () => {
+      const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-warn-'));
+      const configPath = path.join(outputDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath: path.join(fixturesDir, 'with-manifest'),
+        outputDir: path.join(outputDir, 'docs'),
+        attachmentsDir: '_attachments',
+        siteTitle: 'Manifest Warn',
+        siteUrl: 'https://example.github.io/t',
+        excludeDirs: ['_meta'],
+        excludeSections: [],
+        folderMap: { 'Characters/NPCs': 'characters/npcs', Locations: 'locations', Sessions: 'sessions' },
+      }, null, 2));
+
+      const warnings = [];
+      const realWarn = console.warn;
+      console.warn = (...args) => warnings.push(args.join(' '));
+      try {
+        build({ configPath });
+      } finally {
+        console.warn = realWarn;
+        fs.rmSync(outputDir, { recursive: true, force: true });
+      }
+
+      assert.ok(warnings.some(w => w.includes('Locations/Typo In This Path.md') && w.includes('no such page was scanned')),
+        `expected an unmatched-entry warning, got: ${JSON.stringify(warnings)}`);
+      assert.ok(!warnings.some(w => w.includes('Locations/Tavern.md')),
+        'an annotated but valid entry must not warn');
+    });
+  });
+
   describe('with-manifest fixture', () => {
     let outputDir;
     let configPath;
@@ -1285,6 +1374,58 @@ describe('build integration', () => {
       const html = fs.readFileSync(indexPath, 'utf-8');
       assert.ok(html.includes('AUTHORED_WORLD_INDEX_MARKER_9f3c'));
       assert.ok(!html.includes('class="card-grid"'));
+    });
+  });
+  describe('timeline target (issue #83)', () => {
+    function buildFixture(fixture, folderMap) {
+      const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-timeline-'));
+      const configPath = path.join(outputDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath: path.join(fixturesDir, fixture),
+        outputDir: path.join(outputDir, 'docs'),
+        attachmentsDir: '_attachments',
+        siteTitle: 'Timeline Test',
+        siteUrl: 'https://example.github.io/t',
+        excludeDirs: ['_meta'],
+        excludeSections: [],
+        folderMap,
+      }, null, 2));
+      build({ configPath });
+      return path.join(outputDir, 'docs');
+    }
+
+    it('aims nav and the events redirect at an authored timeline, not a root one that is never written', () => {
+      const docs = buildFixture('authored-timeline', { Events: 'events', _Campaign: 'campaign' });
+      try {
+        assert.ok(!fs.existsSync(path.join(docs, 'timeline.html')),
+          'no dated events, so no root timeline should be generated');
+        assert.ok(fs.existsSync(path.join(docs, 'campaign', 'timeline.html')));
+
+        const eventPage = fs.readFileSync(path.join(docs, 'events', 'undated-event.html'), 'utf-8');
+        assert.ok(eventPage.includes('href="../campaign/timeline.html"'));
+        assert.ok(!eventPage.includes('href="../timeline.html"'));
+
+        const redirect = fs.readFileSync(path.join(docs, 'events', 'index.html'), 'utf-8');
+        assert.ok(redirect.includes('url=../campaign/timeline.html'));
+      } finally {
+        fs.rmSync(path.dirname(docs), { recursive: true, force: true });
+      }
+    });
+
+    it('gives events a real index when there is no timeline at all', () => {
+      const docs = buildFixture('no-timeline', { Events: 'events' });
+      try {
+        assert.ok(!fs.existsSync(path.join(docs, 'timeline.html')));
+        const index = fs.readFileSync(path.join(docs, 'events', 'index.html'), 'utf-8');
+        assert.ok(!index.includes('http-equiv="refresh"'), 'should not redirect to a missing timeline');
+        assert.ok(index.includes('Undated Event'));
+
+        const eventPage = fs.readFileSync(path.join(docs, 'events', 'undated-event.html'), 'utf-8');
+        assert.ok(eventPage.includes('href="index.html"'), 'nav Events should point at the events index');
+        assert.ok(!eventPage.includes('timeline.html'));
+      } finally {
+        fs.rmSync(path.dirname(docs), { recursive: true, force: true });
+      }
     });
   });
 });

--- a/tools/publish/test/unit/excerpt.test.js
+++ b/tools/publish/test/unit/excerpt.test.js
@@ -112,3 +112,56 @@ describe('excerptFromMarkdown', () => {
     assert.ok(!out.includes('construct'), 'must not leak excluded content');
   });
 });
+
+describe('excerptFromMarkdown sanitization (issue #87)', () => {
+  it('drops HTML heading elements rather than leaking their text', () => {
+    const html = '<h2>Overview</h2>\n<p>A charted dead-end. More.</p>';
+    assert.strictEqual(excerptFromMarkdown(html), 'A charted dead-end.');
+  });
+
+  it('drops rendered image tags', () => {
+    const html = '<p><img src="../images/Thides System.png" alt="Thides System"> A dead-end star. More.</p>';
+    assert.strictEqual(excerptFromMarkdown(html), 'A dead-end star.');
+  });
+
+  it('drops raw image markdown', () => {
+    const md = '## Overview\n\n![Thides System](../images/Thides System.png)\n\nA charted dead-end. More.';
+    assert.strictEqual(excerptFromMarkdown(md), 'A charted dead-end.');
+  });
+
+  it('drops unresolved Obsidian image embeds', () => {
+    assert.strictEqual(excerptFromMarkdown('![[Thides.png]]\n\nA dead-end. More.'), 'A dead-end.');
+  });
+
+  it('drops HTML comments, including a truncated one', () => {
+    const html = '<p>Points of Interest.</p>\n&lt;!-- mobRPG changed this entity';
+    assert.strictEqual(excerptFromMarkdown(html), 'Points of Interest.');
+    assert.strictEqual(excerptFromMarkdown('<!-- note -->\nReal prose. More.'), 'Real prose.');
+  });
+
+  it('drops a callout marker line, title included', () => {
+    const md = '> [!warning] DRAFT — player-side backstory\n\nMarek is the man they send. More.';
+    assert.strictEqual(excerptFromMarkdown(md), 'Marek is the man they send.');
+  });
+
+  it('drops a rendered callout title', () => {
+    const html = '<div class="callout callout-warning"><div class="callout-title">DRAFT</div>'
+      + '<p>Marek is the man they send. More.</p></div>';
+    assert.strictEqual(excerptFromMarkdown(html), 'Marek is the man they send.');
+  });
+
+  it('de-links a wikilink anchor without leaving a stray space', () => {
+    const html = '<p><a href="x.html">Shackleton Magellan</a>’s enemy walks in. More.</p>';
+    assert.strictEqual(excerptFromMarkdown(html), 'Shackleton Magellan’s enemy walks in.');
+  });
+
+  it('does not fuse adjacent paragraphs into one word', () => {
+    const html = '<p>One</p><p>Two. Three.</p>';
+    assert.strictEqual(excerptFromMarkdown(html), 'One Two.');
+  });
+
+  it('drops rendered tables', () => {
+    const html = '<table><tr><td>Str</td><td>12</td></tr></table><p>Real prose. More.</p>';
+    assert.strictEqual(excerptFromMarkdown(html), 'Real prose.');
+  });
+});

--- a/tools/publish/test/unit/gurps/parse.test.js
+++ b/tools/publish/test/unit/gurps/parse.test.js
@@ -448,3 +448,51 @@ describe('parseGurps — current encumbrance row (review hardening)', () => {
     assert.deepStrictEqual(model.encumbrance.map(e => e.current), [false, false, true]);
   });
 });
+
+describe('parseGurps — helper tables under a ### subheading (issue #82)', () => {
+  const techniquesSection = {
+    title: 'Techniques', id: 'techniques',
+    html: '<table><tr><th>Name</th><th>Default</th><th>Points</th><th>Base</th><th>Current</th></tr>' +
+          '<tr><td>Choke Hold</td><td>Judo-2</td><td>[3]</td><td>14</td><td>14</td></tr>' +
+          '<tr><td>Kicking</td><td>Karate-2</td><td>[3]</td><td>15</td><td>15</td></tr></table>' +
+          '<h3>Freefighting — techniques at a glance</h3>' +
+          '<table><tr><th>Technique</th><th>Diff</th><th>Rolls at (now)</th><th>Bought cap</th><th>Use</th></tr>' +
+          '<tr><td>Arm Lock (Judo)</td><td>Avg</td><td>14</td><td>18</td><td>leverage joint-lock</td></tr>' +
+          '<tr><td>Sweeping Kick</td><td>Hard</td><td>12</td><td>15</td><td>momentum takedown</td></tr></table>',
+  };
+
+  it('parses only the schema table, not the helper table beneath the subheading', () => {
+    const c = parseGurps({}, [techniquesSection]);
+    assert.deepStrictEqual(c.techniques.map(t => t.name), ['Choke Hold', 'Kicking']);
+  });
+
+  it('keeps the real techniques resolving correctly', () => {
+    const c = parseGurps({}, [techniquesSection]);
+    const choke = c.techniques.find(t => t.name === 'Choke Hold');
+    assert.strictEqual(choke.level, '14');
+    assert.strictEqual(choke.def, 'Judo-2');
+    assert.strictEqual(choke.points, '3');
+  });
+
+  it('applies the same guard to Skills', () => {
+    const c = parseGurps({}, [{
+      title: 'Skills', id: 'skills',
+      html: '<table><tr><th>Name</th><th>Level</th><th>Points</th></tr>' +
+            '<tr><td>Judo</td><td>14</td><td>[8]</td></tr></table>' +
+            '<h3>Cheat sheet</h3><table><tr><th>Move</th><th>Note</th></tr>' +
+            '<tr><td>Throw</td><td>see B403</td></tr></table>',
+    }]);
+    assert.deepStrictEqual(c.skills.map(s => s.name), ['Judo']);
+  });
+
+  it('applies the same guard to Spells', () => {
+    const c = parseGurps({}, [{
+      title: 'Spells', id: 'spells',
+      html: '<table><tr><th>Name</th><th>Level</th><th>Points</th></tr>' +
+            '<tr><td>Lend Energy</td><td>13</td><td>1</td></tr></table>' +
+            '<h3>Ritual notes</h3><table><tr><th>Phase</th><th>Note</th></tr>' +
+            '<tr><td>Cast</td><td>1 sec</td></tr></table>',
+    }]);
+    assert.deepStrictEqual(c.spells.map(s => s.name), ['Lend Energy']);
+  });
+});

--- a/tools/publish/test/unit/gurps/tables.test.js
+++ b/tools/publish/test/unit/gurps/tables.test.js
@@ -27,3 +27,29 @@ describe('gurps/tables', () => {
     assert.doesNotThrow(() => extractSubsectionHtml(html, 'Senses (Extended)'));
   });
 });
+
+describe('topLevelHtml (issue #82)', () => {
+  const { topLevelHtml, parseTableRows } = require('../../../lib/templates/gurps/tables');
+
+  it('excludes tables under a ### subheading', () => {
+    const html = '<table><tr><th>Name</th></tr><tr><td>Choke Hold</td></tr></table>'
+      + '<h3>At a glance</h3><table><tr><th>Technique</th></tr><tr><td>Arm Lock</td></tr></table>';
+    const rows = parseTableRows(topLevelHtml(html));
+    assert.deepStrictEqual(rows, [['Name'], ['Choke Hold']]);
+  });
+
+  it('falls back to the whole section when the only table is under a subheading', () => {
+    const html = '<h3>Techniques</h3><table><tr><th>Name</th></tr><tr><td>Kicking</td></tr></table>';
+    const rows = parseTableRows(topLevelHtml(html));
+    assert.deepStrictEqual(rows, [['Name'], ['Kicking']]);
+  });
+
+  it('keeps multiple top-level tables', () => {
+    const html = '<table><tr><td>a</td></tr></table><table><tr><td>b</td></tr></table>';
+    assert.deepStrictEqual(parseTableRows(topLevelHtml(html)), [['a'], ['b']]);
+  });
+
+  it('is inert on a section with no table at all', () => {
+    assert.strictEqual(topLevelHtml('<p>prose</p>'), '<p>prose</p>');
+  });
+});

--- a/tools/publish/test/unit/heritage.test.js
+++ b/tools/publish/test/unit/heritage.test.js
@@ -75,7 +75,7 @@ describe('worldDomainTemplate', () => {
 
   it('renders rules sidebar when rules present', () => {
     const page = { ...basePage, frontmatter: { ...basePage.frontmatter, rules: [{ rule: 'No flying mounts' }, { rule: 'Rivers flow south' }] } };
-    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {}, {});
     assert.ok(html.includes('World Rules'), 'should have rules sidebar heading');
     assert.ok(html.includes('No flying mounts'), 'should render first rule');
     assert.ok(html.includes('Rivers flow south'), 'should render second rule');
@@ -83,20 +83,20 @@ describe('worldDomainTemplate', () => {
 
   it('suppresses rules sidebar when publish_rules is false', () => {
     const page = { ...basePage, frontmatter: { ...basePage.frontmatter, publish_rules: false, rules: [{ rule: 'Hidden rule' }] } };
-    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {}, {});
     assert.ok(!html.includes('World Rules'), 'should not render rules sidebar');
     assert.ok(!html.includes('Hidden rule'), 'should not render rule content');
   });
 
   it('renders summary subtitle', () => {
     const page = { ...basePage, frontmatter: { ...basePage.frontmatter, summary: 'The lay of the land' } };
-    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {}, {});
     assert.ok(html.includes('The lay of the land'), 'should render summary');
     assert.ok(html.includes('world-domain-summary'), 'should use summary class');
   });
 
   it('renders without optional fields', () => {
-    const html = worldDomainTemplate(basePage, baseContent, stubNav, baseConfig, {});
+    const html = worldDomainTemplate(basePage, baseContent, stubNav, baseConfig, {}, {});
     assert.ok(html.includes('Geography'), 'should render title');
     assert.ok(html.includes('Mountains and rivers'), 'should render body content');
     assert.ok(!html.includes('world-rules-sidebar'), 'should not render rules sidebar');
@@ -104,7 +104,7 @@ describe('worldDomainTemplate', () => {
 
   it('falls back to rule id when rule field is absent', () => {
     const page = { ...basePage, frontmatter: { ...basePage.frontmatter, rules: [{ id: 'MAX_ALTITUDE_5000' }] } };
-    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {});
+    const html = worldDomainTemplate(page, baseContent, stubNav, baseConfig, {}, {});
     assert.ok(html.includes('MAX_ALTITUDE_5000'), 'should fall back to id field');
   });
 });

--- a/tools/publish/test/unit/index-filters.test.js
+++ b/tools/publish/test/unit/index-filters.test.js
@@ -380,3 +380,67 @@ describe('NPC table avatars', () => {
     assert.ok(html.includes('data-sort="karl brenner"'));
   });
 });
+
+describe('NPC index session filter (issue #89)', () => {
+  const config = { siteTitle: 'T', attachmentsDir: '_attachments' };
+  const stubNav = () => '';
+
+  function npc(name, fm) {
+    return {
+      title: name, displayTitle: name,
+      outputPath: `characters/npcs/${name.toLowerCase()}.html`,
+      outputDir: 'characters/npcs',
+      frontmatter: { type: 'npc', ...fm },
+    };
+  }
+
+  function render(pages) {
+    return indexTemplate('characters/npcs', 'NPCs', pages, stubNav, config, {}, {});
+  }
+
+  it('never offers a lastUpdated date as a session option', () => {
+    const html = render([
+      npc('Alice', { asOfSession: 'Session 1', lastUpdated: '2026-07-05' }),
+      npc('Bob', { asOfSession: 'Session 2', lastUpdated: '2026-07-05' }),
+      npc('Carol', { asOfSession: '', lastUpdated: '2026-07-05' }),
+    ]);
+    assert.ok(html.includes('<option value="Session 1">'), 'real session survives');
+    assert.ok(html.includes('<option value="Session 2">'), 'real session survives');
+    assert.ok(!html.includes('<option value="2026-07-05">'), 'maintenance date is not a session');
+  });
+
+  it('drops the dropdown entirely when the date was the only second option', () => {
+    const html = render([
+      npc('Alice', { asOfSession: 'Session 1', lastUpdated: '2026-07-05' }),
+      npc('Bob', { asOfSession: 'Session 1', lastUpdated: '2026-07-06' }),
+    ]);
+    assert.ok(!html.includes('data-col="session"'), 'one real session is nothing to filter by');
+  });
+
+  it('does not tag a row with a lastUpdated date', () => {
+    const html = render([npc('Bob', { asOfSession: '', lastUpdated: '2026-07-05' })]);
+    assert.ok(html.includes('data-session=""'), 'no session means not session-filterable');
+    assert.ok(!html.includes('data-session="2026-07-05"'));
+  });
+
+  it('rejects an ISO date written directly into asOfSession', () => {
+    const html = render([npc('Carol', { asOfSession: '2026-07-05' })]);
+    assert.ok(!html.includes('data-session="2026-07-05"'));
+    assert.ok(!html.includes('<option value="2026-07-05">'));
+  });
+
+  it('keeps a session wikilink as a session', () => {
+    const html = render([
+      npc('Dave', { asOfSession: '[[Session 02 - The Deep]]' }),
+      npc('Erin', { asOfSession: 'Session 1' }),
+    ]);
+    assert.ok(html.includes('data-session="Session 02 - The Deep"'));
+    assert.ok(html.includes('<option value="Session 02 - The Deep">'));
+  });
+
+  it('labels the column for what it now holds', () => {
+    const html = render([npc('Alice', { asOfSession: 'Session 1' })]);
+    assert.ok(html.includes('>As of Session</th>'));
+    assert.ok(!html.includes('>Last Updated</th>'));
+  });
+});

--- a/tools/publish/test/unit/manifest.test.js
+++ b/tools/publish/test/unit/manifest.test.js
@@ -111,3 +111,76 @@ describe('loadManifest', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe('parseManifest inline comments (issue #80)', () => {
+  const { stripInlineComment } = require('../../lib/manifest');
+
+  it('keeps only the path from an annotated Publishing entry', () => {
+    const md = [
+      '## Publishing (2 files)',
+      '- [x] Documents/Freefighting (Spacer Kung-Fu).md — Six’s style writeup',
+      '- [x] Locations/Thides.md',
+    ].join('\n');
+    assert.deepStrictEqual(parseManifest(md).publishing, [
+      'Documents/Freefighting (Spacer Kung-Fu).md',
+      'Locations/Thides.md',
+    ]);
+  });
+
+  it('strips en-dash and double-hyphen comments too', () => {
+    assert.strictEqual(stripInlineComment('A/B.md – note'), 'A/B.md');
+    assert.strictEqual(stripInlineComment('A/B.md -- note'), 'A/B.md');
+  });
+
+  it('leaves a bare path untouched', () => {
+    assert.strictEqual(stripInlineComment('A/B.md'), 'A/B.md');
+  });
+
+  it('does not cut a hyphenated filename', () => {
+    assert.strictEqual(stripInlineComment('Docs/well-known-file.md'), 'Docs/well-known-file.md');
+  });
+
+  it('strips comments from Needs Decision entries as well', () => {
+    const md = [
+      '## Needs Decision (2 files)',
+      '- [ ] A.md — undecided',
+      '- [x] B.md — resolved, publish it',
+    ].join('\n');
+    const parsed = parseManifest(md);
+    assert.deepStrictEqual(parsed.needsDecision, ['A.md']);
+    assert.deepStrictEqual(parsed.resolved, ['B.md']);
+  });
+});
+
+describe('parseManifest does not truncate dashed filenames (review regression)', () => {
+  const { stripInlineComment } = require('../../lib/manifest');
+
+  it('keeps an em-dash that is part of the filename', () => {
+    assert.strictEqual(
+      stripInlineComment('Items & Artifacts/Six — Field Sundries & Reloads.md'),
+      'Items & Artifacts/Six — Field Sundries & Reloads.md');
+  });
+
+  it('keeps an en-dash that is part of the filename', () => {
+    assert.strictEqual(
+      stripInlineComment('Sessions/Session 3 – Aftermath.md'),
+      'Sessions/Session 3 – Aftermath.md');
+  });
+
+  it('strips the comment from a dashed filename that also carries one', () => {
+    assert.strictEqual(stripInlineComment('Items/Six — Field.md — the note'), 'Items/Six — Field.md');
+  });
+
+  it('is not confused by a dot in a directory name', () => {
+    assert.strictEqual(stripInlineComment('v1.2/Notes.md — note'), 'v1.2/Notes.md');
+    assert.strictEqual(stripInlineComment('v1.2/Notes.md'), 'v1.2/Notes.md');
+  });
+
+  it('stops at the path, not a .md mentioned inside the comment', () => {
+    assert.strictEqual(stripInlineComment('Foo.md — see Bar.md'), 'Foo.md');
+  });
+
+  it('leaves an extensionless entry alone', () => {
+    assert.strictEqual(stripInlineComment('NoExtension'), 'NoExtension');
+  });
+});

--- a/tools/publish/test/unit/markdown.test.js
+++ b/tools/publish/test/unit/markdown.test.js
@@ -1,0 +1,50 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { createRenderer } = require('../../lib/markdown');
+
+const md = createRenderer();
+
+describe('obsidian callouts (issue #86a)', () => {
+  it('renders a titled callout as a styled div, not literal [!type] text', () => {
+    const html = md.render('> [!info] Reconstruction Note\n> The record is partial.');
+    assert.match(html, /<div class="callout callout-info">/);
+    assert.match(html, /<div class="callout-title">Reconstruction Note<\/div>/);
+    assert.match(html, /<p>The record is partial\.<\/p>/);
+    assert.doesNotMatch(html, /\[!info\]/);
+  });
+
+  it('falls back to the callout type as title when none is given', () => {
+    const html = md.render('> [!tip]\n> Only a body.');
+    assert.match(html, /<div class="callout-title">Tip<\/div>/);
+    assert.match(html, /<p>Only a body\.<\/p>/);
+  });
+
+  it('ignores the fold marker on the type', () => {
+    const html = md.render('> [!note]- Folded\n> body');
+    assert.match(html, /<div class="callout callout-note">/);
+    assert.match(html, /<div class="callout-title">Folded<\/div>/);
+  });
+
+  it('keeps separate body paragraphs separate', () => {
+    const html = md.render('> [!warning] Heads up\n>\n> One.\n>\n> Two.');
+    assert.match(html, /<p>One\.<\/p>/);
+    assert.match(html, /<p>Two\.<\/p>/);
+  });
+
+  it('leaves an ordinary blockquote alone', () => {
+    const html = md.render('> Just an ordinary quote.');
+    assert.match(html, /<blockquote>/);
+    assert.doesNotMatch(html, /callout/);
+  });
+
+  it('lowercases the type for the class but keeps typographer on the title', () => {
+    const html = md.render('> [!Warning] DRAFT -- player-side\n> body');
+    assert.match(html, /class="callout callout-warning"/);
+    assert.match(html, /<div class="callout-title">DRAFT – player-side<\/div>/);
+  });
+
+  it('still renders inline markup inside a callout title', () => {
+    const html = md.render('> [!note] A **bold** title\n> body');
+    assert.match(html, /<div class="callout-title">A <strong>bold<\/strong> title<\/div>/);
+  });
+});

--- a/tools/publish/test/unit/nav-groups.test.js
+++ b/tools/publish/test/unit/nav-groups.test.js
@@ -100,3 +100,24 @@ describe('generateNav', () => {
     assert.strictEqual(desktopMatches, 1);
   });
 });
+
+describe('generateNavGroups timeline target (issue #83)', () => {
+  const pages = [{ outputDir: 'events', outputPath: 'events/battle.html', displayTitle: 'Battle' }];
+
+  function eventsHref(options) {
+    const story = generateNavGroups(pages, options).find(g => g.name === 'Story');
+    return story.links.find(l => l.label === 'Events').href;
+  }
+
+  it('points Events at the generated root timeline when one exists', () => {
+    assert.strictEqual(eventsHref({ timelineHref: 'timeline.html' }), 'timeline.html');
+  });
+
+  it('points Events at an authored timeline wherever it renders', () => {
+    assert.strictEqual(eventsHref({ timelineHref: 'campaign/timeline.html' }), 'campaign/timeline.html');
+  });
+
+  it('falls back to the events index when no timeline exists', () => {
+    assert.strictEqual(eventsHref({}), 'events/index.html');
+  });
+});

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -273,3 +273,153 @@ describe('renderRelationships', () => {
     assert.ok(!result.includes('Captain_James_Harker'), 'Should not contain raw underscored name');
   });
 });
+
+describe('stripHtmlComments (issue #85)', () => {
+  const { stripHtmlComments } = require('../../lib/processor');
+
+  it('removes a standalone comment without splitting the paragraph', () => {
+    assert.strictEqual(
+      stripHtmlComments('Line one.\n<!-- private note -->\nLine two.'),
+      'Line one.\nLine two.');
+  });
+
+  it('removes an inline comment', () => {
+    assert.strictEqual(stripHtmlComments('before <!-- x --> after'), 'before  after');
+  });
+
+  it('removes a multi-line comment', () => {
+    assert.strictEqual(
+      stripHtmlComments('a\n<!-- one\ntwo\nthree -->\nb'),
+      'a\nb');
+  });
+
+  it('leaves comments inside fenced code blocks alone', () => {
+    const md = '```html\n<!-- keep me -->\n```';
+    assert.strictEqual(stripHtmlComments(md), md);
+  });
+
+  it('warns and strips to end of file on an unclosed comment', () => {
+    const out = stripHtmlComments('visible\n<!-- oops\nswallowed');
+    assert.strictEqual(out.text, 'visible');
+    assert.match(out.warnings[0], /unclosed/);
+  });
+
+  it('returns a plain string when there is nothing to warn about', () => {
+    assert.strictEqual(typeof stripHtmlComments('plain text'), 'string');
+  });
+});
+
+describe('resolveImageEmbeds (issues #86b, #88)', () => {
+  const { resolveImageEmbeds } = require('../../lib/processor');
+  const imageMap = {
+    'Chrome Jockey.png': { relPath: 'heritages/Chrome Jockey.png' },
+    'Kung-Fu (Spacer).png': { relPath: 'docs/Kung-Fu (Spacer).png' },
+  };
+
+  it('percent-encodes spaces so the link parses as an image', () => {
+    const out = resolveImageEmbeds('![[Chrome Jockey.png]]', imageMap, 'heritages/chrome-jockey.html');
+    assert.strictEqual(out, '![Chrome Jockey](../images/heritages/Chrome%20Jockey.png)');
+  });
+
+  it('encodes parentheses in the destination', () => {
+    const out = resolveImageEmbeds('![[Kung-Fu (Spacer).png]]', imageMap, 'documents/x.html');
+    const dest = out.slice(out.lastIndexOf('(') + 1, -1);
+    assert.strictEqual(dest, '../images/docs/Kung-Fu%20%28Spacer%29.png');
+  });
+
+  it('drops an embed that duplicates the page portrait', () => {
+    const out = resolveImageEmbeds('![[Chrome Jockey.png]]', imageMap, 'heritages/chrome-jockey.html',
+      null, { portraitBasename: 'Chrome Jockey.png' });
+    assert.strictEqual(out, '');
+  });
+
+  it('keeps the embed when the portrait names a different file', () => {
+    const out = resolveImageEmbeds('![[Chrome Jockey.png]]', imageMap, 'heritages/chrome-jockey.html',
+      null, { portraitBasename: 'Other.png' });
+    assert.match(out, /<img|!\[Chrome Jockey\]/);
+  });
+
+  it('keeps the embed when the portrait is not a scanned image', () => {
+    const out = resolveImageEmbeds('![[Chrome Jockey.png]]', imageMap, 'heritages/chrome-jockey.html',
+      null, { portraitBasename: 'Missing.png' });
+    assert.match(out, /!\[Chrome Jockey\]/);
+  });
+
+  it('removes a missing embed rather than leaving a visible comment', () => {
+    const out = resolveImageEmbeds('![[Nope.png]]', imageMap, 'x.html');
+    assert.strictEqual(out, '');
+  });
+
+  it('still records the image as used before deduping', () => {
+    const used = new Set();
+    resolveImageEmbeds('![[Chrome Jockey.png]]', imageMap, 'heritages/chrome-jockey.html',
+      used, { portraitBasename: 'Chrome Jockey.png' });
+    assert.ok(used.has('Chrome Jockey.png'));
+  });
+
+  it('leaves a non-image embed untouched', () => {
+    assert.strictEqual(resolveImageEmbeds('![[Some Note]]', imageMap, 'x.html'), '![[Some Note]]');
+  });
+});
+
+describe('renderMetaValue / plainMetaValue (issue #86c)', () => {
+  const { renderMetaValue, plainMetaValue } = require('../../lib/processor');
+  const linkMap = { 'Corvid Financial': 'factions/corvid-financial.html' };
+
+  it('resolves a wikilink in a frontmatter-derived field', () => {
+    const out = renderMetaValue('Agent for [[Corvid Financial]]', linkMap, 'characters/npcs/marek.html');
+    assert.strictEqual(out,
+      'Agent for <a href="../../factions/corvid-financial.html" class="entity-link">Corvid Financial</a>');
+  });
+
+  it('honors an explicit alias', () => {
+    const out = renderMetaValue('[[Corvid Financial|the bank]]', linkMap, 'x.html');
+    assert.match(out, />the bank<\/a>/);
+  });
+
+  it('degrades an unresolved link to humanized plain text', () => {
+    assert.strictEqual(renderMetaValue('sees [[P.E.T.A.]]', {}, 'x.html'), 'sees P.E.T.A.');
+    assert.strictEqual(renderMetaValue('[[Lord_Percival]]', {}, 'x.html'), 'Lord Percival');
+  });
+
+  it('escapes surrounding text', () => {
+    assert.strictEqual(renderMetaValue('a < b & c', {}, 'x.html'), 'a &lt; b &amp; c');
+  });
+
+  it('plainMetaValue never emits an anchor', () => {
+    assert.strictEqual(plainMetaValue('Agent for [[Corvid Financial]]'), 'Agent for Corvid Financial');
+    assert.doesNotMatch(plainMetaValue('[[Corvid Financial]]'), /</);
+  });
+});
+
+describe('stripHtmlComments fence markers (review regression)', () => {
+  const { stripHtmlComments } = require('../../lib/processor');
+
+  it('does not let a ``` inside a ~~~ block close the fence', () => {
+    const md = ['~~~', '```', 'sample <!-- keep --> here', '~~~'].join('\n');
+    assert.strictEqual(stripHtmlComments(md), md);
+  });
+
+  it('still strips comments after a fence closes', () => {
+    const out = stripHtmlComments(['```', 'code', '```', 'after <!-- gone -->'].join('\n'));
+    assert.strictEqual(out, ['```', 'code', '```', 'after '].join('\n'));
+  });
+});
+
+describe('resolveWikiLinks on non-image transclusions (review regression)', () => {
+  const { resolveWikiLinks } = require('../../lib/processor');
+
+  it('degrades ![[Note]] to a link, never a broken <img> src', () => {
+    const out = resolveWikiLinks('![[Backstory]]', { Backstory: 'docs/backstory.html' }, 'x.html');
+    assert.strictEqual(out, '[Backstory](docs/backstory.html)');
+  });
+
+  it('degrades an unresolved ![[Note]] to plain text', () => {
+    assert.strictEqual(resolveWikiLinks('![[Nope]]', {}, 'x.html'), 'Nope');
+  });
+
+  it('still resolves an ordinary wikilink', () => {
+    const out = resolveWikiLinks('[[Backstory]]', { Backstory: 'docs/backstory.html' }, 'x.html');
+    assert.strictEqual(out, '[Backstory](docs/backstory.html)');
+  });
+});


### PR DESCRIPTION
Closes #80, #82, #83, #84, #85, #86, #87, #88, #89.

Publish tool 1.9.0, plugin 1.8.16.

Every bug was reproduced against a real 178-page player-mode vault before
being fixed, and the built site re-checked afterwards: all 7,748 internal
links resolve, and no leaked comments, wikilinks, callout markers or
maintenance dates remain.

## The fixes

- **#85** — HTML comments were escaped and printed as visible body text,
  leaking private authoring notes (including an explicit "needs GM
  confirmation" flag) onto a player-facing site. Comments are stripped
  before render, outside fenced code, with a warning on an unclosed one.
- **#80** — A Publishing manifest entry carrying an inline `— comment`
  silently published nothing. Entries are now parsed by anchoring on the
  file extension, so an em dash *inside* a filename is preserved. An entry
  matching no scanned page prints a warning.
- **#83** — The nav's Events link and the `events/` redirect both hard-coded
  a root `timeline.html` that is only written when dated events exist. With
  an authored timeline elsewhere the global nav dangled on ~175 of 177
  pages. The target is computed once, and `events/` gets a real index when
  there is no timeline at all.
- **#84** — The homepage "Characters" card pointed at an index that was
  never generated. It now exists, aggregating PCs and NPCs.
- **#86** — Obsidian callouts render as styled callouts; image embed
  destinations are percent-encoded (a raw space made the link unparseable,
  so it fell through as literal text and the typographer then rewrote the
  leading `../` into `…/`); wikilinks in frontmatter-derived fields resolve.
- **#87** — Pull-quote excerpts no longer include section headings, raw
  image markdown, HTML comments or callout markers, and de-linking a
  wikilink no longer leaves a stray space.
- **#88** — An inline embed that resolves to the page's `portrait:` is
  skipped, so the image is not published twice.
- **#82** — `parseTechniques()` (and Skills/Spells) no longer merge helper
  tables that sit under a `###` subheading into the machine-readable grid.
- **#89** — The NPC listing's session filter fell back to `lastUpdated`, so
  a maintenance date appeared in the "filter by session" dropdown and was
  sorted against `Session N`. Session refs come from `asOfSession` alone.

## Also fixed along the way

- A non-image transclusion (`![[Some Note]]`) became an `<img>` whose `src`
  pointed at an HTML page; it now degrades to a link.
- `world_domain` pages render their `portrait:`, which every other entity
  template already did. That makes the #88 dedupe safe rather than
  dependent on an implicit assumption.
- Unclosed-marker warnings were being recorded and then discarded; they are
  now surfaced.
- The NPC table's last column was headed "Last Updated" while holding,
  sorting and filtering a session. It now reads "As of Session".

## Notes on approach

For #87 I moved pull-quotes onto a page's published markdown — the same
source backlinks, search and recency already read — rather than regex
scrubbing the renderer's own HTML output. That deleted the fragile parsing
path and fixed the stray-space bug at its origin. `publishedSource()` is now
one shared helper instead of four near-identical copies.

## Testing

828 tests pass (64 new), including the clean-install integration test.
Schema validation, markdownlint, and skill-creator validation all pass.
The new manifest and timeline tests were confirmed to fail against the
unfixed code.