### PR TITLE
Publish tool: overrides.css wiring, WebP optimization, Locations pivot grouping, section banners

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.17",
+  "version": "1.8.18",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.17] — 2026-07-09
+
+Publish tool 1.10.0.
+
+### Added
+
+- **Opt-in WebP image optimization.** `publish.images.optimize` re-encodes
+  PNG/JPEG attachments to WebP as they're copied, resizing to
+  `max_width` (default 1600) at `quality` (default 82). On a
+  portrait-heavy vault this cut 164 MB of images to 11 MB. The pass runs
+  before any page renders, so the swapped extension flows into `<img src>`
+  at emission time rather than being rewritten into generated HTML
+  afterwards. Requires the `cwebp` binary; without it the build warns and
+  copies originals. Images that would grow when re-encoded keep their
+  original bytes. (#91)
+- **Pivot grouping for the Locations index.** `publish.locations.group_by`
+  gives each matching `location_type` — a star system, say — its own
+  section, instead of one deep tree rooted at a single political node. The
+  scaffolding above the pivot collapses into a context caption; every
+  location below it stays a first-class row with its own thumbnail and
+  type badge, children nested beneath it. Locations outside any pivot
+  collect under `ungrouped_label`. Defaults on for the `scifi` genre, and
+  falls back to the flat view when fewer than two locations match. (#93)
+
+### Fixed
+
+- **`css/overrides.css` is now wired into the build.** `gm-publish init`
+  scaffolded it, but nothing copied or linked it, so the one file that
+  looked like the customization seam did nothing — and `theme.css`, the
+  only file that would have worked, is regenerated every build. It is now
+  copied into `docs/css/` and linked last in `<head>`, after `theme.css`
+  and the genre overlay, so site rules win the cascade. Sites without one
+  emit no link tag. (#92)
+- **Portraits resolve through the scanner's image map.** `portraitImg`
+  built its output path from the `portrait:` frontmatter string, so a
+  `portrait:` that omitted its subdirectory pointed at a file the build
+  had copied elsewhere.
+
 ## [1.8.16] — 2026-07-09
 
 Publish tool 1.9.0. Fixes the eight open publish-site issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ Publish tool 1.11.0.
   anchor would have swallowed. A banner declaring a `link` renders as an
   `<img>` inside an `<a>` instead. Assets copy to `docs/images/banners/`;
   a path resolving outside the vault, or a missing file, warns and is
-  skipped rather than failing the build. (#95)
+  skipped rather than failing the build. Assets are namespaced by section
+  (`docs/images/banners/<section>/`), since the conventional `_banner.*`
+  filename is identical in every section folder. (#95)
 
 ## [1.8.17] — 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.18] — 2026-07-10
+
+Publish tool 1.11.0.
+
+### Added
+
+- **Section index banners.** `publish.banners` attaches a hero image or a
+  clickable map to the top of a section index, or a conventional
+  `_banner.*` file in the section's vault folder is picked up with no
+  config at all. An SVG with no click-through target is inlined, so its
+  internal `<a>` elements stay live — a star map whose nodes link to
+  entity pages keeps working, which an `<img>` could not do and an outer
+  anchor would have swallowed. A banner declaring a `link` renders as an
+  `<img>` inside an `<a>` instead. Assets copy to `docs/images/banners/`;
+  a path resolving outside the vault, or a missing file, warns and is
+  skipped rather than failing the build. (#95)
+
 ## [1.8.17] — 2026-07-09
 
 Publish tool 1.10.0.

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -24,6 +24,7 @@ any equivalent in `vault.config.json`.
 | Section index titles | `publish.section_titles` | Override h1 titles on the Locations/Factions/Items/Creatures index pages |
 | Exclude drafts | `publish.exclude_drafts` | When `true`, DRAFT entities are excluded entirely (default: `false`) |
 | Image optimization | `publish.images` | Opt-in WebP re-encoding of copied images (default: off) |
+| Section banners | `publish.banners` | Hero image or clickable map at the top of a section index |
 | Locations grouping | `publish.locations` | Pivot the Locations index on a `location_type` (default: genre-derived) |
 | Setting year | `setting_year` | Fallback in-game date on the landing page (used only when the campaign overview has no `current_game_date`) |
 
@@ -86,6 +87,35 @@ missing encoder never breaks a build. Images that would grow when
 re-encoded keep their original bytes; SVG, GIF, WebP and AVIF are always
 passed through. On a portrait-heavy campaign this is the biggest single
 weight on the site — one real vault went from 164 MB to 11 MB.
+
+### Section index banners
+
+A hero image or clickable map at the top of a section index. Either drop
+a `_banner.*` file into the section's vault folder
+(`Locations/_banner.svg`), or name one explicitly:
+
+```yaml
+publish:
+  banners:
+    locations:
+      image: _attachments/sector-map.webp
+      link: _attachments/sector-map.svg    # optional click-through
+      alt: Sector 7-G star chart
+    factions: _attachments/factions-hero.svg   # shorthand
+```
+
+Keys are output directories (`locations`, `factions`), not vault
+folders. Config wins over the conventional file.
+
+An **SVG with no `link` is inlined**, so its internal `<a>` elements stay
+live — a star map whose nodes link to entity pages keeps working. Write
+those hrefs relative to the index page (`corwin-system.html`). Anything
+with a `link` renders as an `<img>` inside an `<a>`, since an outer
+anchor would swallow an SVG's own links.
+
+Assets are copied to `docs/images/banners/`. A path resolving outside the
+vault, or a missing file, warns and is skipped rather than failing the
+build.
 
 ### Locations index grouping
 

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -23,6 +23,8 @@ any equivalent in `vault.config.json`.
 | Overrides | `publish.overrides` | Per-file include/exclude/field overrides |
 | Section index titles | `publish.section_titles` | Override h1 titles on the Locations/Factions/Items/Creatures index pages |
 | Exclude drafts | `publish.exclude_drafts` | When `true`, DRAFT entities are excluded entirely (default: `false`) |
+| Image optimization | `publish.images` | Opt-in WebP re-encoding of copied images (default: off) |
+| Locations grouping | `publish.locations` | Pivot the Locations index on a `location_type` (default: genre-derived) |
 | Setting year | `setting_year` | Fallback in-game date on the landing page (used only when the campaign overview has no `current_game_date`) |
 
 > **Landing page state.** The landing hero (in-game date, session count) and the
@@ -62,6 +64,53 @@ Valid keys: `locations`, `factions`, `items`, `creatures`.
 supplies the palette and fonts; a custom `publish.theme.palette`
 overrides the preset colors. A live gallery of all presets built over
 the same campaign is published from the repo's theme-showcase workflow.
+
+### Image optimization
+
+Off by default — images are copied byte-for-byte. When enabled, PNG and
+JPEG attachments are re-encoded to WebP as they're copied, and the
+`<img src>` is written to match:
+
+```yaml
+publish:
+  images:
+    optimize: true    # default false
+    format: webp      # the only supported target today
+    max_width: 1600   # 0 disables resizing
+    quality: 82
+```
+
+Needs the `cwebp` binary on `PATH` (`brew install webp`, `apt install
+webp`). Without it the build warns and copies the originals, so a
+missing encoder never breaks a build. Images that would grow when
+re-encoded keep their original bytes; SVG, GIF, WebP and AVIF are always
+passed through. On a portrait-heavy campaign this is the biggest single
+weight on the site — one real vault went from 164 MB to 11 MB.
+
+### Locations index grouping
+
+When a campaign's geography funnels through one political root
+(`Republic → Sector → System → planet`), the default listing is a single
+deep tree. Pivot grouping makes each mid-level node its own section
+instead:
+
+```yaml
+publish:
+  locations:
+    group_by: system                    # matched against location_type
+    ungrouped_label: Deep Space & Routes
+```
+
+`group_by` is a case-insensitive substring of `location_type`, so
+`system` matches both `system` and `star system`. The `scifi` genre
+defaults it to `system`; every other genre leaves grouping off. Set
+`group_by: false` to turn a genre default back off.
+
+Locations with no matching ancestor collect under `ungrouped_label`. The
+scaffolding above the pivot (the Republic, the Sector) is demoted to a
+small context caption rather than rendered as tree rows. Grouping is
+skipped — falling back to the flat view — when fewer than two locations
+match the pivot, since one section is not a grouping.
 
 ## `vault.config.json` (in the site repo)
 

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -113,7 +113,8 @@ those hrefs relative to the index page (`corwin-system.html`). Anything
 with a `link` renders as an `<img>` inside an `<a>`, since an outer
 anchor would swallow an SVG's own links.
 
-Assets are copied to `docs/images/banners/`. A path resolving outside the
+Assets are copied to `docs/images/banners/<section>/`, namespaced so two
+sections' `_banner.*` files can't collide. A path resolving outside the
 vault, or a missing file, warns and is skipped rather than failing the
 build.
 

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -230,6 +230,44 @@ It includes these sections (each omitted if no relevant data exists):
 - **Explore** — compact grid of category index pages with entry counts,
   excluding PC and NPC categories (those have dedicated sections above)
 
+### Section index banners
+
+Put a hero image or a clickable map at the top of a section index. Either
+drop a `_banner.*` file in the section's vault folder
+(`Locations/_banner.svg`), or name one explicitly:
+
+```yaml
+publish:
+  banners:
+    locations:
+      image: _attachments/sector-map.webp
+      link: _attachments/sector-map.svg    # optional, click-through target
+      alt: Sector 7-G star chart
+    factions: _attachments/factions-hero.svg   # shorthand: image only
+```
+
+Keys are output directories (`locations`, `factions`, `items`, …), not
+vault folders. Config wins over the conventional file. Accepted
+extensions, in preference order: `svg`, `webp`, `avif`, `png`, `jpg`,
+`jpeg`, `gif`.
+
+**SVG with no `link` is inlined**, so its internal `<a>` elements stay
+clickable — a star map whose nodes link to entity pages keeps working.
+An `<img>` would not run those links, and wrapping the SVG in an outer
+anchor would swallow them, so anything with a `link` renders as an
+`<img>` inside an `<a>` instead. That's the "raster on the page,
+full-size SVG behind it" shape.
+
+Because an inlined SVG lands in `<section>/index.html`, its internal
+hrefs must be written relative to that page (`corwin-system.html`, or
+`../characters/npcs/rook.html`).
+
+Assets are copied to `docs/images/banners/`. A banner path that resolves
+outside the vault, or names a file that doesn't exist, prints a warning
+and is skipped rather than failing the build. Banners apply to generated
+index pages; a section with an authored `index.md` renders that page
+instead.
+
 ### Locations index grouping
 
 When a campaign's geography funnels through one political root

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -262,11 +262,12 @@ Because an inlined SVG lands in `<section>/index.html`, its internal
 hrefs must be written relative to that page (`corwin-system.html`, or
 `../characters/npcs/rook.html`).
 
-Assets are copied to `docs/images/banners/`. A banner path that resolves
-outside the vault, or names a file that doesn't exist, prints a warning
-and is skipped rather than failing the build. Banners apply to generated
-index pages; a section with an authored `index.md` renders that page
-instead.
+Assets are copied to `docs/images/banners/<section>/`, namespaced by
+section so the conventional `_banner.*` sitting in two different folders
+can't collide. A banner path that resolves outside the vault, or names a
+file that doesn't exist, prints a warning and is skipped rather than
+failing the build. Banners apply to generated index pages; a section with
+an authored `index.md` renders that page instead.
 
 ### Locations index grouping
 

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -238,6 +238,37 @@ prevents GM-only images (maps, handouts, portraits of hidden NPCs)
 from leaking into the public site. In full mode, all vault images
 are copied.
 
+### Image optimization
+
+Off by default: images are copied byte-for-byte. Turn it on in
+`_meta/vault-config.md` and PNG/JPEG attachments are re-encoded to WebP
+as they are copied, with the `<img src>` written to match:
+
+```yaml
+publish:
+  images:
+    optimize: true    # default false
+    format: webp      # the only supported target today
+    max_width: 1600   # 0 disables resizing
+    quality: 82
+```
+
+On a portrait-heavy campaign this is the single biggest weight on the
+published site — one real vault of 89 portraits went from 164 MB to
+11 MB.
+
+Requires the **`cwebp`** binary on `PATH` (`brew install webp`,
+`apt install webp`). If it isn't found the build prints a warning and
+copies the originals unchanged, so a missing encoder never breaks a
+build. Images that would grow when re-encoded keep their original bytes,
+and SVG, GIF, WebP and AVIF are always passed through untouched.
+
+Because the tool owns both the image copy and every `<img src>`, it
+converts and re-references in one pass. An external postbuild that
+rewrites `src` attributes after the fact has to string-match paths the
+tool URL-encodes (`images/Rock%20Lavey.jpg`), and silently misses every
+filename containing a space.
+
 ---
 
 ## Library API

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -230,6 +230,31 @@ It includes these sections (each omitted if no relevant data exists):
 - **Explore** — compact grid of category index pages with entry counts,
   excluding PC and NPC categories (those have dedicated sections above)
 
+### Locations index grouping
+
+When a campaign's geography funnels through one political root
+(`Republic → Sector → System → planet`), the default Locations listing is
+a single deep tree. Pivot grouping gives each mid-level node its own
+section:
+
+```yaml
+publish:
+  locations:
+    group_by: system                    # matched against location_type
+    ungrouped_label: Deep Space & Routes
+```
+
+`group_by` is a case-insensitive substring of `location_type`, so
+`system` matches `star system` too. The `scifi` genre defaults it to
+`system`; other genres leave grouping off, and `group_by: false` turns a
+genre default back off.
+
+Every location stays a first-class row with its own thumbnail and type
+badge, with children nested beneath it. Only the scaffolding *above* the
+pivot is collapsed, into a context caption. Locations with no matching
+ancestor collect under `ungrouped_label`. Fewer than two matches falls
+back to the flat view — one section is not a grouping.
+
 ### Player-mode image filtering
 
 When building in `player` mode with a publish manifest, only images

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -2205,9 +2205,17 @@ tr:nth-child(even) {
   border-radius: 0.25rem;
   display: block;
 }
+/* Sized on the span, not just the img, so the empty spacer occupies the same box. */
+.loc-system-thumb,
 .loc-system-thumb img.portrait {
   width: 2.25rem;
   height: 2.25rem;
+  flex: 0 0 2.25rem;
+}
+/* Reserve the column so section titles align across the grid; a system with no portrait
+   shouldn't be advertised by a placeholder box. */
+.loc-system-thumb-empty {
+  visibility: hidden;
 }
 /* The collapsed political scaffolding (Republic › Sector): context, not navigation. */
 .loc-context {

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -2159,6 +2159,100 @@ tr:nth-child(even) {
   color: var(--text-muted);
 }
 
+/* ===== LOCATIONS: PIVOT-GROUPED VIEW ===== */
+/* Sections flow in columns so the page width does the work, instead of one tall,
+   deeply-indented tree rooted at a single political node. */
+.loc-system-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  gap: 1rem;
+  align-items: start;
+  margin-top: 1rem;
+}
+.loc-system {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+.loc-system-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
+.loc-system-title {
+  font-size: 1rem;
+  margin: 0;
+  flex: 1 1 auto;
+}
+.loc-system-title a {
+  color: var(--text);
+}
+.loc-system-title a:hover {
+  color: var(--accent);
+}
+.loc-system-count {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.loc-system-thumb img.portrait,
+.loc-node-thumb img.portrait {
+  object-fit: cover;
+  border-radius: 0.25rem;
+  display: block;
+}
+.loc-system-thumb img.portrait {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+/* The collapsed political scaffolding (Republic › Sector): context, not navigation. */
+.loc-context {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.75rem;
+}
+.loc-system .loc-context {
+  margin: 0.6rem 0 0;
+}
+.loc-system-body {
+  margin-top: 0.6rem;
+}
+.loc-node-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+}
+.loc-node-thumb,
+.loc-node-thumb img.portrait {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex: 0 0 1.5rem;
+}
+/* Reserve the column so names stay aligned; an entity with no portrait shouldn't be
+   advertised by a placeholder box. */
+.loc-node-thumb-empty {
+  visibility: hidden;
+}
+.loc-node-name {
+  color: var(--text);
+  font-size: 0.9rem;
+}
+.loc-node-name:hover {
+  color: var(--accent);
+}
+.loc-node-children {
+  margin-left: 0.75rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--border);
+}
+
 /* ===== CAMPAIGN DEEP DIVE ===== */
 .campaign-deep-dive {
   display: flex;

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -2159,6 +2159,29 @@ tr:nth-child(even) {
   color: var(--text-muted);
 }
 
+/* ===== SECTION INDEX BANNER ===== */
+.section-banner {
+  margin: 0 0 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  line-height: 0; /* kill the descender gap under an inline-level child */
+}
+.section-banner-img,
+.section-banner svg,
+.section-banner-inline svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+}
+.section-banner-link {
+  display: block;
+}
+.section-banner-link:hover {
+  opacity: 0.92;
+}
+
 /* ===== LOCATIONS: PIVOT-GROUPED VIEW ===== */
 /* Sections flow in columns so the page width does the work, instead of one tall,
    deeply-indented tree rooted at a single political node. */

--- a/tools/publish/lib/banners.js
+++ b/tools/publish/lib/banners.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const { escapeHtml, encodeImageUrl } = require('./processor');
+
+// Ordered by preference: the first match wins when a section folder holds several.
+const BANNER_EXTS = ['svg', 'webp', 'avif', 'png', 'jpg', 'jpeg', 'gif'];
+const CONVENTION_BASENAME = '_banner';
+
+function isSvg(p) {
+  return /\.svg$/i.test(String(p));
+}
+
+/**
+ * A banner is either a bare path or a { image, link, alt } object.
+ * Anything else (a number, an object with no image) resolves to no banner.
+ */
+function normalizeEntry(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    return raw.trim() ? { image: raw.trim(), link: null, alt: null } : null;
+  }
+  if (typeof raw === 'object' && raw.image) {
+    return {
+      image: String(raw.image).trim(),
+      link: raw.link ? String(raw.link).trim() : null,
+      alt: raw.alt ? String(raw.alt) : null,
+    };
+  }
+  return null;
+}
+
+/** The vault folder a generated index dir was built from, per folderMap. */
+function sourceFolderFor(dir, folderMap) {
+  for (const [folder, outDir] of Object.entries(folderMap || {})) {
+    if (outDir === dir) return folder;
+  }
+  return null;
+}
+
+function findConventionBanner(vaultPath, folder) {
+  if (!folder) return null;
+  for (const ext of BANNER_EXTS) {
+    const rel = `${folder}/${CONVENTION_BASENAME}.${ext}`;
+    if (fs.existsSync(path.join(vaultPath, rel))) return rel;
+  }
+  return null;
+}
+
+/**
+ * Resolve the banner for one section index, config first, then convention.
+ *
+ * @returns {{image: string, link: string|null, alt: string|null}|null} vault-relative paths
+ */
+function resolveBanner(dir, { vaultPath, folderMap, banners }) {
+  const configured = normalizeEntry((banners || {})[dir]);
+  if (configured) return configured;
+
+  const conventional = findConventionBanner(vaultPath, sourceFolderFor(dir, folderMap));
+  return conventional ? { image: conventional, link: null, alt: null } : null;
+}
+
+/** Alt text derived from a filename when the config supplies none. */
+function defaultAlt(imagePath) {
+  return path.basename(String(imagePath))
+    .replace(/\.[^.]+$/, '')
+    .replace(/^_/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+}
+
+/**
+ * Render the banner block for a section index.
+ *
+ * An SVG with no link target is inlined rather than referenced through an `<img>`: only
+ * inline SVG keeps its internal `<a>` links live, which is the whole point of shipping a
+ * clickable star map. Wrapping it in an outer `<a>` would swallow those same links, so a
+ * banner that declares a link target renders as a plain `<img>` inside the anchor instead —
+ * that is the "raster display, full-size SVG behind it" shape.
+ *
+ * @param {{svg?: string, imageHref?: string, linkHref?: string|null, alt?: string}} banner
+ * @returns {string}
+ */
+function renderBanner({ svg, imageHref, linkHref, alt }) {
+  if (svg) {
+    return `<figure class="section-banner section-banner-inline">${svg}</figure>`;
+  }
+  if (!imageHref) return '';
+
+  const img = `<img src="${encodeImageUrl(imageHref)}" alt="${escapeHtml(alt || '')}" class="section-banner-img">`;
+  const inner = linkHref
+    ? `<a class="section-banner-link" href="${encodeImageUrl(linkHref)}">${img}</a>`
+    : img;
+  return `<figure class="section-banner">${inner}</figure>`;
+}
+
+module.exports = {
+  resolveBanner, renderBanner, normalizeEntry, sourceFolderFor,
+  findConventionBanner, defaultAlt, isSvg, BANNER_EXTS,
+};

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -600,8 +600,13 @@ function build(options = {}) {
     return full;
   }
 
-  function copyBannerAsset(sourceFull) {
-    const outRel = 'images/banners/' + path.basename(sourceFull);
+  // Namespaced by section, because the conventional banner filename is identical in every
+  // section folder: Locations/_banner.png and Creatures/_banner.png would otherwise both
+  // land on images/banners/_banner.png, and whichever copied last would show on both pages.
+  // The dir may itself contain a slash ("characters/npcs"), so flatten it to one segment.
+  function copyBannerAsset(sourceFull, dir) {
+    const slug = String(dir).replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'section';
+    const outRel = `images/banners/${slug}/${path.basename(sourceFull)}`;
     const dest = path.join(outputDir, outRel);
     ensureDir(dest);
     fs.copyFileSync(sourceFull, dest);
@@ -632,10 +637,10 @@ function build(options = {}) {
       let linkHref = null;
       if (entry.link) {
         const linkFull = resolveVaultAsset(entry.link, `banner link for "${dir}"`);
-        if (linkFull) linkHref = relativePath(dir, copyBannerAsset(linkFull));
+        if (linkFull) linkHref = relativePath(dir, copyBannerAsset(linkFull, dir));
       }
       rendered[dir] = renderBanner({
-        imageHref: relativePath(dir, copyBannerAsset(imageFull)),
+        imageHref: relativePath(dir, copyBannerAsset(imageFull, dir)),
         linkHref,
         alt: entry.alt || defaultAlt(imageFull),
       });

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -77,6 +77,21 @@ function build(options = {}) {
     console.log(`  wrote css/themes/${genrePreset}.css`);
   }
 
+  // `gm-publish init` scaffolds css/overrides.css next to vault.config.json as the seam for
+  // durable per-site CSS. It is the only stylesheet the build does not generate, so it is the
+  // only one safe to hand-edit — theme.css is rewritten every build. Returns whether a link
+  // tag should be emitted; absent file means no link, no 404.
+  function copyOverridesCSS() {
+    const src = path.join(configDir, 'css/overrides.css');
+    if (!fs.existsSync(src)) return false;
+    const dest = path.join(outputDir, 'css/overrides.css');
+    if (path.resolve(src) === path.resolve(dest)) return true;
+    ensureDir(dest);
+    fs.copyFileSync(src, dest);
+    console.log('  wrote css/overrides.css');
+    return true;
+  }
+
   function copyJS() {
     const jsDir = path.join(__dirname, '../js');
     if (!fs.existsSync(jsDir)) return;
@@ -110,6 +125,7 @@ function build(options = {}) {
       four_oh_four: publishConfig.four_oh_four,
       theme: publishConfig.theme,
       genrePreset: publishConfig._genrePreset,
+      overridesCss: publishConfig._overridesCss,
     });
     fs.writeFileSync(path.join(outputDir, '404.html'), html);
     console.log('  wrote 404.html');
@@ -324,6 +340,7 @@ function build(options = {}) {
   copyJS();
   copyGenreCSS();
   writeThemeCSS();
+  publishConfig._overridesCss = copyOverridesCSS();
 
   let campaignImageCopied = false;
   // Resolve campaign_image: copy from vault to output and rewrite to output-relative path

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -3,6 +3,7 @@ const os = require('os');
 const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
 const { optimizeImages, resolveImageConfig } = require('./image-optimize');
+const { resolveBanner, renderBanner, defaultAlt, isSvg } = require('./banners');
 const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
@@ -582,6 +583,68 @@ function build(options = {}) {
     if (!dirs[dir]) dirs[dir] = [];
     dirs[dir].push(page);
   }
+
+  // Section-index banners. Resolved and copied before the index loop so each index page can
+  // be handed finished HTML with hrefs already relative to its own depth.
+  function resolveVaultAsset(vaultRelPath, label) {
+    const vaultRoot = path.resolve(config.vaultPath);
+    const full = path.resolve(vaultRoot, vaultRelPath);
+    if (full !== vaultRoot && !full.startsWith(vaultRoot + path.sep)) {
+      console.warn(`  WARNING: ${label} "${vaultRelPath}" resolves outside the vault — skipping`);
+      return null;
+    }
+    if (!fs.existsSync(full)) {
+      console.warn(`  WARNING: ${label} "${vaultRelPath}" not found in the vault — skipping`);
+      return null;
+    }
+    return full;
+  }
+
+  function copyBannerAsset(sourceFull) {
+    const outRel = 'images/banners/' + path.basename(sourceFull);
+    const dest = path.join(outputDir, outRel);
+    ensureDir(dest);
+    fs.copyFileSync(sourceFull, dest);
+    return outRel;
+  }
+
+  function buildBanners(dirs) {
+    const rendered = {};
+    for (const dir of dirs) {
+      const entry = resolveBanner(dir, {
+        vaultPath: config.vaultPath,
+        folderMap: config.folderMap,
+        banners: publishConfig.banners,
+      });
+      if (!entry) continue;
+
+      const imageFull = resolveVaultAsset(entry.image, `banner for "${dir}"`);
+      if (!imageFull) continue;
+
+      // Inline SVG keeps its internal <a> links clickable; an <img> would not. A banner that
+      // declares a link target is asking for the anchor instead, so it goes down the <img> path.
+      if (isSvg(imageFull) && !entry.link) {
+        rendered[dir] = renderBanner({ svg: fs.readFileSync(imageFull, 'utf8') });
+        console.log(`  inlined banner for ${dir}/index.html`);
+        continue;
+      }
+
+      let linkHref = null;
+      if (entry.link) {
+        const linkFull = resolveVaultAsset(entry.link, `banner link for "${dir}"`);
+        if (linkFull) linkHref = relativePath(dir, copyBannerAsset(linkFull));
+      }
+      rendered[dir] = renderBanner({
+        imageHref: relativePath(dir, copyBannerAsset(imageFull)),
+        linkHref,
+        alt: entry.alt || defaultAlt(imageFull),
+      });
+      console.log(`  wrote banner for ${dir}/index.html`);
+    }
+    return rendered;
+  }
+
+  publishConfig._banners = buildBanners(Object.keys(DIR_LABELS));
 
   const pcRoster = pages.find(p => p.frontmatter.type === 'pc_roster');
   const pcRedirectTarget = pcRoster ? pcRoster.outputPath : null;

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -341,6 +341,11 @@ function build(options = {}) {
   // `<img src>`, so converting here means the new extension flows into references at
   // emission time — no rewriting of generated HTML, and no string-matching URL-encoded
   // paths (`images/Rock%20Lavey.jpg`) that an external postbuild would silently miss.
+  //
+  // The cost of that ordering: player mode only learns which images are actually referenced
+  // (`usedImages`) while rendering, so an unreferenced attachment is encoded here and then
+  // dropped at copy time. Correct, just wasted work — and unavoidable without emitting a
+  // `src` before knowing the extension it will end up with.
   let imagesTmpDir = null;
   if (resolveImageConfig(publishConfig.images).optimize) {
     imagesTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-img-'));

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
+const { optimizeImages, resolveImageConfig } = require('./image-optimize');
 const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
@@ -144,7 +146,7 @@ function build(options = {}) {
     for (const entry of Object.values(imageMap)) {
       const dest = path.join(outputDir, 'images', entry.relPath);
       ensureDir(dest);
-      fs.copyFileSync(entry.sourcePath, dest);
+      fs.copyFileSync(entry.encodedPath || entry.sourcePath, dest);
     }
     console.log(`Copied ${Object.keys(imageMap).length} images`);
   }
@@ -334,6 +336,30 @@ function build(options = {}) {
 
   const imageMap = scanAttachments(config);
   console.log(`Found ${Object.keys(imageMap).length} image files`);
+
+  // Re-encode before a single page renders. The tool owns both the image copy and every
+  // `<img src>`, so converting here means the new extension flows into references at
+  // emission time — no rewriting of generated HTML, and no string-matching URL-encoded
+  // paths (`images/Rock%20Lavey.jpg`) that an external postbuild would silently miss.
+  let imagesTmpDir = null;
+  if (resolveImageConfig(publishConfig.images).optimize) {
+    imagesTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-img-'));
+    const stats = optimizeImages(imageMap, publishConfig.images, imagesTmpDir);
+    if (stats.reason) {
+      console.warn(`  WARNING: image optimization requested but skipped — ${stats.reason}`);
+    } else {
+      const mb = bytes => (bytes / 1024 / 1024).toFixed(1);
+      const saved = stats.bytesBefore > 0
+        ? Math.round((1 - stats.bytesAfter / stats.bytesBefore) * 100)
+        : 0;
+      console.log(
+        `Optimized ${stats.converted} image(s) via ${stats.encoder}: ` +
+        `${mb(stats.bytesBefore)} MB → ${mb(stats.bytesAfter)} MB (${saved}% smaller)` +
+        `${stats.skipped ? `, ${stats.skipped} left as-is` : ''}` +
+        `${stats.failed ? `, ${stats.failed} failed` : ''}`
+      );
+    }
+  }
 
   cleanOutput();
   copyCSS();
@@ -539,6 +565,10 @@ function build(options = {}) {
   } else {
     copyImages(imageMap);
   }
+
+  // The encoded bytes are now in the output tree. Scratch dir lives under os.tmpdir(), so a
+  // build that throws before reaching here leaks nothing the OS won't reclaim.
+  if (imagesTmpDir) fs.rmSync(imagesTmpDir, { recursive: true, force: true });
 
   // Generate index pages for each output directory
   const dirs = {};

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -26,6 +26,13 @@ const PUBLISH_DEFAULTS = {
     style: 'in-world',
     message: 'This page is not available.',
   },
+  // Opt-in. Off means images are copied byte-for-byte, as they always were.
+  images: {
+    optimize: false,
+    format: 'webp',
+    max_width: 1600,
+    quality: 82,
+  },
   overrides: {
     exclude: [],
     include: [],
@@ -104,6 +111,11 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
     four_oh_four: {
       ...PUBLISH_DEFAULTS.four_oh_four,
       ...publish.four_oh_four,
+    },
+    images: {
+      ...PUBLISH_DEFAULTS.images,
+      ...jsonConfigFallback.images,
+      ...publish.images,
     },
     overrides: {
       ...PUBLISH_DEFAULTS.overrides,

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -117,6 +117,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
       ...jsonConfigFallback.images,
       ...publish.images,
     },
+    // Per-section index banners, keyed by output dir ("locations", "factions", …). No
+    // defaults: absent means "look for the conventional _banner.* in the section folder".
+    banners: { ...jsonConfigFallback.banners, ...publish.banners },
     // Deliberately not merged with a default: the Locations index needs to tell
     // "group_by never mentioned" (fall back to the genre's pivot) apart from
     // "group_by explicitly falsy" (grouping off), and a default would erase that.

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -117,6 +117,10 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
       ...jsonConfigFallback.images,
       ...publish.images,
     },
+    // Deliberately not merged with a default: the Locations index needs to tell
+    // "group_by never mentioned" (fall back to the genre's pivot) apart from
+    // "group_by explicitly falsy" (grouping off), and a default would erase that.
+    locations: { ...jsonConfigFallback.locations, ...publish.locations },
     overrides: {
       ...PUBLISH_DEFAULTS.overrides,
       ...publish.overrides,

--- a/tools/publish/lib/image-optimize.js
+++ b/tools/publish/lib/image-optimize.js
@@ -107,14 +107,24 @@ function detectEncoder() {
   }
 }
 
+// A non-numeric config value must fall back to the default, not sail through as NaN: cwebp
+// would receive the literal string "NaN" as its -q and fail every single image.
+function numberOr(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(n, min, max) {
+  return Math.min(max, Math.max(min, n));
+}
+
 function resolveImageConfig(images) {
   const cfg = images || {};
-  const maxWidth = cfg.max_width ?? cfg.maxWidth ?? 1600;
   return {
     optimize: cfg.optimize === true,
     format: String(cfg.format || 'webp').toLowerCase(),
-    maxWidth: Number(maxWidth) || 0,
-    quality: Number(cfg.quality ?? 82),
+    maxWidth: Math.max(0, numberOr(cfg.max_width ?? cfg.maxWidth, 1600)),
+    quality: clamp(numberOr(cfg.quality, 82), 0, 100),
   };
 }
 

--- a/tools/publish/lib/image-optimize.js
+++ b/tools/publish/lib/image-optimize.js
@@ -1,0 +1,202 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+// Only raster formats that reliably shrink when re-encoded. SVG is vector, GIF may be
+// animated, and WebP/AVIF are already in a modern format — all pass through untouched.
+const OPTIMIZABLE_EXT = /\.(png|jpe?g)$/i;
+
+const SUPPORTED_FORMATS = new Set(['webp']);
+
+/**
+ * Read an image's pixel width straight from its header.
+ *
+ * Cheaper and far more portable than shelling out to `sips`/`identify` just to learn
+ * whether a resize is needed: cwebp's `-resize` has no shrink-only mode and will happily
+ * upscale an image that is already narrower than maxWidth.
+ *
+ * @returns {number|null} width in pixels, or null if the header can't be read
+ */
+function probeWidth(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const head = Buffer.alloc(2);
+    if (fs.readSync(fd, head, 0, 2, 0) < 2) return null;
+
+    // PNG: 8-byte signature, then a 4-byte chunk length, 'IHDR', width (uint32 BE).
+    if (head[0] === 0x89 && head[1] === 0x50) {
+      const buf = Buffer.alloc(4);
+      if (fs.readSync(fd, buf, 0, 4, 16) < 4) return null;
+      return buf.readUInt32BE(0) || null;
+    }
+
+    // JPEG: walk the marker chain to a Start-Of-Frame segment, whose payload is
+    // precision(1) height(2) width(2).
+    if (head[0] === 0xff && head[1] === 0xd8) {
+      const { size } = fs.fstatSync(fd);
+      let offset = 2;
+      const seg = Buffer.alloc(9);
+      while (offset + 9 <= size) {
+        if (fs.readSync(fd, seg, 0, 9, offset) < 9) return null;
+        if (seg[0] !== 0xff) return null; // desynced from the marker chain
+        const marker = seg[1];
+        // Standalone markers carry no length payload.
+        if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd9)) { offset += 2; continue; }
+        const segLength = seg.readUInt16BE(2);
+        if (segLength < 2) return null;
+        // SOF0-3, SOF5-7, SOF9-11, SOF13-15. DHT (c4), JPG (c8) and DAC (cc) are not frames.
+        const isSOF = marker >= 0xc0 && marker <= 0xcf
+          && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+        if (isSOF) return seg.readUInt16BE(7) || null;
+        offset += 2 + segLength;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * Assemble the cwebp argv for one image.
+ *
+ * `-resize W 0` scales to width W preserving aspect ratio — but it enlarges as readily as
+ * it shrinks, and cwebp has no shrink-only flag. So the resize is only requested once the
+ * source is known to be wider than the cap; an unreadable header means no resize at all.
+ *
+ * @param {{src: string, dest: string, maxWidth: number, quality: number, width: number|null}} spec
+ * @returns {string[]}
+ */
+function buildCwebpArgs({ src, dest, maxWidth, quality, width }) {
+  const args = ['-quiet', '-q', String(quality)];
+  if (maxWidth > 0 && width && width > maxWidth) args.push('-resize', String(maxWidth), '0');
+  args.push(src, '-o', dest);
+  return args;
+}
+
+function cwebpEncoder() {
+  return {
+    name: 'cwebp',
+    encode(src, dest, { maxWidth, quality }) {
+      const args = buildCwebpArgs({ src, dest, maxWidth, quality, width: probeWidth(src) });
+      execFileSync('cwebp', args, { stdio: 'ignore' });
+    },
+  };
+}
+
+/**
+ * Pick an available encoder.
+ *
+ * cwebp (libwebp) rather than `sharp`, for two reasons. This tool vendors its runtime deps
+ * into a git-tracked node_modules so they survive the copy into the plugin cache, and
+ * sharp's per-platform native binaries are not viable to vendor. And sharp's API is
+ * promise-only, which would make the whole synchronous build pipeline async for a feature
+ * that is off by default.
+ *
+ * @returns {{name: string, encode: Function}|null}
+ */
+function detectEncoder() {
+  try {
+    execFileSync('cwebp', ['-version'], { stdio: 'ignore' });
+    return cwebpEncoder();
+  } catch {
+    return null;
+  }
+}
+
+function resolveImageConfig(images) {
+  const cfg = images || {};
+  const maxWidth = cfg.max_width ?? cfg.maxWidth ?? 1600;
+  return {
+    optimize: cfg.optimize === true,
+    format: String(cfg.format || 'webp').toLowerCase(),
+    maxWidth: Number(maxWidth) || 0,
+    quality: Number(cfg.quality ?? 82),
+  };
+}
+
+/**
+ * Re-encode every optimizable image in `imageMap` into `tmpDir`, in place.
+ *
+ * Mutates each converted entry: `relPath` gains the new extension (so templates emit the
+ * converted reference at src-emission time, never by string-matching generated HTML) and
+ * `encodedPath` points at the encoded bytes for the later copy pass. An entry whose encode
+ * fails, or whose result is not actually smaller, is left completely untouched.
+ *
+ * @param {Record<string, {sourcePath: string, relPath: string, encodedPath?: string}>} imageMap
+ * @param {object} imagesConfig - the `publish.images` block
+ * @param {string} tmpDir - scratch directory the caller owns and cleans up
+ * @param {{encoder?: {name: string, encode: Function}|null}} [options] - inject an encoder (tests)
+ * @returns {{converted: number, skipped: number, failed: number, bytesBefore: number, bytesAfter: number, encoder: string|null, reason?: string}}
+ */
+function optimizeImages(imageMap, imagesConfig, tmpDir, options = {}) {
+  const stats = { converted: 0, skipped: 0, failed: 0, bytesBefore: 0, bytesAfter: 0, encoder: null };
+  const cfg = resolveImageConfig(imagesConfig);
+  if (!cfg.optimize) return { ...stats, reason: 'disabled' };
+
+  if (!SUPPORTED_FORMATS.has(cfg.format)) {
+    return { ...stats, reason: `unsupported format "${cfg.format}" (supported: webp)` };
+  }
+
+  const encoder = 'encoder' in options ? options.encoder : detectEncoder();
+  if (!encoder) {
+    return { ...stats, reason: 'cwebp not found on PATH — install libwebp (brew install webp / apt install webp)' };
+  }
+  stats.encoder = encoder.name;
+
+  // Two sources with the same stem in the same directory (`a.png` and `a.jpg`) would both
+  // want `a.webp`. First one wins; the loser keeps its original bytes rather than silently
+  // clobbering a sibling that other pages already reference.
+  const claimedRelPaths = new Set(Object.values(imageMap).map(e => e.relPath.toLowerCase()));
+  let counter = 0;
+
+  for (const [basename, entry] of Object.entries(imageMap)) {
+    if (!OPTIMIZABLE_EXT.test(basename)) { stats.skipped++; continue; }
+
+    const targetRelPath = entry.relPath.replace(OPTIMIZABLE_EXT, `.${cfg.format}`);
+    if (claimedRelPaths.has(targetRelPath.toLowerCase())) {
+      console.warn(`  images: skipping "${basename}" — "${targetRelPath}" is already taken`);
+      stats.skipped++;
+      continue;
+    }
+
+    // Encoded filenames are ordinals, not the source basename: the scratch path never has
+    // to survive spaces, non-ASCII, or a nested relPath.
+    const encodedPath = path.join(tmpDir, `${counter++}.${cfg.format}`);
+    try {
+      encoder.encode(entry.sourcePath, encodedPath, cfg);
+    } catch (e) {
+      console.warn(`  images: failed to encode "${basename}" — ${e.message.split('\n')[0]}`);
+      stats.failed++;
+      continue;
+    }
+
+    if (!fs.existsSync(encodedPath)) { stats.failed++; continue; }
+
+    const before = fs.statSync(entry.sourcePath).size;
+    const after = fs.statSync(encodedPath).size;
+    if (after >= before) {
+      // Already well-compressed. Keeping the original is strictly better than shipping a
+      // larger file in a format some older clients can't read.
+      fs.rmSync(encodedPath, { force: true });
+      stats.skipped++;
+      continue;
+    }
+
+    claimedRelPaths.add(targetRelPath.toLowerCase());
+    entry.encodedPath = encodedPath;
+    entry.relPath = targetRelPath;
+    stats.converted++;
+    stats.bytesBefore += before;
+    stats.bytesAfter += after;
+  }
+
+  return stats;
+}
+
+module.exports = {
+  optimizeImages, detectEncoder, resolveImageConfig, probeWidth, buildCwebpArgs, OPTIMIZABLE_EXT,
+};

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -160,14 +160,14 @@ function metadataBadgesFor(frontmatter) {
   return `<div class="metadata-badges">${badges.join('\n')}</div>`;
 }
 
-function portraitImg(frontmatter, outputPath, imageMap, attachmentsDir) {
+function portraitImg(frontmatter, outputPath, imageMap) {
   const portrait = frontmatter.portrait;
   if (!portrait) return '';
 
-  const prefix = (attachmentsDir || '_attachments') + '/';
-  const portraitStr = String(portrait);
-  const declaredPath = portraitStr.startsWith(prefix) ? portraitStr.slice(prefix.length) : portraitStr;
-  const basename = declaredPath.split('/').pop();
+  // The scanner keys imageMap by bare basename, so however a `portrait:` spells its path —
+  // `_attachments/characters/Rock.png`, `characters/Rock.png`, or `Rock.png` — the lookup is
+  // the last segment. Stripping the attachments prefix first never changed that.
+  const basename = String(portrait).split('/').pop();
 
   // Verify the image was actually discovered by the scanner
   const entry = imageMap[basename];

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -166,14 +166,18 @@ function portraitImg(frontmatter, outputPath, imageMap, attachmentsDir) {
 
   const prefix = (attachmentsDir || '_attachments') + '/';
   const portraitStr = String(portrait);
-  const relPath = portraitStr.startsWith(prefix) ? portraitStr.slice(prefix.length) : portraitStr;
-  const basename = relPath.split('/').pop();
+  const declaredPath = portraitStr.startsWith(prefix) ? portraitStr.slice(prefix.length) : portraitStr;
+  const basename = declaredPath.split('/').pop();
 
   // Verify the image was actually discovered by the scanner
-  if (!imageMap[basename]) return '';
+  const entry = imageMap[basename];
+  if (!entry) return '';
 
   const currentDir = outputPath.substring(0, outputPath.lastIndexOf('/'));
-  const imgPath = 'images/' + relPath;
+  // The scanner's relPath, not the frontmatter's: it is where copyImages actually writes the
+  // file, so a `portrait:` that omits the subdirectory still resolves — and an image the
+  // build re-encoded carries its new extension here.
+  const imgPath = 'images/' + entry.relPath;
   // Attachment filenames routinely carry spaces and non-ASCII ("Vita Ó Taidhg.png"), which
   // are not valid in a URL. Templates that lift this src back out of the tag (hero banners)
   // inherit the encoding.

--- a/tools/publish/lib/templates/base.js
+++ b/tools/publish/lib/templates/base.js
@@ -34,7 +34,7 @@ function clientScripts(outputPath) {
   return [root + 'js/nav.js', root + 'js/lightbox.js', root + 'js/search.js'];
 }
 
-function baseShell({ title, siteTitle, cssHref, navHtml, rootHref, content, footer, genrePreset, breadcrumbsHtml, scripts }) {
+function baseShell({ title, siteTitle, cssHref, navHtml, rootHref, content, footer, genrePreset, overridesCss, breadcrumbsHtml, scripts }) {
   const footerHtml = footer ? `<footer class="site-footer">${escapeHtml(footer)}</footer>` : '';
   const themeCssHref = cssHref.replace('style.css', 'theme.css');
   const genreCssHref = genrePreset
@@ -42,6 +42,12 @@ function baseShell({ title, siteTitle, cssHref, navHtml, rootHref, content, foot
     : '';
   const genreLinkTag = genreCssHref
     ? `\n  <link rel="stylesheet" href="${genreCssHref}">`
+    : '';
+  // Linked last so a site's own rules win the cascade against style.css, the genre overlay,
+  // and the generated theme.css. Only emitted when the build actually copied one, so a site
+  // that never scaffolded css/overrides.css doesn't 404 on every page.
+  const overridesLinkTag = overridesCss
+    ? `\n  <link rel="stylesheet" href="${cssHref.replace('style.css', 'overrides.css')}">`
     : '';
   const breadcrumbs = breadcrumbsHtml || '';
   const scriptTags = scripts
@@ -54,7 +60,7 @@ function baseShell({ title, siteTitle, cssHref, navHtml, rootHref, content, foot
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${escapeHtml(title)} — ${escapeHtml(siteTitle)}</title>
   <link rel="stylesheet" href="${cssHref}">${genreLinkTag}
-  <link rel="stylesheet" href="${themeCssHref}">
+  <link rel="stylesheet" href="${themeCssHref}">${overridesLinkTag}
 </head>
 <body>
 

--- a/tools/publish/lib/templates/creature.js
+++ b/tools/publish/lib/templates/creature.js
@@ -8,7 +8,7 @@ function creatureTemplate(page, processedContent, navFor, config, imageMap, cont
   const publishConfig = (context || {}).publishConfig || {};
   const linkMap = (context || {}).linkMap || {};
   const backlinks = (publishConfig._backlinks || {})[page.title] || [];
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
   // Build stat block from frontmatter fields
   const stats = [];

--- a/tools/publish/lib/templates/creature.js
+++ b/tools/publish/lib/templates/creature.js
@@ -77,6 +77,7 @@ function creatureTemplate(page, processedContent, navFor, config, imageMap, cont
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/event.js
+++ b/tools/publish/lib/templates/event.js
@@ -121,6 +121,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/event.js
+++ b/tools/publish/lib/templates/event.js
@@ -25,7 +25,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
   const fm = page.frontmatter;
   const publishConfig = (context || {}).publishConfig || {};
   const backlinks = (publishConfig._backlinks || {})[page.title] || [];
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
   const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
 
   const badges = [];

--- a/tools/publish/lib/templates/faction.js
+++ b/tools/publish/lib/templates/faction.js
@@ -7,7 +7,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
   const fm = page.frontmatter;
   const publishConfig = (context || {}).publishConfig || {};
   const backlinks = (publishConfig._backlinks || {})[page.title] || [];
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
   // Metadata badges
   const badges = [];

--- a/tools/publish/lib/templates/faction.js
+++ b/tools/publish/lib/templates/faction.js
@@ -104,6 +104,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/four-oh-four.js
+++ b/tools/publish/lib/templates/four-oh-four.js
@@ -16,6 +16,12 @@ function fourOhFourTemplate(config) {
     ? `\n  <link rel="stylesheet" href="${href(`css/themes/${config.genrePreset}.css`)}">`
     : '';
 
+  // Same cascade position as every other page: after the generated theme, before the
+  // page-local <style>. Only linked when the build copied one.
+  const overridesLinkTag = config.overridesCss
+    ? `\n  <link rel="stylesheet" href="${href('css/overrides.css')}">`
+    : '';
+
   const imageHtml = campaignImage
     ? `<img src="${href(escapeHtml(campaignImage))}" alt="${siteTitle}" class="four-oh-four-image">`
     : '';
@@ -27,7 +33,7 @@ function fourOhFourTemplate(config) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Not Found — ${siteTitle}</title>
   <link rel="stylesheet" href="${href('css/style.css')}">
-  <link rel="stylesheet" href="${href('css/theme.css')}">${genreLinkTag}
+  <link rel="stylesheet" href="${href('css/theme.css')}">${genreLinkTag}${overridesLinkTag}
   <style>
     .four-oh-four-hero {
       text-align: center;

--- a/tools/publish/lib/templates/heritage.js
+++ b/tools/publish/lib/templates/heritage.js
@@ -8,7 +8,7 @@ function heritageTemplate(page, processedContent, navFor, config, imageMap, cont
   const publishConfig = (context || {}).publishConfig || {};
   const linkMap = (context || {}).linkMap || {};
   const backlinks = (publishConfig._backlinks || {})[page.title] || [];
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
   const badges = [];
   if (fm.notable_traits && Array.isArray(fm.notable_traits)) {

--- a/tools/publish/lib/templates/heritage.js
+++ b/tools/publish/lib/templates/heritage.js
@@ -65,6 +65,7 @@ function heritageTemplate(page, processedContent, navFor, config, imageMap, cont
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -802,6 +802,7 @@ ${bodyContent}`;
     content,
     footer: config.footer,
     genrePreset: (publishConfig || {})._genrePreset,
+    overridesCss: (publishConfig || {})._overridesCss,
     breadcrumbsHtml,
     scripts: [...clientScripts(outputPath), rootPath(outputPath) + 'js/filters.js'],
   });

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -227,9 +227,17 @@ function renderGroupedLocationsPage(pages, indexDir, imageMap, grouping) {
     const count = subtreeSize(node);
     const rows = node.children.slice().sort(byTitle).map(renderNode).join('\n');
 
+    // The system heading a section is a location like any other, so it reserves the same
+    // thumbnail slot. Without the spacer, a portrait-less system's title sits flush left
+    // while its neighbours' titles are pushed right by their thumbnails — and in a grid of
+    // section cards that misalignment reads across the whole page.
+    const thumbHtml = thumb
+      ? `<span class="loc-system-thumb">${thumb}</span>`
+      : '<span class="loc-system-thumb loc-system-thumb-empty" aria-hidden="true"></span>';
+
     return `<section class="loc-system">
   <header class="loc-system-header">
-    ${thumb ? `<span class="loc-system-thumb">${thumb}</span>` : ''}
+    ${thumbHtml}
     <h2 class="loc-system-title"><a href="${escapeHtml(relHref(p, indexDir))}">${escapeHtml(p.displayTitle)}</a></h2>
     ${locType ? `<span class="loc-type-badge">${escapeHtml(locType)}</span>` : ''}
     <span class="loc-system-count">${count} location${count !== 1 ? 's' : ''}</span>
@@ -256,6 +264,7 @@ function renderGroupedLocationsPage(pages, indexDir, imageMap, grouping) {
   const ungroupedHtml = leftoverRoots.length
     ? `<section class="loc-system loc-system-ungrouped">
   <header class="loc-system-header">
+    <span class="loc-system-thumb loc-system-thumb-empty" aria-hidden="true"></span>
     <h2 class="loc-system-title">${escapeHtml(grouping.ungroupedLabel)}</h2>
     <span class="loc-system-count">${leftoverRoots.length} entr${leftoverRoots.length !== 1 ? 'ies' : 'y'}</span>
   </header>

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -105,7 +105,177 @@ function renderLocationTreeHTML(nodes, depth, indexDir) {
   return items;
 }
 
-function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_attachments') {
+// The location_type that becomes a top-level section, per genre. A space campaign's
+// geography funnels through one political root (Republic → Sector → System → body), so the
+// star system — not the polity — is the unit a reader actually navigates by.
+const GENRE_LOCATION_PIVOT = {
+  scifi: 'system',
+};
+
+const DEFAULT_UNGROUPED_LABEL = 'Deep Space & Routes';
+
+/**
+ * Resolve the pivot grouping for the Locations index, or null to keep the flat region view.
+ * An explicit `group_by` always wins, including a falsy one, which turns grouping off for a
+ * genre that would otherwise default it on.
+ */
+function resolveLocationGrouping(publishConfig) {
+  const locations = (publishConfig && publishConfig.locations) || {};
+  const genre = (publishConfig && publishConfig._genrePreset) || null;
+  const pivot = Object.prototype.hasOwnProperty.call(locations, 'group_by')
+    ? locations.group_by
+    : GENRE_LOCATION_PIVOT[genre];
+  if (!pivot) return null;
+  return {
+    pivot: String(pivot).toLowerCase(),
+    ungroupedLabel: locations.ungrouped_label || DEFAULT_UNGROUPED_LABEL,
+  };
+}
+
+function isPivotNode(node, pivot) {
+  return String(node.page.frontmatter.location_type || '').toLowerCase().includes(pivot);
+}
+
+function subtreeSize(node) {
+  return 1 + node.children.reduce((sum, c) => sum + subtreeSize(c), 0);
+}
+
+/**
+ * Split the location forest into pivot sections plus everything that hangs outside one.
+ *
+ * A non-pivot node with a pivot somewhere beneath it is *scaffolding* — the political chain
+ * above the systems. It never renders as a row; it survives only as each section's context
+ * caption. A subtree with no pivot anywhere in it (routes, anomalies) is a leftover, and is
+ * captured at its topmost node so it renders exactly once.
+ *
+ * @returns {{sections: Array<{node: object, ancestors: object[]}>, leftoverRoots: object[]}}
+ */
+function partitionByPivot(roots, pivot) {
+  const out = { sections: [], leftoverRoots: [] };
+
+  // Returns whether this node, or anything under it, is a pivot.
+  function classify(node, ancestors) {
+    if (isPivotNode(node, pivot)) {
+      // Don't descend: a pivot nested inside another pivot's subtree stays a nested row
+      // rather than becoming a competing top-level section.
+      out.sections.push({ node, ancestors });
+      return true;
+    }
+    const childHasPivot = node.children.map(child => classify(child, ancestors.concat(node)));
+    if (!childHasPivot.some(Boolean)) return false;
+    node.children.forEach((child, i) => {
+      if (!childHasPivot[i]) out.leftoverRoots.push(child);
+    });
+    return true;
+  }
+
+  for (const root of roots) {
+    if (!classify(root, [])) out.leftoverRoots.push(root);
+  }
+  return out;
+}
+
+function renderContextCaption(ancestors) {
+  if (!ancestors.length) return '';
+  const trail = ancestors.map(a => escapeHtml(a.page.displayTitle)).join(' &rsaquo; ');
+  return `<p class="loc-context">${trail}</p>`;
+}
+
+function renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, grouping) {
+  const roots = buildLocationTree(pages);
+  const { sections, leftoverRoots } = partitionByPivot(roots, grouping.pivot);
+
+  // One pivot is not a grouping — it's the same single deep tree with a new heading. Fall
+  // back rather than pretend.
+  if (sections.length < 2) return null;
+
+  const outputPath = indexDir + '/index.html';
+  const byTitle = (a, b) => a.page.displayTitle.localeCompare(b.page.displayTitle);
+
+  // Every location is a first-class row: its own thumbnail, its own badge, its children
+  // nested beneath it even when it is an only child. Collapsing a single-child chain into a
+  // breadcrumb would swallow real bodies — a planet, an asteroid belt — into scaffolding and
+  // make them read unlike their sibling bodies. Grouping by system already keeps this shallow.
+  function renderNode(node) {
+    const p = node.page;
+    const locType = p.frontmatter.location_type || '';
+    const thumb = portraitImg(p.frontmatter, outputPath, imageMap, attachmentsDir);
+    // An invisible spacer, not a dashed placeholder box: rows stay aligned without drawing
+    // attention to an entity that simply has no portrait yet.
+    const thumbHtml = thumb
+      ? `<span class="loc-node-thumb">${thumb}</span>`
+      : '<span class="loc-node-thumb loc-node-thumb-empty" aria-hidden="true"></span>';
+
+    const childrenHtml = node.children.length
+      ? `<div class="loc-node-children">${node.children.slice().sort(byTitle).map(renderNode).join('\n')}</div>`
+      : '';
+
+    return `<div class="loc-node">
+  <div class="loc-node-row">
+    ${thumbHtml}
+    <a class="loc-node-name" href="${escapeHtml(relHref(p, indexDir))}">${escapeHtml(p.displayTitle)}</a>
+    ${locType ? `<span class="loc-type-badge">${escapeHtml(locType)}</span>` : ''}
+  </div>
+  ${childrenHtml}
+</div>`;
+  }
+
+  function renderSection({ node, ancestors }, { caption }) {
+    const p = node.page;
+    const locType = p.frontmatter.location_type || '';
+    const thumb = portraitImg(p.frontmatter, outputPath, imageMap, attachmentsDir);
+    const count = subtreeSize(node);
+    const rows = node.children.slice().sort(byTitle).map(renderNode).join('\n');
+
+    return `<section class="loc-system">
+  <header class="loc-system-header">
+    ${thumb ? `<span class="loc-system-thumb">${thumb}</span>` : ''}
+    <h2 class="loc-system-title"><a href="${escapeHtml(relHref(p, indexDir))}">${escapeHtml(p.displayTitle)}</a></h2>
+    ${locType ? `<span class="loc-type-badge">${escapeHtml(locType)}</span>` : ''}
+    <span class="loc-system-count">${count} location${count !== 1 ? 's' : ''}</span>
+  </header>
+  ${caption ? renderContextCaption(ancestors) : ''}
+  <div class="loc-system-body">${rows}</div>
+</section>`;
+  }
+
+  // When every system hangs off the same political chain, the chain is page context, not
+  // per-section context. Say it once above the sections instead of on every card.
+  const chainOf = s => s.ancestors.map(a => a.page.displayTitle).join(' > ');
+  const sharedChain = sections.every(s => chainOf(s) === chainOf(sections[0]))
+    ? sections[0].ancestors
+    : null;
+  const pageCaption = sharedChain && sharedChain.length ? renderContextCaption(sharedChain) : '';
+
+  const sectionsHtml = sections
+    .slice()
+    .sort((a, b) => byTitle(a.node, b.node))
+    .map(section => renderSection(section, { caption: !sharedChain }))
+    .join('\n');
+
+  const ungroupedHtml = leftoverRoots.length
+    ? `<section class="loc-system loc-system-ungrouped">
+  <header class="loc-system-header">
+    <h2 class="loc-system-title">${escapeHtml(grouping.ungroupedLabel)}</h2>
+    <span class="loc-system-count">${leftoverRoots.length} entr${leftoverRoots.length !== 1 ? 'ies' : 'y'}</span>
+  </header>
+  <div class="loc-system-body">${leftoverRoots.slice().sort(byTitle).map(renderNode).join('\n')}</div>
+</section>`
+    : '';
+
+  return `<div class="locations-page locations-grouped">
+  ${pageCaption}
+  <div class="loc-system-grid">${sectionsHtml}\n${ungroupedHtml}</div>
+</div>`;
+}
+
+function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_attachments', publishConfig = null) {
+  const grouping = resolveLocationGrouping(publishConfig);
+  if (grouping) {
+    const grouped = renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, grouping);
+    if (grouped) return grouped;
+  }
+
   const roots = buildLocationTree(pages);
 
   // Group ROOT cards: by the (unpublished) parent name if one was
@@ -700,7 +870,7 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
   } else if (isCreatures) {
     bodyContent = renderBestiary(pages, dir);
   } else if (isLocations) {
-    bodyContent = renderLocationsPage(pages, dir, imageMap, attachmentsDir);
+    bodyContent = renderLocationsPage(pages, dir, imageMap, attachmentsDir, publishConfig);
   } else if (isFactions) {
     bodyContent = renderFactions(pages, dir, imageMap, attachmentsDir);
   } else if (isItems) {
@@ -808,4 +978,7 @@ ${bodyContent}`;
   });
 }
 
-module.exports = { indexTemplate, buildPillFilters, buildLocationTree, renderLocationsPage };
+module.exports = {
+  indexTemplate, buildPillFilters, buildLocationTree, renderLocationsPage,
+  resolveLocationGrouping, partitionByPivot,
+};

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -971,13 +971,16 @@ ${locationTreeHtml}
 ${bodyContent}`;
   }
 
+  // Above the page title, full-width: a section hero, not an illustration of the listing.
+  const bannerHtml = ((publishConfig || {})._banners || {})[dir] || '';
+
   return baseShell({
     title: label,
     siteTitle: config.siteTitle,
     cssHref: cssPath(outputPath),
     navHtml: navFor(outputPath, config),
     rootHref: rootPath(outputPath),
-    content,
+    content: bannerHtml + content,
     footer: config.footer,
     genrePreset: (publishConfig || {})._genrePreset,
     overridesCss: (publishConfig || {})._overridesCss,

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -181,7 +181,7 @@ function renderContextCaption(ancestors) {
   return `<p class="loc-context">${trail}</p>`;
 }
 
-function renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, grouping) {
+function renderGroupedLocationsPage(pages, indexDir, imageMap, grouping) {
   const roots = buildLocationTree(pages);
   const { sections, leftoverRoots } = partitionByPivot(roots, grouping.pivot);
 
@@ -199,7 +199,7 @@ function renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, g
   function renderNode(node) {
     const p = node.page;
     const locType = p.frontmatter.location_type || '';
-    const thumb = portraitImg(p.frontmatter, outputPath, imageMap, attachmentsDir);
+    const thumb = portraitImg(p.frontmatter, outputPath, imageMap);
     // An invisible spacer, not a dashed placeholder box: rows stay aligned without drawing
     // attention to an entity that simply has no portrait yet.
     const thumbHtml = thumb
@@ -223,7 +223,7 @@ function renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, g
   function renderSection({ node, ancestors }, { caption }) {
     const p = node.page;
     const locType = p.frontmatter.location_type || '';
-    const thumb = portraitImg(p.frontmatter, outputPath, imageMap, attachmentsDir);
+    const thumb = portraitImg(p.frontmatter, outputPath, imageMap);
     const count = subtreeSize(node);
     const rows = node.children.slice().sort(byTitle).map(renderNode).join('\n');
 
@@ -269,10 +269,10 @@ function renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, g
 </div>`;
 }
 
-function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_attachments', publishConfig = null) {
+function renderLocationsPage(pages, indexDir, imageMap = {}, publishConfig = null) {
   const grouping = resolveLocationGrouping(publishConfig);
   if (grouping) {
-    const grouped = renderGroupedLocationsPage(pages, indexDir, imageMap, attachmentsDir, grouping);
+    const grouped = renderGroupedLocationsPage(pages, indexDir, imageMap, grouping);
     if (grouped) return grouped;
   }
 
@@ -310,7 +310,7 @@ function renderLocationsPage(pages, indexDir, imageMap = {}, attachmentsDir = '_
       ? `<div class="loc-children">${renderLocationTreeHTML(node.children, 0, indexDir)}</div>`
       : '';
 
-    const thumb = portraitImg(fm, indexDir + '/index.html', imageMap, attachmentsDir);
+    const thumb = portraitImg(fm, indexDir + '/index.html', imageMap);
 
     return `<div class="loc-card">
   ${thumb ? `<div class="loc-card-thumb">${thumb}</div>` : ''}
@@ -488,7 +488,7 @@ function renderBestiary(pages, indexDir) {
   return `<div class="bestiary">${cards}</div>`;
 }
 
-function renderFactions(pages, indexDir, imageMap = {}, attachmentsDir = '_attachments') {
+function renderFactions(pages, indexDir, imageMap = {}) {
   const factions = pages
     .filter(p => p.frontmatter.type === 'faction' || p.frontmatter.type === 'organization')
     .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle));
@@ -547,7 +547,7 @@ function renderFactions(pages, indexDir, imageMap = {}, attachmentsDir = '_attac
       ? `<span class="intel-canon-badge">${escapeHtml(canon)}</span>`
       : '';
 
-    const thumb = portraitImg(fm, indexDir + '/index.html', imageMap, attachmentsDir);
+    const thumb = portraitImg(fm, indexDir + '/index.html', imageMap);
 
     return `<article class="intel-card">
   <div class="intel-card-header">
@@ -755,7 +755,7 @@ function sessionRef(frontmatter) {
   return ISO_DATE_RE.test(value) ? '' : value;
 }
 
-function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachments', linkMap = {}) {
+function renderNPCTable(pages, dir, imageMap = {}, linkMap = {}) {
   const sorted = pages
     .filter(p => p.frontmatter.type === 'npc')
     .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle));
@@ -795,7 +795,7 @@ function renderNPCTable(pages, dir, imageMap = {}, attachmentsDir = '_attachment
     const firstApp = cleanRef(fm.first_appearance || '');
     const lastSession = sessionRef(fm);
     const canonStatus = getCanonStatus(fm) || '';
-    const avatar = portraitImg(fm, dir + '/index.html', imageMap, attachmentsDir);
+    const avatar = portraitImg(fm, dir + '/index.html', imageMap);
     const avatarHtml = avatar
       ? `<span class="npc-row-avatar">${avatar}</span>`
       : `<span class="npc-row-avatar npc-row-initials" aria-hidden="true">${escapeHtml(getInitials(p.displayTitle))}</span>`;
@@ -832,7 +832,6 @@ ${rows}
 
 function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMap = {}) {
   const outputPath = dir + '/index.html';
-  const attachmentsDir = config.attachmentsDir || '_attachments';
   const crumbs = generateBreadcrumbs(outputPath, {});
   const breadcrumbsHtml = renderBreadcrumbs(crumbs);
   const total = pages.length;
@@ -864,15 +863,15 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
 
   let bodyContent;
   if (isNPCs) {
-    bodyContent = renderNPCTable(pages, dir, imageMap, attachmentsDir, (publishConfig || {})._linkMap || {});
+    bodyContent = renderNPCTable(pages, dir, imageMap, (publishConfig || {})._linkMap || {});
   } else if (isChapters) {
     bodyContent = renderChapterList(pages, dir);
   } else if (isCreatures) {
     bodyContent = renderBestiary(pages, dir);
   } else if (isLocations) {
-    bodyContent = renderLocationsPage(pages, dir, imageMap, attachmentsDir, publishConfig);
+    bodyContent = renderLocationsPage(pages, dir, imageMap, publishConfig);
   } else if (isFactions) {
-    bodyContent = renderFactions(pages, dir, imageMap, attachmentsDir);
+    bodyContent = renderFactions(pages, dir, imageMap);
   } else if (isItems) {
     bodyContent = renderArmory(pages, dir);
   } else if (isCampaign && pages.some(p => p.frontmatter.type === 'campaign_overview')) {
@@ -886,7 +885,7 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
       const fm = p.frontmatter;
       const entityType = isLocations ? (fm.location_type || fm.type) : fm.type;
       const avatarShape = (fm.type === 'pc') ? 'border-radius:0.375rem' : 'border-radius:50%';
-      const cardImg = portraitImg(fm, outputPath, imageMap, attachmentsDir);
+      const cardImg = portraitImg(fm, outputPath, imageMap);
       const portraitHtml = isCharacters && cardImg
         ? `<div class="npc-icon" style="${avatarShape}">${cardImg}</div>`
         : '';

--- a/tools/publish/lib/templates/item.js
+++ b/tools/publish/lib/templates/item.js
@@ -7,7 +7,7 @@ function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap,
   const fm = page.frontmatter;
   const publishConfig = (context || {}).publishConfig || {};
   const backlinks = (publishConfig._backlinks || {})[page.title] || [];
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
   // Build stat block
   const stats = [];

--- a/tools/publish/lib/templates/item.js
+++ b/tools/publish/lib/templates/item.js
@@ -92,6 +92,7 @@ function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap,
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -266,6 +266,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
     content,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     scripts: clientScripts(outputPath),
   });
 }

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -107,7 +107,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
     const pcCards = activePCs.map(pc => {
       const fm = pc.frontmatter;
       const initials = getInitials(pc.displayTitle);
-      const portraitTag = fm.portrait ? portraitImg(fm, outputPath, imageMap || {}, config.attachmentsDir) : '';
+      const portraitTag = fm.portrait ? portraitImg(fm, outputPath, imageMap || {}) : '';
       const portraitHtml = portraitTag
         ? `<div class="pc-portrait">${portraitTag}</div>`
         : `<div class="pc-portrait">${escapeHtml(initials)}</div>`;
@@ -150,7 +150,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
     const npcCards = recentNPCs.map(({ page }) => {
       const fm = page.frontmatter;
       const initials = getInitials(page.displayTitle);
-      const portraitTag = fm.portrait ? portraitImg(fm, outputPath, imageMap || {}, config.attachmentsDir) : '';
+      const portraitTag = fm.portrait ? portraitImg(fm, outputPath, imageMap || {}) : '';
       const iconHtml = portraitTag
         ? `<div class="npc-icon">${portraitTag}</div>`
         : `<div class="npc-icon">${escapeHtml(initials)}</div>`;

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -161,6 +161,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
     content: contentHtml,
     footer: config.footer,
     genrePreset: (publishConfig || {})._genrePreset,
+    overridesCss: (publishConfig || {})._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -38,7 +38,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
 
   let heroBanner;
   if (hasPortrait) {
-    const imgSrc = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+    const imgSrc = portraitImg(fm, page.outputPath, imageMap || {});
     const imgMatch = (imgSrc || '').match(/src="([^"]+)"/);
     const imgUrl = imgMatch ? imgMatch[1] : '';
     heroBanner = `<div class="hero-banner">

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -144,6 +144,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
     content: contentHtml,
     footer: config.footer,
     genrePreset: (publishConfig || {})._genrePreset,
+    overridesCss: (publishConfig || {})._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -26,7 +26,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
 
   let heroBanner;
   if (hasPortrait) {
-    const imgTag = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+    const imgTag = portraitImg(fm, page.outputPath, imageMap || {});
     const imgMatch = (imgTag || '').match(/src="([^"]+)"/);
     const imgUrl = imgMatch ? imgMatch[1] : '';
     heroBanner = `<div class="hero-cinematic">

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -139,7 +139,7 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
 
   let heroBanner;
   if (hasPortrait) {
-    const imgTag = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+    const imgTag = portraitImg(fm, page.outputPath, imageMap || {});
     const imgMatch = (imgTag || '').match(/src="([^"]+)"/);
     const imgUrl = imgMatch ? imgMatch[1] : '';
     heroBanner = `<div class="hero-cinematic">

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -275,6 +275,7 @@ ${tabScript()}`;
     content: body,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/story-landing.js
+++ b/tools/publish/lib/templates/story-landing.js
@@ -26,7 +26,9 @@ function storyLanding(spine, characterStories, config, publishConfig, navFor) {
   return baseShell({
     title: 'Story', siteTitle: config.siteTitle, cssHref: cssPath(OUT), navHtml: navFor(OUT, config),
     rootHref: rootPath(OUT), content, footer: config.footer,
-    genrePreset: (publishConfig || {})._genrePreset, scripts: clientScripts(OUT),
+    genrePreset: (publishConfig || {})._genrePreset,
+    overridesCss: (publishConfig || {})._overridesCss,
+    scripts: clientScripts(OUT),
   });
 }
 

--- a/tools/publish/lib/templates/story.js
+++ b/tools/publish/lib/templates/story.js
@@ -30,6 +30,7 @@ function storyPage(unit, config, publishConfig, navFor) {
     content,
     footer: config.footer,
     genrePreset: (publishConfig || {})._genrePreset,
+    overridesCss: (publishConfig || {})._overridesCss,
     scripts: clientScripts(unit.outputPath),
   });
 }
@@ -47,7 +48,9 @@ function characterStoryPage(story, config, publishConfig, navFor) {
     title: story.title, siteTitle: config.siteTitle,
     cssHref: cssPath(story.outputPath), navHtml: navFor(story.outputPath, config),
     rootHref: rootPath(story.outputPath), content, footer: config.footer,
-    genrePreset: (publishConfig || {})._genrePreset, scripts: clientScripts(story.outputPath),
+    genrePreset: (publishConfig || {})._genrePreset,
+    overridesCss: (publishConfig || {})._overridesCss,
+    scripts: clientScripts(story.outputPath),
   });
 }
 

--- a/tools/publish/lib/templates/timeline-page.js
+++ b/tools/publish/lib/templates/timeline-page.js
@@ -21,6 +21,7 @@ function timelineTemplate(timelineContent, navFor, config, publishConfig) {
     content,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(outputPath),
   });

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -100,6 +100,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -11,7 +11,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
   const backlinks = (publishConfig._backlinks || {})[page.title] || [];
   const extraSidebar = (context || {}).extraSidebar || {};
   const badges = metadataBadgesFor(fm);
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
   const crumbs = generateBreadcrumbs(page.outputPath, {});
   const breadcrumbsHtml = renderBreadcrumbs(crumbs);

--- a/tools/publish/lib/templates/world-domain.js
+++ b/tools/publish/lib/templates/world-domain.js
@@ -24,7 +24,7 @@ function worldDomainTemplate(page, processedContent, navFor, config, imageMap, c
 
   // Render `portrait:` like every other entity template. That invariant is what lets the
   // processor safely drop an inline embed of the same image as a duplicate (#88).
-  const portrait = portraitImg(fm, page.outputPath, imageMap || {}, config.attachmentsDir);
+  const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
   const headerHtml = `<h1>${escapeHtml(page.displayTitle)}${canonStatusBadge(fm)}</h1>${summaryHtml}${portrait}`;
 

--- a/tools/publish/lib/templates/world-domain.js
+++ b/tools/publish/lib/templates/world-domain.js
@@ -45,6 +45,7 @@ function worldDomainTemplate(page, processedContent, navFor, config, imageMap, c
     content: contentHtml,
     footer: config.footer,
     genrePreset: publishConfig._genrePreset,
+    overridesCss: publishConfig._overridesCss,
     breadcrumbsHtml,
     scripts: clientScripts(page.outputPath),
   });

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/helpers/make-png.js
+++ b/tools/publish/test/helpers/make-png.js
@@ -1,0 +1,91 @@
+const zlib = require('zlib');
+
+// Minimal PNG encoder. Lets the image tests work on a real, decodable image of a chosen
+// size without committing a binary fixture — and a smooth gradient is something WebP
+// genuinely compresses, so the "only keep the re-encode if it's smaller" path is exercised
+// rather than accidentally skipped.
+
+const CRC_TABLE = (() => {
+  const table = new Int32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+    table[n] = c;
+  }
+  return table;
+})();
+
+function crc32(buf) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type, data) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const typeAndData = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(typeAndData), 0);
+  return Buffer.concat([len, typeAndData, crc]);
+}
+
+/**
+ * Encode an RGB gradient as a PNG buffer.
+ * @param {number} width
+ * @param {number} height
+ * @returns {Buffer}
+ */
+function makePng(width, height) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;  // bit depth
+  ihdr[9] = 2;  // colour type: truecolour RGB
+  // 10..12 = compression, filter, interlace — all 0
+
+  const stride = width * 3;
+  const raw = Buffer.alloc(height * (stride + 1));
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * (stride + 1);
+    raw[rowStart] = 0; // filter type: none
+    for (let x = 0; x < width; x++) {
+      const px = rowStart + 1 + x * 3;
+      raw[px] = (x * 255 / width) | 0;
+      raw[px + 1] = (y * 255 / height) | 0;
+      raw[px + 2] = 128;
+    }
+  }
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+/**
+ * A JPEG header stub: SOI, an APP0 segment, then an SOF0 frame carrying the dimensions.
+ * Enough for header probing; not a decodable image.
+ */
+function makeJpegHeader(width, height) {
+  const sof0 = Buffer.alloc(11);
+  sof0[0] = 0xff; sof0[1] = 0xc0;
+  sof0.writeUInt16BE(9, 2);   // segment length
+  sof0[4] = 8;                // sample precision
+  sof0.writeUInt16BE(height, 5);
+  sof0.writeUInt16BE(width, 7);
+  sof0[9] = 1;                // component count
+  sof0[10] = 1;               // component id
+
+  const app0 = Buffer.concat([
+    Buffer.from([0xff, 0xe0, 0x00, 0x10]),
+    Buffer.from('JFIF\0', 'ascii'),
+    Buffer.alloc(9),
+  ]);
+
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), app0, sof0]);
+}
+
+module.exports = { makePng, makeJpegHeader };

--- a/tools/publish/test/integration/build-banners.test.js
+++ b/tools/publish/test/integration/build-banners.test.js
@@ -1,0 +1,138 @@
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { build } = require('../../lib/build');
+
+// A star map whose nodes link to entity pages — the case that forces inlining rather than
+// an <img>, since an <img> would never run these anchors.
+const STAR_MAP_SVG = '<svg viewBox="0 0 10 10"><a href="../locations/corwin-system.html"><circle cx="5" cy="5" r="2"/></a></svg>';
+
+function setupSite({ banners, conventionFile, linkFile }) {
+  const siteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-banners-'));
+  const vaultPath = path.join(siteDir, 'vault');
+  const outputDir = path.join(siteDir, 'docs');
+
+  fs.mkdirSync(path.join(vaultPath, '_meta'), { recursive: true });
+  fs.mkdirSync(path.join(vaultPath, 'Locations'), { recursive: true });
+  fs.mkdirSync(path.join(vaultPath, '_attachments'), { recursive: true });
+
+  fs.writeFileSync(path.join(vaultPath, '_meta/vault-config.md'),
+    banners ? `---\npublish:\n  banners:\n${banners}\n---\n` : '---\n---\n');
+
+  if (conventionFile) fs.writeFileSync(path.join(vaultPath, 'Locations', conventionFile), STAR_MAP_SVG);
+  fs.writeFileSync(path.join(vaultPath, '_attachments/Sector Map.webp'), 'fake-webp-bytes');
+  if (linkFile) fs.writeFileSync(path.join(vaultPath, '_attachments/Sector Map.svg'), STAR_MAP_SVG);
+
+  fs.writeFileSync(path.join(vaultPath, 'Locations/Corwin System.md'),
+    '---\ntype: location\nlocation_type: system\n---\n\n# Corwin System\n\nA star system.\n');
+
+  const configPath = path.join(siteDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({
+    vaultPath, outputDir,
+    attachmentsDir: '_attachments',
+    siteTitle: 'Banner Site',
+    siteUrl: 'https://example.github.io/banner-site',
+    excludeDirs: ['_meta'],
+    folderMap: { 'Locations': 'locations' },
+  }, null, 2));
+
+  build({ configPath });
+  return { siteDir, outputDir };
+}
+
+const locationsIndex = outputDir => fs.readFileSync(path.join(outputDir, 'locations/index.html'), 'utf8');
+
+describe('section index banners', () => {
+  describe('conventional Locations/_banner.svg', () => {
+    let outputDir;
+    before(() => { ({ outputDir } = setupSite({ conventionFile: '_banner.svg' })); });
+
+    it('is picked up with no configuration at all', () => {
+      assert.ok(locationsIndex(outputDir).includes('section-banner'));
+    });
+
+    it('is inlined, so the map nodes keep linking to entity pages', () => {
+      const html = locationsIndex(outputDir);
+      assert.ok(html.includes('section-banner-inline'));
+      assert.ok(html.includes('<a href="../locations/corwin-system.html">'), 'internal link survives');
+      assert.ok(!html.includes('<img src="../images/banners/_banner.svg"'), 'must not degrade to an <img>');
+    });
+
+    it('sits above the page title', () => {
+      const html = locationsIndex(outputDir);
+      assert.ok(html.indexOf('section-banner') < html.indexOf('page-title'));
+    });
+
+    it('does not put a banner on a section that has none', () => {
+      const characters = fs.readFileSync(path.join(outputDir, 'characters/index.html'), 'utf8');
+      assert.ok(!characters.includes('section-banner'));
+    });
+  });
+
+  describe('configured raster linking to the full-size SVG', () => {
+    let outputDir;
+    before(() => {
+      ({ outputDir } = setupSite({
+        linkFile: true,
+        banners: [
+          '    locations:',
+          '      image: _attachments/Sector Map.webp',
+          '      link: _attachments/Sector Map.svg',
+          '      alt: Sector 7-G star chart',
+        ].join('\n'),
+      }));
+    });
+
+    it('copies both assets into the output', () => {
+      assert.ok(fs.existsSync(path.join(outputDir, 'images/banners/Sector Map.webp')));
+      assert.ok(fs.existsSync(path.join(outputDir, 'images/banners/Sector Map.svg')));
+    });
+
+    it('renders a clickable img, URL-encoded, at the right relative depth', () => {
+      const html = locationsIndex(outputDir);
+      assert.ok(html.includes('<a class="section-banner-link" href="../images/banners/Sector%20Map.svg">'));
+      assert.ok(html.includes('<img src="../images/banners/Sector%20Map.webp"'));
+      assert.ok(html.includes('alt="Sector 7-G star chart"'));
+    });
+
+    it('does not inline, because a link target was declared', () => {
+      assert.ok(!locationsIndex(outputDir).includes('section-banner-inline'));
+    });
+  });
+
+  describe('config overrides the convention', () => {
+    let outputDir;
+    before(() => {
+      ({ outputDir } = setupSite({
+        conventionFile: '_banner.svg',
+        banners: '    locations: _attachments/Sector Map.webp',
+      }));
+    });
+
+    it('uses the configured image, not the conventional file', () => {
+      const html = locationsIndex(outputDir);
+      assert.ok(html.includes('images/banners/Sector%20Map.webp'));
+      assert.ok(!html.includes('section-banner-inline'));
+    });
+
+    it('derives alt text from the filename when none is given', () => {
+      assert.ok(locationsIndex(outputDir).includes('alt="Sector Map"'));
+    });
+  });
+
+  describe('bad banner paths', () => {
+    it('skips a banner that escapes the vault, and still builds', () => {
+      const { outputDir } = setupSite({ banners: '    locations: ../../../../etc/passwd' });
+      const html = locationsIndex(outputDir);
+      assert.ok(!html.includes('section-banner'), 'traversal must not produce a banner');
+      assert.ok(!fs.existsSync(path.join(outputDir, 'images/banners')), 'nothing copied out of the vault');
+    });
+
+    it('skips a banner whose file is missing, and still builds', () => {
+      const { outputDir } = setupSite({ banners: '    locations: _attachments/nope.svg' });
+      assert.ok(!locationsIndex(outputDir).includes('section-banner'));
+    });
+  });
+});

--- a/tools/publish/test/integration/build-banners.test.js
+++ b/tools/publish/test/integration/build-banners.test.js
@@ -57,7 +57,7 @@ describe('section index banners', () => {
       const html = locationsIndex(outputDir);
       assert.ok(html.includes('section-banner-inline'));
       assert.ok(html.includes('<a href="../locations/corwin-system.html">'), 'internal link survives');
-      assert.ok(!html.includes('<img src="../images/banners/_banner.svg"'), 'must not degrade to an <img>');
+      assert.ok(!html.includes('<img src="../images/banners/locations/_banner.svg"'), 'must not degrade to an <img>');
     });
 
     it('sits above the page title', () => {
@@ -86,14 +86,14 @@ describe('section index banners', () => {
     });
 
     it('copies both assets into the output', () => {
-      assert.ok(fs.existsSync(path.join(outputDir, 'images/banners/Sector Map.webp')));
-      assert.ok(fs.existsSync(path.join(outputDir, 'images/banners/Sector Map.svg')));
+      assert.ok(fs.existsSync(path.join(outputDir, 'images/banners/locations/Sector Map.webp')));
+      assert.ok(fs.existsSync(path.join(outputDir, 'images/banners/locations/Sector Map.svg')));
     });
 
     it('renders a clickable img, URL-encoded, at the right relative depth', () => {
       const html = locationsIndex(outputDir);
-      assert.ok(html.includes('<a class="section-banner-link" href="../images/banners/Sector%20Map.svg">'));
-      assert.ok(html.includes('<img src="../images/banners/Sector%20Map.webp"'));
+      assert.ok(html.includes('<a class="section-banner-link" href="../images/banners/locations/Sector%20Map.svg">'));
+      assert.ok(html.includes('<img src="../images/banners/locations/Sector%20Map.webp"'));
       assert.ok(html.includes('alt="Sector 7-G star chart"'));
     });
 
@@ -113,12 +113,57 @@ describe('section index banners', () => {
 
     it('uses the configured image, not the conventional file', () => {
       const html = locationsIndex(outputDir);
-      assert.ok(html.includes('images/banners/Sector%20Map.webp'));
+      assert.ok(html.includes('images/banners/locations/Sector%20Map.webp'));
       assert.ok(!html.includes('section-banner-inline'));
     });
 
     it('derives alt text from the filename when none is given', () => {
       assert.ok(locationsIndex(outputDir).includes('alt="Sector Map"'));
+    });
+  });
+
+  describe('two sections whose banners share a filename', () => {
+    // The conventional basename is identical in every section folder, so this is the common
+    // case, not a corner one: unnamespaced, whichever copied last would show on both pages.
+    let outputDir;
+    before(() => {
+      const siteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-banner-clash-'));
+      const vaultPath = path.join(siteDir, 'vault');
+      outputDir = path.join(siteDir, 'docs');
+      for (const folder of ['_meta', 'Locations', 'Creatures']) {
+        fs.mkdirSync(path.join(vaultPath, folder), { recursive: true });
+      }
+      fs.writeFileSync(path.join(vaultPath, '_meta/vault-config.md'), '---\n---\n');
+      // Raster, not SVG: an SVG with no link is inlined and never copied.
+      fs.writeFileSync(path.join(vaultPath, 'Locations/_banner.png'), 'LOCATIONS-BYTES');
+      fs.writeFileSync(path.join(vaultPath, 'Creatures/_banner.png'), 'CREATURES-BYTES');
+      fs.writeFileSync(path.join(vaultPath, 'Locations/Corwin.md'), '---\ntype: location\n---\n# Corwin\n');
+      fs.writeFileSync(path.join(vaultPath, 'Creatures/Xeno.md'), '---\ntype: creature\n---\n# Xeno\n');
+
+      const configPath = path.join(siteDir, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath, outputDir, attachmentsDir: '_attachments',
+        siteTitle: 'Clash', siteUrl: 'https://example.github.io/clash',
+        excludeDirs: ['_meta'],
+        folderMap: { 'Locations': 'locations', 'Creatures': 'creatures' },
+      }, null, 2));
+      build({ configPath });
+    });
+
+    it('keeps both assets on disk instead of one overwriting the other', () => {
+      const locations = path.join(outputDir, 'images/banners/locations/_banner.png');
+      const creatures = path.join(outputDir, 'images/banners/creatures/_banner.png');
+      assert.ok(fs.existsSync(locations), 'locations banner survives');
+      assert.ok(fs.existsSync(creatures), 'creatures banner survives');
+      assert.strictEqual(fs.readFileSync(locations, 'utf8'), 'LOCATIONS-BYTES');
+      assert.strictEqual(fs.readFileSync(creatures, 'utf8'), 'CREATURES-BYTES');
+    });
+
+    it('points each index at its own banner', () => {
+      const locations = locationsIndex(outputDir);
+      const creatures = fs.readFileSync(path.join(outputDir, 'creatures/index.html'), 'utf8');
+      assert.ok(locations.includes('src="../images/banners/locations/_banner.png"'));
+      assert.ok(creatures.includes('src="../images/banners/creatures/_banner.png"'));
     });
   });
 

--- a/tools/publish/test/integration/build-image-optimize.test.js
+++ b/tools/publish/test/integration/build-image-optimize.test.js
@@ -1,0 +1,113 @@
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { build } = require('../../lib/build');
+const { detectEncoder } = require('../../lib/image-optimize');
+const { makePng } = require('../helpers/make-png');
+
+const hasCwebp = detectEncoder() !== null;
+
+const scratchDirs = () => new Set(fs.readdirSync(os.tmpdir()).filter(n => n.startsWith('gm-publish-img-')));
+// Snapshot before any build in this file runs, so a scratch dir orphaned by some earlier
+// crashed run can't masquerade as one this build leaked.
+const preexistingScratch = scratchDirs();
+
+// A portrait whose filename contains a space, because that is precisely the case an
+// external postbuild gets wrong: the emitted src is URL-encoded ("Rock%20Lavey.jpg") and
+// never string-matches the filesystem path it would need to rewrite.
+const PORTRAIT = 'Rock Lavey.png';
+
+function setupSite({ optimize }) {
+  const siteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-images-'));
+  const vaultPath = path.join(siteDir, 'vault');
+  const outputDir = path.join(siteDir, 'docs');
+
+  fs.mkdirSync(path.join(vaultPath, '_meta'), { recursive: true });
+  fs.mkdirSync(path.join(vaultPath, '_attachments/characters'), { recursive: true });
+  fs.mkdirSync(path.join(vaultPath, 'Characters/NPCs'), { recursive: true });
+
+  fs.writeFileSync(path.join(vaultPath, '_meta/vault-config.md'), [
+    '---',
+    'publish:',
+    '  images:',
+    `    optimize: ${optimize}`,
+    '    max_width: 400',
+    '---',
+    '',
+  ].join('\n'));
+
+  fs.writeFileSync(path.join(vaultPath, '_attachments/characters', PORTRAIT), makePng(1600, 900));
+
+  fs.writeFileSync(path.join(vaultPath, 'Characters/NPCs/Rock Lavey.md'), [
+    '---',
+    'type: npc',
+    'status: alive',
+    `portrait: _attachments/characters/${PORTRAIT}`,
+    '---',
+    '',
+    '# Rock Lavey',
+    '',
+    'A dockhand with opinions.',
+    '',
+  ].join('\n'));
+
+  const configPath = path.join(siteDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({
+    vaultPath, outputDir,
+    attachmentsDir: '_attachments',
+    siteTitle: 'Image Site',
+    siteUrl: 'https://example.github.io/image-site',
+    excludeDirs: ['_meta'],
+    folderMap: { 'Characters/NPCs': 'characters/npcs' },
+  }, null, 2));
+
+  build({ configPath });
+  return { outputDir };
+}
+
+describe('image optimization', { skip: !hasCwebp }, () => {
+  describe('when publish.images.optimize is true', () => {
+    let outputDir;
+    before(() => { ({ outputDir } = setupSite({ optimize: true })); });
+
+    it('writes the converted WebP and not the original PNG', () => {
+      assert.ok(fs.existsSync(path.join(outputDir, 'images/characters/Rock Lavey.webp')));
+      assert.ok(!fs.existsSync(path.join(outputDir, 'images/characters/Rock Lavey.png')));
+    });
+
+    it('emits the .webp reference, URL-encoded, at src-emission time', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'characters/npcs/rock-lavey.html'), 'utf8');
+      assert.ok(html.includes('images/characters/Rock%20Lavey.webp'),
+        'portrait src should point at the encoded .webp path');
+      assert.ok(!html.includes('Rock%20Lavey.png'), 'no reference should survive to the deleted PNG');
+    });
+
+    it('actually shrinks the file', () => {
+      const converted = fs.statSync(path.join(outputDir, 'images/characters/Rock Lavey.webp')).size;
+      assert.ok(converted > 0);
+      assert.ok(converted < 200 * 1024, `expected a small webp, got ${converted} bytes`);
+    });
+
+    it('leaves no scratch directory behind', () => {
+      const leaked = [...scratchDirs()].filter(n => !preexistingScratch.has(n));
+      assert.deepStrictEqual(leaked, []);
+    });
+  });
+
+  describe('when optimization is off (the default)', () => {
+    let outputDir;
+    before(() => { ({ outputDir } = setupSite({ optimize: false })); });
+
+    it('copies the original bytes untouched', () => {
+      assert.ok(fs.existsSync(path.join(outputDir, 'images/characters/Rock Lavey.png')));
+      assert.ok(!fs.existsSync(path.join(outputDir, 'images/characters/Rock Lavey.webp')));
+    });
+
+    it('still references the .png', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'characters/npcs/rock-lavey.html'), 'utf8');
+      assert.ok(html.includes('images/characters/Rock%20Lavey.png'));
+    });
+  });
+});

--- a/tools/publish/test/integration/build-overrides-css.test.js
+++ b/tools/publish/test/integration/build-overrides-css.test.js
@@ -1,0 +1,87 @@
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { build } = require('../../lib/build');
+
+const fixturesDir = path.join(__dirname, '..', 'fixtures');
+
+function setupSite({ withOverrides }) {
+  const siteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-overrides-'));
+  const configPath = path.join(siteDir, 'config.json');
+  const outputDir = path.join(siteDir, 'docs');
+
+  fs.writeFileSync(configPath, JSON.stringify({
+    vaultPath: path.join(fixturesDir, 'minimal'),
+    outputDir,
+    attachmentsDir: '_attachments',
+    siteTitle: 'Overrides Site',
+    siteUrl: 'https://example.github.io/overrides-site',
+    excludeDirs: ['_meta', '_Templates'],
+    folderMap: {
+      '_Campaign': 'campaign',
+      'Characters/PCs': 'characters/pcs',
+      'Characters/NPCs': 'characters/npcs',
+      'Locations': 'locations',
+    },
+  }, null, 2));
+
+  if (withOverrides) {
+    fs.mkdirSync(path.join(siteDir, 'css'), { recursive: true });
+    fs.writeFileSync(path.join(siteDir, 'css/overrides.css'), ':root { --accent: #8b0000; }\n');
+  }
+
+  build({ configPath });
+  return { siteDir, outputDir };
+}
+
+describe('css/overrides.css is the site customization seam', () => {
+  describe('when the site scaffolds one', () => {
+    let outputDir;
+    before(() => { ({ outputDir } = setupSite({ withOverrides: true })); });
+
+    it('copies it into the output css/ directory verbatim', () => {
+      const copied = path.join(outputDir, 'css/overrides.css');
+      assert.ok(fs.existsSync(copied), 'expected docs/css/overrides.css');
+      assert.match(fs.readFileSync(copied, 'utf8'), /--accent: #8b0000/);
+    });
+
+    it('links it from a nested entity page with the right relative depth', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'characters/npcs/test-npc.html'), 'utf8');
+      assert.ok(html.includes('<link rel="stylesheet" href="../../css/overrides.css">'));
+    });
+
+    it('links it last so it wins the cascade over theme.css', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'index.html'), 'utf8');
+      const head = html.slice(0, html.indexOf('</head>'));
+      assert.ok(head.indexOf('css/overrides.css') > head.indexOf('css/theme.css'),
+        'overrides.css must be linked after theme.css');
+      assert.ok(head.indexOf('css/overrides.css') > head.indexOf('css/style.css'),
+        'overrides.css must be linked after style.css');
+    });
+
+    it('links it from index pages and the 404 page too', () => {
+      const indexPage = fs.readFileSync(path.join(outputDir, 'locations/index.html'), 'utf8');
+      assert.ok(indexPage.includes('css/overrides.css'));
+      const fourOhFour = fs.readFileSync(path.join(outputDir, '404.html'), 'utf8');
+      assert.ok(fourOhFour.includes('css/overrides.css'));
+    });
+  });
+
+  describe('when the site has none', () => {
+    let outputDir;
+    before(() => { ({ outputDir } = setupSite({ withOverrides: false })); });
+
+    it('writes no overrides.css', () => {
+      assert.ok(!fs.existsSync(path.join(outputDir, 'css/overrides.css')));
+    });
+
+    it('emits no link tag that would 404', () => {
+      for (const page of ['index.html', '404.html', 'locations/index.html']) {
+        const html = fs.readFileSync(path.join(outputDir, page), 'utf8');
+        assert.ok(!html.includes('overrides.css'), `${page} should not link overrides.css`);
+      }
+    });
+  });
+});

--- a/tools/publish/test/unit/banners.test.js
+++ b/tools/publish/test/unit/banners.test.js
@@ -1,0 +1,144 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  resolveBanner, renderBanner, normalizeEntry, sourceFolderFor, findConventionBanner, defaultAlt,
+} = require('../../lib/banners');
+
+describe('normalizeEntry', () => {
+  it('accepts a bare path as the image', () => {
+    assert.deepStrictEqual(normalizeEntry('_attachments/map.svg'), {
+      image: '_attachments/map.svg', link: null, alt: null,
+    });
+  });
+
+  it('accepts the full object form', () => {
+    assert.deepStrictEqual(normalizeEntry({ image: 'a.webp', link: 'a.svg', alt: 'Star chart' }), {
+      image: 'a.webp', link: 'a.svg', alt: 'Star chart',
+    });
+  });
+
+  it('rejects anything without an image', () => {
+    for (const raw of [null, undefined, '', '   ', 0, {}, { link: 'a.svg' }, []]) {
+      assert.strictEqual(normalizeEntry(raw), null, `${JSON.stringify(raw)} should not resolve`);
+    }
+  });
+});
+
+describe('sourceFolderFor', () => {
+  const folderMap = { 'Locations': 'locations', 'Factions & Organizations': 'factions' };
+
+  it('inverts the folder map', () => {
+    assert.strictEqual(sourceFolderFor('locations', folderMap), 'Locations');
+    assert.strictEqual(sourceFolderFor('factions', folderMap), 'Factions & Organizations');
+  });
+
+  it('returns null for a dir no folder maps to, and for no map at all', () => {
+    assert.strictEqual(sourceFolderFor('creatures', folderMap), null);
+    assert.strictEqual(sourceFolderFor('locations', undefined), null);
+  });
+});
+
+describe('defaultAlt', () => {
+  it('humanizes the filename', () => {
+    assert.strictEqual(defaultAlt('/v/Locations/_banner.svg'), 'banner');
+    assert.strictEqual(defaultAlt('_attachments/sector-map_wide.webp'), 'sector map wide');
+  });
+});
+
+describe('findConventionBanner / resolveBanner', () => {
+  let vault;
+  before(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-banner-'));
+    fs.mkdirSync(path.join(vault, 'Locations'), { recursive: true });
+    fs.mkdirSync(path.join(vault, 'Creatures'), { recursive: true });
+    fs.mkdirSync(path.join(vault, '_attachments'), { recursive: true });
+    fs.writeFileSync(path.join(vault, 'Locations/_banner.svg'), '<svg/>');
+    fs.writeFileSync(path.join(vault, 'Locations/_banner.png'), 'raster');
+    fs.writeFileSync(path.join(vault, '_attachments/chosen.webp'), 'x');
+  });
+  after(() => fs.rmSync(vault, { recursive: true, force: true }));
+
+  const folderMap = { 'Locations': 'locations', 'Creatures': 'creatures' };
+
+  it('finds the conventional _banner in the section folder', () => {
+    assert.strictEqual(findConventionBanner(vault, 'Locations'), 'Locations/_banner.svg');
+  });
+
+  it('prefers svg over a raster sibling', () => {
+    // Both exist; svg wins because it is first in the extension preference order.
+    assert.strictEqual(findConventionBanner(vault, 'Locations'), 'Locations/_banner.svg');
+  });
+
+  it('returns null for a folder with no banner, or no folder', () => {
+    assert.strictEqual(findConventionBanner(vault, 'Creatures'), null);
+    assert.strictEqual(findConventionBanner(vault, null), null);
+  });
+
+  it('resolves the convention when nothing is configured', () => {
+    const b = resolveBanner('locations', { vaultPath: vault, folderMap, banners: {} });
+    assert.deepStrictEqual(b, { image: 'Locations/_banner.svg', link: null, alt: null });
+  });
+
+  it('lets config override the convention', () => {
+    const banners = { locations: { image: '_attachments/chosen.webp', link: '_attachments/x.svg' } };
+    const b = resolveBanner('locations', { vaultPath: vault, folderMap, banners });
+    assert.strictEqual(b.image, '_attachments/chosen.webp');
+    assert.strictEqual(b.link, '_attachments/x.svg');
+  });
+
+  it('is null for a section with neither config nor convention', () => {
+    assert.strictEqual(resolveBanner('creatures', { vaultPath: vault, folderMap, banners: {} }), null);
+  });
+});
+
+describe('renderBanner', () => {
+  it('inlines an SVG so its internal <a> links stay clickable', () => {
+    const svg = '<svg><a href="../locations/corwin.html"><circle/></a></svg>';
+    const html = renderBanner({ svg });
+    assert.ok(html.includes('section-banner-inline'));
+    assert.ok(html.includes('<a href="../locations/corwin.html">'), 'internal link survives');
+    assert.ok(!html.includes('<img'), 'an <img> would not run the internal links');
+  });
+
+  it('never wraps an inlined SVG in an outer anchor', () => {
+    const html = renderBanner({ svg: '<svg><a href="x.html"/></svg>' });
+    assert.ok(!html.includes('section-banner-link'),
+      'an outer <a> would swallow the SVG\'s own links');
+  });
+
+  it('renders a raster as a plain img when there is no link target', () => {
+    const html = renderBanner({ imageHref: '../images/banners/map.webp', alt: 'Star chart' });
+    assert.ok(html.includes('<img src="../images/banners/map.webp"'));
+    assert.ok(html.includes('alt="Star chart"'));
+    assert.ok(!html.includes('<a '));
+  });
+
+  it('wraps the img in an anchor when a link target is given', () => {
+    const html = renderBanner({
+      imageHref: '../images/banners/map.webp',
+      linkHref: '../images/banners/map.svg',
+      alt: 'Star chart',
+    });
+    assert.ok(html.includes('<a class="section-banner-link" href="../images/banners/map.svg">'));
+    assert.ok(html.includes('<img src="../images/banners/map.webp"'));
+  });
+
+  it('URL-encodes hrefs with spaces', () => {
+    const html = renderBanner({ imageHref: '../images/banners/Sector 7G.webp', alt: '' });
+    assert.ok(html.includes('Sector%207G.webp'));
+  });
+
+  it('escapes the alt text', () => {
+    const html = renderBanner({ imageHref: 'a.webp', alt: '"><script>alert(1)</script>' });
+    assert.ok(!html.includes('<script>'));
+    assert.ok(html.includes('&lt;script&gt;'));
+  });
+
+  it('renders nothing without an svg or an image', () => {
+    assert.strictEqual(renderBanner({}), '');
+    assert.strictEqual(renderBanner({ linkHref: 'a.svg' }), '');
+  });
+});

--- a/tools/publish/test/unit/image-optimize.test.js
+++ b/tools/publish/test/unit/image-optimize.test.js
@@ -1,0 +1,268 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  optimizeImages, detectEncoder, resolveImageConfig, probeWidth, buildCwebpArgs,
+} = require('../../lib/image-optimize');
+const { makePng, makeJpegHeader } = require('../helpers/make-png');
+
+const hasCwebp = detectEncoder() !== null;
+
+// Encoders that write a chosen number of bytes, so the size-comparison, failure and
+// no-encoder branches are exercised on any machine — libwebp installed or not.
+function fakeEncoder(bytes, name = 'fake') {
+  return { name, encode: (src, dest) => fs.writeFileSync(dest, Buffer.alloc(bytes, 1)) };
+}
+const throwingEncoder = {
+  name: 'fake',
+  encode: () => { throw new Error('encoder exploded\nstack line'); },
+};
+
+describe('resolveImageConfig', () => {
+  it('is off with no config at all', () => {
+    assert.strictEqual(resolveImageConfig(undefined).optimize, false);
+    assert.strictEqual(resolveImageConfig({}).optimize, false);
+  });
+
+  it('requires optimize to be exactly true, not merely truthy', () => {
+    assert.strictEqual(resolveImageConfig({ optimize: 'yes' }).optimize, false);
+    assert.strictEqual(resolveImageConfig({ optimize: 1 }).optimize, false);
+    assert.strictEqual(resolveImageConfig({ optimize: true }).optimize, true);
+  });
+
+  it('defaults format, width and quality', () => {
+    const cfg = resolveImageConfig({ optimize: true });
+    assert.strictEqual(cfg.format, 'webp');
+    assert.strictEqual(cfg.maxWidth, 1600);
+    assert.strictEqual(cfg.quality, 82);
+  });
+
+  it('accepts camelCase maxWidth as well as snake_case max_width', () => {
+    assert.strictEqual(resolveImageConfig({ maxWidth: 800 }).maxWidth, 800);
+    assert.strictEqual(resolveImageConfig({ max_width: 900 }).maxWidth, 900);
+    // snake_case wins when a config sets both
+    assert.strictEqual(resolveImageConfig({ max_width: 900, maxWidth: 800 }).maxWidth, 900);
+  });
+
+  it('treats maxWidth 0 as "do not resize" rather than falling back to the default', () => {
+    assert.strictEqual(resolveImageConfig({ max_width: 0 }).maxWidth, 0);
+  });
+
+  it('allows quality 0 without silently substituting 82', () => {
+    assert.strictEqual(resolveImageConfig({ quality: 0 }).quality, 0);
+  });
+});
+
+describe('buildCwebpArgs', () => {
+  const base = { src: '/in.png', dest: '/out.webp', maxWidth: 1600, quality: 82 };
+
+  it('resizes a source wider than the cap', () => {
+    const args = buildCwebpArgs({ ...base, width: 2400 });
+    assert.deepStrictEqual(args, ['-quiet', '-q', '82', '-resize', '1600', '0', '/in.png', '-o', '/out.webp']);
+  });
+
+  it('never enlarges a source narrower than the cap', () => {
+    assert.ok(!buildCwebpArgs({ ...base, width: 300 }).includes('-resize'));
+  });
+
+  it('never resizes a source exactly at the cap', () => {
+    assert.ok(!buildCwebpArgs({ ...base, width: 1600 }).includes('-resize'));
+  });
+
+  it('skips the resize when the width could not be probed', () => {
+    assert.ok(!buildCwebpArgs({ ...base, width: null }).includes('-resize'));
+  });
+
+  it('skips the resize when maxWidth is 0', () => {
+    assert.ok(!buildCwebpArgs({ ...base, maxWidth: 0, width: 9000 }).includes('-resize'));
+  });
+});
+
+describe('probeWidth', () => {
+  let dir;
+  before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-probe-')); });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('reads width from a PNG IHDR', () => {
+    const p = path.join(dir, 'a.png');
+    fs.writeFileSync(p, makePng(320, 100));
+    assert.strictEqual(probeWidth(p), 320);
+  });
+
+  it('reads width from a JPEG SOF0 frame, skipping the APP0 segment', () => {
+    const p = path.join(dir, 'a.jpg');
+    fs.writeFileSync(p, makeJpegHeader(1234, 567));
+    assert.strictEqual(probeWidth(p), 1234);
+  });
+
+  it('returns null for a file that is not a PNG or JPEG', () => {
+    const p = path.join(dir, 'a.txt');
+    fs.writeFileSync(p, 'definitely not an image');
+    assert.strictEqual(probeWidth(p), null);
+  });
+
+  it('returns null rather than throwing on a missing file', () => {
+    assert.strictEqual(probeWidth(path.join(dir, 'nope.png')), null);
+  });
+
+  it('returns null on a truncated JPEG instead of looping', () => {
+    const p = path.join(dir, 'trunc.jpg');
+    fs.writeFileSync(p, Buffer.from([0xff, 0xd8, 0xff]));
+    assert.strictEqual(probeWidth(p), null);
+  });
+});
+
+describe('optimizeImages', () => {
+  let dir, tmpDir;
+
+  function imageMapWith(entries) {
+    const map = {};
+    for (const [name, spec] of Object.entries(entries)) {
+      const { width = 2000, height = 400, relPath = name, bytes } = spec || {};
+      const sourcePath = path.join(dir, name);
+      fs.writeFileSync(sourcePath, bytes || makePng(width, height));
+      map[name] = { sourcePath, relPath };
+    }
+    return map;
+  }
+
+  before(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-opt-src-')); });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  // Fresh scratch dir per test so encoded-file ordinals never collide across cases.
+  const withTmp = fn => () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-opt-tmp-'));
+    try { return fn(); } finally { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  };
+
+  it('does nothing when optimize is off', withTmp(() => {
+    const map = imageMapWith({ 'off.png': {} });
+    const stats = optimizeImages(map, { optimize: false }, tmpDir, { encoder: fakeEncoder(1) });
+    assert.strictEqual(stats.reason, 'disabled');
+    assert.strictEqual(stats.converted, 0);
+    assert.strictEqual(map['off.png'].relPath, 'off.png');
+    assert.strictEqual(map['off.png'].encodedPath, undefined);
+  }));
+
+  it('refuses an unsupported target format and changes nothing', withTmp(() => {
+    const map = imageMapWith({ 'fmt.png': {} });
+    const stats = optimizeImages(map, { optimize: true, format: 'avif' }, tmpDir, { encoder: fakeEncoder(1) });
+    assert.match(stats.reason, /unsupported format "avif"/);
+    assert.strictEqual(map['fmt.png'].relPath, 'fmt.png');
+  }));
+
+  it('reports a missing encoder instead of throwing', withTmp(() => {
+    const map = imageMapWith({ 'noenc.png': {} });
+    const stats = optimizeImages(map, { optimize: true }, tmpDir, { encoder: null });
+    assert.match(stats.reason, /cwebp not found/);
+    assert.strictEqual(map['noenc.png'].relPath, 'noenc.png');
+  }));
+
+  it('leaves non-raster and already-modern formats alone', withTmp(() => {
+    const map = {};
+    for (const name of ['vector.svg', 'anim.gif', 'already.webp']) {
+      map[name] = { sourcePath: path.join(dir, name), relPath: name };
+      fs.writeFileSync(map[name].sourcePath, 'x');
+    }
+    const stats = optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(1) });
+    assert.strictEqual(stats.converted, 0);
+    assert.strictEqual(stats.skipped, 3);
+    assert.strictEqual(map['vector.svg'].relPath, 'vector.svg');
+    assert.strictEqual(map['already.webp'].relPath, 'already.webp');
+  }));
+
+  it('converts a PNG and swaps relPath to .webp', withTmp(() => {
+    const map = imageMapWith({ 'portrait.png': {} });
+    const stats = optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(10) });
+
+    assert.strictEqual(stats.converted, 1);
+    assert.strictEqual(stats.encoder, 'fake');
+    assert.strictEqual(map['portrait.png'].relPath, 'portrait.webp');
+    assert.ok(fs.existsSync(map['portrait.png'].encodedPath));
+  }));
+
+  it('keys stay the original basename so portrait: and ![[embeds]] still resolve', withTmp(() => {
+    const map = imageMapWith({ 'Rock Lavey.png': {} });
+    optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(10) });
+    assert.ok(map['Rock Lavey.png'], 'lookup key must not change');
+    assert.strictEqual(map['Rock Lavey.png'].relPath, 'Rock Lavey.webp');
+  }));
+
+  it('preserves the subdirectory when swapping the extension', withTmp(() => {
+    const map = imageMapWith({ 'nested.png': { relPath: 'characters/nested.png' } });
+    optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(10) });
+    assert.strictEqual(map['nested.png'].relPath, 'characters/nested.webp');
+  }));
+
+  it('keeps the original when the re-encode is not actually smaller', withTmp(() => {
+    const map = imageMapWith({ 'big.png': { width: 4, height: 4 } });
+    const original = fs.statSync(map['big.png'].sourcePath).size;
+    const stats = optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(original + 1) });
+
+    assert.strictEqual(stats.converted, 0);
+    assert.strictEqual(stats.skipped, 1);
+    assert.strictEqual(map['big.png'].relPath, 'big.png');
+    assert.strictEqual(map['big.png'].encodedPath, undefined);
+    assert.strictEqual(fs.readdirSync(tmpDir).length, 0, 'oversized encode should be cleaned up');
+  }));
+
+  it('keeps the original when the encoder throws, and counts it as failed', withTmp(() => {
+    const map = imageMapWith({ 'boom.png': {} });
+    const stats = optimizeImages(map, { optimize: true }, tmpDir, { encoder: throwingEncoder });
+
+    assert.strictEqual(stats.failed, 1);
+    assert.strictEqual(stats.converted, 0);
+    assert.strictEqual(map['boom.png'].relPath, 'boom.png');
+    assert.strictEqual(map['boom.png'].encodedPath, undefined);
+  }));
+
+  it('will not let two sources collide on one .webp path', withTmp(() => {
+    const map = imageMapWith({ 'clash.png': {}, 'clash.jpg': {} });
+    const stats = optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(10) });
+
+    const relPaths = Object.values(map).map(e => e.relPath);
+    assert.strictEqual(new Set(relPaths).size, 2, `relPaths must stay distinct: ${relPaths}`);
+    assert.strictEqual(stats.converted, 1);
+    assert.strictEqual(stats.skipped, 1);
+  }));
+
+  it('does not convert onto a .webp path an existing source already occupies', withTmp(() => {
+    const map = imageMapWith({ 'held.png': {} });
+    map['held.webp'] = { sourcePath: path.join(dir, 'held-real.webp'), relPath: 'held.webp' };
+    fs.writeFileSync(map['held.webp'].sourcePath, 'pretend webp');
+
+    optimizeImages(map, { optimize: true }, tmpDir, { encoder: fakeEncoder(1) });
+    assert.strictEqual(map['held.png'].relPath, 'held.png', 'must not clobber the real held.webp');
+  }));
+});
+
+describe('optimizeImages with the real cwebp encoder', { skip: !hasCwebp }, () => {
+  let dir, tmpDir;
+  before(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-cwebp-src-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-cwebp-tmp-'));
+  });
+  after(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('really shrinks a wide PNG and writes a valid WebP', () => {
+    const sourcePath = path.join(dir, 'wide.png');
+    fs.writeFileSync(sourcePath, makePng(2400, 600));
+    const map = { 'wide.png': { sourcePath, relPath: 'wide.png' } };
+
+    const stats = optimizeImages(map, { optimize: true, max_width: 1000 }, tmpDir);
+
+    assert.strictEqual(stats.encoder, 'cwebp');
+    assert.strictEqual(stats.converted, 1);
+    assert.ok(stats.bytesAfter < stats.bytesBefore, `${stats.bytesAfter} !< ${stats.bytesBefore}`);
+    assert.strictEqual(map['wide.png'].relPath, 'wide.webp');
+
+    const header = fs.readFileSync(map['wide.png'].encodedPath).subarray(0, 12);
+    assert.strictEqual(header.subarray(0, 4).toString('ascii'), 'RIFF');
+    assert.strictEqual(header.subarray(8, 12).toString('ascii'), 'WEBP');
+  });
+});

--- a/tools/publish/test/unit/image-optimize.test.js
+++ b/tools/publish/test/unit/image-optimize.test.js
@@ -53,6 +53,20 @@ describe('resolveImageConfig', () => {
   it('allows quality 0 without silently substituting 82', () => {
     assert.strictEqual(resolveImageConfig({ quality: 0 }).quality, 0);
   });
+
+  it('falls back to defaults rather than passing NaN down to the encoder', () => {
+    assert.strictEqual(resolveImageConfig({ quality: 'high' }).quality, 82);
+    assert.strictEqual(resolveImageConfig({ max_width: 'wide' }).maxWidth, 1600);
+  });
+
+  it('clamps quality into the range cwebp accepts', () => {
+    assert.strictEqual(resolveImageConfig({ quality: 500 }).quality, 100);
+    assert.strictEqual(resolveImageConfig({ quality: -10 }).quality, 0);
+  });
+
+  it('treats a negative max_width as "do not resize"', () => {
+    assert.strictEqual(resolveImageConfig({ max_width: -800 }).maxWidth, 0);
+  });
 });
 
 describe('buildCwebpArgs', () => {

--- a/tools/publish/test/unit/locations-grouping.test.js
+++ b/tools/publish/test/unit/locations-grouping.test.js
@@ -1,0 +1,251 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  renderLocationsPage, buildLocationTree, resolveLocationGrouping, partitionByPivot,
+} = require('../../lib/templates/index-page');
+
+function loc(title, parent, type, extra = {}) {
+  return {
+    title,
+    displayTitle: title.replace(/_/g, ' '),
+    outputPath: `locations/${title.toLowerCase().replace(/_/g, '-')}.html`,
+    frontmatter: {
+      type: 'location',
+      ...(parent ? { parent_location: `[[${parent}]]` } : {}),
+      ...(type ? { location_type: type } : {}),
+      ...extra,
+    },
+    markdown: '',
+  };
+}
+
+// The Dead End vault's shape: one political root, every system beneath it, plus a couple of
+// locations that hang outside any system.
+const VAULT = [
+  loc('Federal_Republic_of_Worlds', null, 'polity'),
+  loc('Sector_7G', 'Federal_Republic_of_Worlds', 'sector'),
+
+  loc('Corwin_System', 'Sector_7G', 'system', { portrait: 'corwin.png' }),
+  loc('Corwin_III', 'Corwin_System', 'planet'),
+  loc('Corwin_III_A', 'Corwin_III', 'moon'),
+
+  loc('Eris_System', 'Sector_7G', 'star system'),
+  loc('Eris_III', 'Eris_System', 'planet'),
+  loc('Aethel', 'Eris_III', 'city'),
+  loc('Aethel_Starport', 'Aethel', 'starport'),
+  loc('Bamboo_Lounge', 'Aethel_Starport', 'venue'),
+
+  loc('Drift_Route', 'Sector_7G', 'route'),
+  loc('Uncharted_Anomaly', null, 'anomaly'),
+];
+
+const IMAGE_MAP = { 'corwin.png': { sourcePath: '/x/corwin.png', relPath: 'corwin.png' } };
+const SCIFI = { _genrePreset: 'scifi' };
+
+const render = (pages = VAULT, publishConfig = SCIFI, imageMap = IMAGE_MAP) =>
+  renderLocationsPage(pages, 'locations', imageMap, '_attachments', publishConfig);
+
+const countOf = (html, needle) => html.split(needle).length - 1;
+
+describe('resolveLocationGrouping', () => {
+  it('is off with no config and no genre', () => {
+    assert.strictEqual(resolveLocationGrouping(null), null);
+    assert.strictEqual(resolveLocationGrouping({}), null);
+  });
+
+  it('defaults to the star-system pivot for a scifi genre', () => {
+    assert.strictEqual(resolveLocationGrouping(SCIFI).pivot, 'system');
+  });
+
+  it('does not default a pivot on for other genres', () => {
+    assert.strictEqual(resolveLocationGrouping({ _genrePreset: 'horror' }), null);
+  });
+
+  it('lets an explicit group_by override the genre default', () => {
+    const cfg = { _genrePreset: 'scifi', locations: { group_by: 'Sector' } };
+    assert.strictEqual(resolveLocationGrouping(cfg).pivot, 'sector');
+  });
+
+  it('lets an explicit falsy group_by turn a genre default back off', () => {
+    for (const group_by of [false, null, '']) {
+      assert.strictEqual(
+        resolveLocationGrouping({ _genrePreset: 'scifi', locations: { group_by } }), null,
+        `group_by: ${JSON.stringify(group_by)} should disable grouping`,
+      );
+    }
+  });
+
+  it('carries a custom ungrouped label, else the default', () => {
+    assert.strictEqual(resolveLocationGrouping(SCIFI).ungroupedLabel, 'Deep Space & Routes');
+    const cfg = { _genrePreset: 'scifi', locations: { ungrouped_label: 'The Void' } };
+    assert.strictEqual(resolveLocationGrouping(cfg).ungroupedLabel, 'The Void');
+  });
+});
+
+describe('partitionByPivot', () => {
+  const partition = () => partitionByPivot(buildLocationTree(VAULT), 'system');
+
+  it('finds each star system as a section, matching "system" inside "star system" too', () => {
+    const titles = partition().sections.map(s => s.node.page.displayTitle).sort();
+    assert.deepStrictEqual(titles, ['Corwin System', 'Eris System']);
+  });
+
+  it('records the political chain above each system as its ancestors', () => {
+    const corwin = partition().sections.find(s => s.node.page.displayTitle === 'Corwin System');
+    assert.deepStrictEqual(
+      corwin.ancestors.map(a => a.page.displayTitle),
+      ['Federal Republic of Worlds', 'Sector 7G'],
+    );
+  });
+
+  it('captures a pivot-free subtree at its topmost node, and only there', () => {
+    const leftovers = partition().leftoverRoots.map(n => n.page.displayTitle).sort();
+    assert.deepStrictEqual(leftovers, ['Drift Route', 'Uncharted Anomaly']);
+  });
+
+  it('does not promote a system nested inside another system to its own section', () => {
+    const nested = [
+      loc('Alpha_System', null, 'system'),
+      loc('Beta_System', 'Alpha_System', 'system'),
+      loc('Gamma_System', null, 'system'),
+    ];
+    const { sections } = partitionByPivot(buildLocationTree(nested), 'system');
+    assert.deepStrictEqual(sections.map(s => s.node.page.displayTitle).sort(), ['Alpha System', 'Gamma System']);
+  });
+});
+
+describe('grouped locations page', () => {
+  it('renders one section per star system', () => {
+    const html = render();
+    assert.strictEqual(countOf(html, 'class="loc-system-title"'), 3, 'two systems + ungrouped');
+    assert.ok(html.includes('>Corwin System</a>'));
+    assert.ok(html.includes('>Eris System</a>'));
+  });
+
+  it('lists every location exactly once', () => {
+    const html = render();
+    for (const p of VAULT) {
+      // Scaffolding appears as caption text, not as a link; everything else appears as one link.
+      const isScaffold = ['Federal Republic of Worlds', 'Sector 7G'].includes(p.displayTitle);
+      const links = countOf(html, `>${p.displayTitle}</a>`);
+      assert.strictEqual(links, isScaffold ? 0 : 1, `${p.displayTitle}: ${links} link(s)`);
+    }
+  });
+
+  it('demotes the political scaffolding to a single page-level context caption', () => {
+    const html = render();
+    assert.strictEqual(countOf(html, 'class="loc-context"'), 1,
+      'a chain shared by every system should be stated once, not per section');
+    assert.ok(html.includes('Federal Republic of Worlds &rsaquo; Sector 7G'));
+    assert.ok(!html.includes('loc-node-name" href="federal-republic-of-worlds.html"'),
+      'scaffolding must not render as a tree row');
+  });
+
+  it('keeps every in-system location a first-class row rather than a breadcrumb', () => {
+    const html = render();
+    // Aethel is an only child of Eris III and would have been swallowed by chain collapsing.
+    for (const name of ['Eris III', 'Aethel', 'Aethel Starport', 'Bamboo Lounge']) {
+      assert.ok(html.includes(`class="loc-node-name" href="${name.toLowerCase().replace(/ /g, '-')}.html">${name}</a>`),
+        `${name} should be its own row`);
+    }
+    assert.ok(!html.includes('&rsaquo; Aethel'), 'no breadcrumb chain inside a system');
+  });
+
+  it('nests children beneath their parent, single children included', () => {
+    const html = render();
+    assert.ok(html.includes('loc-node-children'));
+    const eris = html.indexOf('>Eris III</a>');
+    const aethel = html.indexOf('>Aethel</a>');
+    const lounge = html.indexOf('>Bamboo Lounge</a>');
+    assert.ok(eris < aethel && aethel < lounge, 'children follow their parent');
+  });
+
+  it('uses badge pills for types, never the plain sidebar badge', () => {
+    const html = render();
+    assert.ok(html.includes('<span class="loc-type-badge">planet</span>'));
+    assert.ok(html.includes('<span class="loc-type-badge">venue</span>'));
+    assert.ok(!html.includes('sidebar-badge'));
+  });
+
+  it('puts a thumbnail on a section header that has a portrait', () => {
+    const html = render();
+    assert.ok(html.includes('class="loc-system-thumb"'));
+    assert.ok(html.includes('images/corwin.png'));
+  });
+
+  it('reserves an invisible spacer on rows with no portrait', () => {
+    const html = render();
+    assert.ok(html.includes('loc-node-thumb loc-node-thumb-empty'));
+    assert.ok(!html.includes('placeholder'), 'no visible placeholder box');
+  });
+
+  it('collects locations with no system ancestor into the ungrouped section', () => {
+    const html = render();
+    assert.ok(html.includes('loc-system-ungrouped'));
+    assert.ok(html.includes('Deep Space &amp; Routes'));
+    const ungrouped = html.slice(html.indexOf('loc-system-ungrouped'));
+    assert.ok(ungrouped.includes('>Drift Route</a>'));
+    assert.ok(ungrouped.includes('>Uncharted Anomaly</a>'));
+  });
+
+  it('counts a system as itself plus its descendants', () => {
+    const html = render();
+    assert.ok(html.includes('<span class="loc-system-count">3 locations</span>'), 'Corwin System');
+    assert.ok(html.includes('<span class="loc-system-count">5 locations</span>'), 'Eris System');
+  });
+
+  it('captions each section separately when the systems do not share one chain', () => {
+    const split = [
+      loc('Republic', null, 'polity'),
+      loc('Corwin_System', 'Republic', 'system'),
+      loc('Coalition', null, 'polity'),
+      loc('Eris_System', 'Coalition', 'system'),
+    ];
+    const html = render(split);
+    assert.strictEqual(countOf(html, 'class="loc-context"'), 2);
+  });
+
+  it('omits the ungrouped section entirely when nothing falls outside a system', () => {
+    const tidy = VAULT.filter(p => !['Drift_Route', 'Uncharted_Anomaly'].includes(p.title));
+    const html = render(tidy);
+    assert.ok(!html.includes('loc-system-ungrouped'));
+  });
+
+  it('escapes titles and types', () => {
+    const nasty = [
+      loc('A_System', null, 'system'),
+      loc('B_System', null, 'system'),
+      { ...loc('Evil', 'A_System', '<script>'), displayTitle: '<img onerror=1>' },
+    ];
+    const html = render(nasty);
+    assert.ok(!html.includes('<script>'));
+    assert.ok(!html.includes('<img onerror=1>'));
+    assert.ok(html.includes('&lt;script&gt;'));
+  });
+});
+
+describe('grouped locations page — falling back', () => {
+  it('keeps the flat region view when no publishConfig is passed at all', () => {
+    const html = renderLocationsPage(VAULT, 'locations');
+    assert.ok(html.includes('loc-region'));
+    assert.ok(!html.includes('loc-system-grid'));
+  });
+
+  it('keeps the flat region view when the genre has no pivot', () => {
+    const html = render(VAULT, { _genrePreset: 'horror' });
+    assert.ok(html.includes('loc-region'));
+  });
+
+  it('keeps the flat region view when only one system exists', () => {
+    const single = VAULT.filter(p => !p.title.startsWith('Eris') && p.title !== 'Aethel'
+      && p.title !== 'Aethel_Starport' && p.title !== 'Bamboo_Lounge');
+    const html = render(single);
+    assert.ok(html.includes('loc-region'), 'one pivot is not a grouping');
+    assert.ok(!html.includes('loc-system-grid'));
+  });
+
+  it('keeps the flat region view when no location matches the pivot', () => {
+    const html = render(VAULT, { _genrePreset: 'scifi', locations: { group_by: 'nebula' } });
+    assert.ok(html.includes('loc-region'));
+  });
+});

--- a/tools/publish/test/unit/locations-grouping.test.js
+++ b/tools/publish/test/unit/locations-grouping.test.js
@@ -43,7 +43,7 @@ const IMAGE_MAP = { 'corwin.png': { sourcePath: '/x/corwin.png', relPath: 'corwi
 const SCIFI = { _genrePreset: 'scifi' };
 
 const render = (pages = VAULT, publishConfig = SCIFI, imageMap = IMAGE_MAP) =>
-  renderLocationsPage(pages, 'locations', imageMap, '_attachments', publishConfig);
+  renderLocationsPage(pages, 'locations', imageMap, publishConfig);
 
 const countOf = (html, needle) => html.split(needle).length - 1;
 

--- a/tools/publish/test/unit/locations-grouping.test.js
+++ b/tools/publish/test/unit/locations-grouping.test.js
@@ -179,6 +179,27 @@ describe('grouped locations page', () => {
     assert.ok(!html.includes('placeholder'), 'no visible placeholder box');
   });
 
+  it('gives every body row a thumbnail slot, image or spacer', () => {
+    const html = render();
+    const rows = (html.match(/<div class="loc-node-row">/g) || []).length;
+    const slots = (html.match(/<span class="loc-node-thumb[" ]/g) || []).length;
+    assert.strictEqual(slots, rows, 'each row reserves exactly one thumbnail column');
+  });
+
+  it('reserves the thumbnail slot on section headers too, so titles align across the grid', () => {
+    // Corwin System has a portrait; Eris System does not. Both headers must reserve the box,
+    // or the portrait-less section's title sits flush left against its neighbours'.
+    const html = render();
+    const headers = html.split('<header class="loc-system-header">').slice(1)
+      .map(h => h.split('</header>')[0]);
+    assert.strictEqual(headers.length, 3, 'two systems + ungrouped');
+    for (const header of headers) {
+      assert.match(header, /<span class="loc-system-thumb[" ]/, 'header reserves a thumbnail slot');
+    }
+    assert.ok(headers.some(h => h.includes('images/corwin.png')), 'Corwin shows its portrait');
+    assert.ok(headers.some(h => h.includes('loc-system-thumb-empty')), 'Eris reserves a spacer');
+  });
+
   it('collects locations with no system ancestor into the ungrouped section', () => {
     const html = render();
     assert.ok(html.includes('loc-system-ungrouped'));


### PR DESCRIPTION
Closes #91, closes #92, closes #93, closes #95 — the full set of site-repo postbuild overrides, moved upstream.

## #92 — `css/overrides.css` is wired into the build

`gm-publish init` scaffolded it, but nothing copied or linked it, so the one file that *looked* like the customization seam did nothing — while `theme.css`, the only file that would have worked, is regenerated every build.

It is now copied into `docs/css/` and linked **last** in `<head>`, after `theme.css` and the genre overlay, so site rules win the cascade. Sites without one emit no link tag rather than 404ing on every page. Threaded through all 16 `baseShell` callers plus the 404 page, which builds its own `<head>`.

## #91 — Opt-in WebP image optimization

```yaml
publish:
  images:
    optimize: true    # default false — unchanged behavior when off
    format: webp
    max_width: 1600   # 0 disables resizing
    quality: 82
```

The pass runs **before any page renders**, so the swapped extension flows into `<img src>` at emission time. That is the whole reason this belongs in the tool rather than a postbuild: no rewriting of generated HTML, and no string-matching URL-encoded paths (`images/Rock%20Lavey.jpg`). An integration test uses a portrait with a space in its name to pin exactly that case.

Images that would grow when re-encoded keep their original bytes. SVG, GIF, WebP and AVIF pass through untouched. Two sources that would collide on one `.webp` path resolve first-wins, loser keeps its originals.

**Encoder choice: `cwebp`, not `sharp`.** Two independent blockers. This tool vendors its runtime deps into a git-tracked `node_modules` so they survive the copy into the plugin cache (`runtime-deps.test.js` enforces it), and sharp's per-platform native binaries can't be vendored. Separately, sharp's API is promise-only, which would make the entire synchronous build async for a feature that is off by default. A missing `cwebp` prints a warning and copies originals — it never breaks a build.

`sips` turned out to be unable to *write* WebP (`Can't write format: org.webmproject.webp`); in the reference postbuild it was only ever the width prober. That is replaced with a pure-JS PNG IHDR / JPEG SOF header read, so no second binary is needed. It exists to gate the resize: `cwebp -resize` has no shrink-only mode and will happily upscale.

## #93 — Locations index pivots on the star system

```yaml
publish:
  locations:
    group_by: system                    # substring of location_type, case-insensitive
    ungrouped_label: Deep Space & Routes
```

Each match becomes its own section. Only the scaffolding *above* the pivot (Republic › Sector) collapses, into a small context caption — stated once above the grid when every system shares one chain, per-section otherwise.

Following the correction comment on the issue rather than its point 2: **no single-child chain collapsing.** Every location stays a first-class row with its own thumbnail and `.loc-type-badge` pill, children nested beneath it even when an only child. Collapsing chains into breadcrumbs swallowed real bodies — a planet, an asteroid belt — into scaffolding and made them read unlike their sibling bodies. Grouping by system already keeps nesting shallow (planet → city → starport → venue). Rows with no portrait get an invisible spacer, not a placeholder box.

Sections flow in a responsive grid, so the page width does the work. Defaults on for the `scifi` genre; `group_by: false` turns that back off. Falls back to the flat region view when fewer than two locations match — one section is not a grouping.

## #95 — Custom banner on a section index page

```yaml
publish:
  banners:
    locations:
      image: _attachments/sector-map.webp
      link: _attachments/sector-map.svg    # optional click-through
      alt: Sector 7-G star chart
```

Or drop a conventional `Locations/_banner.svg` in the section's vault folder and it is picked up with no config at all. Keys are output dirs, not vault folders; config wins over convention.

**An SVG with no `link` is inlined**, because only inline SVG keeps its internal `<a>` elements live — a star map whose nodes link to entity pages. An `<img src="map.svg">` would never run those links, and wrapping the SVG in an outer anchor would swallow them. So a banner that declares a `link` renders as an `<img>` inside an `<a>` instead: the raster-on-page, full-size-SVG-behind-it shape from the reference postbuild. Both paths are tested.

Assets copy to `docs/images/banners/`. A path that resolves outside the vault, or names a missing file, prints a warning and is skipped rather than failing the build (a `../../../../etc/passwd` traversal is covered by a test). Caveat documented rather than papered over: an inlined SVG lands in `locations/index.html`, so its internal hrefs must be written relative to that page. Banners apply to generated index pages; a section with an authored `index.md` renders that instead.

## Drive-by fix

`portraitImg` built its output path from the `portrait:` frontmatter string rather than the scanner's `imageMap` entry. Optimization required fixing that, and it also repairs a latent bug where a `portrait:` that omitted its subdirectory pointed at a file the build had copied elsewhere. The three hero-banner templates that lift `src` back out of the tag inherit the corrected path.

## Verification

- 930 tests pass (`node --test`), 95 of them new.
- `python3 scripts/validate_schema.py` clean; markdownlint clean; `skill-creator` validation passes on `publish-site`.
- A local review pass found no correctness bugs in the risky areas: the `partitionByPivot` recursion is cycle-safe, and no other code path constructs an `images/<path>` URL independently of the image map. It caught non-numeric config reaching `cwebp` as the literal string `"NaN"` — fixed and tested.
- Accepted tradeoff: player mode encodes attachments it later drops, because it cannot know which images are referenced until pages render. Correct, just wasted work; documented in `build.js`.

**CI note:** the image-optimize *integration* tests are skipped when `cwebp` is absent, so they will not run on a runner without libwebp. The unit tests inject fake encoders and cover the convert / skip / fail / collision branches regardless.

Plugin `1.8.16 → 1.8.18`, publish tool `1.9.0 → 1.11.0`, `CHANGELOG.md` updated.
