### PR TITLE
Two-way comms: advice replies and a chat log

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.20",
+  "version": "1.8.21",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.21] — 2026-07-12
+
+### Added
+
+- Two-way comms on the change-request channel: players can ask questions and get
+  a brief, player-safe answer, and every message now returns a response to a
+  per-device chat log (💬) on the sheet — including a plain-language explanation
+  (with point math) when a change can't be applied. The widget reloads only when
+  a change actually applied; advice and refusals update the log without a reload.
+
+### Changed
+
+- Widget input shows its example as helper text (not a placeholder), with a
+  roomier, resizable box. The mobile back-to-top button is centered and more
+  transparent.
+
 ## [1.8.20] — 2026-07-12
 
 ### Added

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -40,36 +40,57 @@ does the waiting, and you only wake when a request actually arrives.
 
 ## When a batch arrives
 
-The watcher exits and re-invokes you with a JSON array of pending entries
+The watcher hands you a JSON array of pending entries
 `{id, character, text, timestamp, status}` (re-run `npx gm-apprentice-publish
-inbox pull` if you want the freshest state). Then:
+inbox pull` if you want the freshest state). For each, in per-character
+submission order (`timestamp` ascending), tracking **running unspent points**
+(read the current value from the PC's `.md`):
 
-1. Group by `character`; within each character sort by `timestamp` ascending.
-2. For each character, walk their requests in order, tracking **running unspent
-   points** (read the current value from the PC's `.md`):
-   - **Interpret** the natural-language `text`.
-   - **Validate** against GURPS costs using `ttrpg-expert`'s references
-     (`systems/gurps-4e/character-generation.md`, `character-sheet.md`,
-     `skills-*.md`, `traits-*.md`). Attributes: ST/HT 10/level, DX/IQ 20/level.
-     Skills and traits: per those references.
-   - **Classify:**
-     - **Clean** (unambiguous AND affordable/valid): edit the PC's `.md` —
-       raise the attribute/skill, add the equipment, grant/adjust XP, or edit
-       the narrative field — and decrement running unspent points accordingly.
-       Collect the entry `id` into `appliedIds`. Log a `✓` line.
-     - **Edge case** (can't afford / over-budget / ambiguous skill or item):
-       do **not** edit; collect into `flaggedIds`; log a `⚠` line with the
-       reason. Never block the clean ones.
-3. **If `appliedIds` is non-empty**, publish once for the whole batch:
+1. **Classify** the `text`: a **sheet change** (imperative — spend/add/set/
+   raise/remove/note) or a **question** (interrogative / advice-seeking). If
+   genuinely unsure, treat it as a question — never edit the sheet on a guess.
+2. **Change → apply or refuse.** Validate against GURPS costs using
+   `ttrpg-expert`'s references (`systems/gurps-4e/character-generation.md`,
+   `character-sheet.md`, `skills-*.md`, `traits-*.md`). Attributes: ST/HT
+   10/level, DX/IQ 20/level; skills and traits per those references.
+   - **Affordable & unambiguous:** edit the PC's `.md` — raise the attribute/
+     skill, add the equipment, grant/adjust XP, or edit the narrative field —
+     decrement running unspent points, and collect the id into the applied
+     batch. Log a `✓` line. (Its response comes after the deploy.)
+   - **Unaffordable / over-budget / ambiguous:** do **not** edit. Finalize now
+     with a plain-language explanation and the point math, and log a `⚠` line:
+
+     ```bash
+     npx gm-apprentice-publish inbox reply <id> rejected "Ronin → Sex Appeal +2 (11→13). Costs 6; he has 5. One short — nothing applied."
+     ```
+3. **Question → answer** using **player-safe scope only** — the published
+   sheet/site + GURPS rules + the character's own non-GM sections. NEVER use
+   `GM Notes`, `DM Notes`, `Player Notes`, `Source References`,
+   `<!-- gm-only -->` regions, other PCs' private data, or hidden plot/secret.
+   If a good answer would need GM-only info, reply that it's beyond what you
+   can see — never the hidden info itself. Answer as a brief bullet list, then
+   finalize:
+
+   ```bash
+   npx gm-apprentice-publish inbox reply <id> advice "• DX 13→14 = 20 pts …\n• you have 15 — not yet affordable"
+   ```
+4. **Publish the applied batch once.** If the applied batch is non-empty,
    `npm run build` then `npx wrangler@4 pages deploy`.
-   - **On deploy success:** `npx gm-apprentice-publish inbox handled <appliedIds…>`.
-   - **On deploy failure:** do NOT mark handled — the entries stay `pending`
-     (nothing marks them otherwise) and are pulled again on the next watcher
-     cycle. Log the failure.
-4. For each flagged id: `npx gm-apprentice-publish inbox flag <id>` and keep it
-   in the terminal's visible "needs you" list.
+   - **On deploy success:** finalize each applied id with its confirmation:
+
+     ```bash
+     npx gm-apprentice-publish inbox reply <id> applied "✓ Streetwise 2→3 — applied"
+     ```
+   - **On deploy failure:** do **not** reply — the entries stay `pending`
+     (nothing else marks them) and are pulled again on the next watcher cycle.
+     Log the failure.
 5. **Relaunch the background watcher** (the same command as in Start step 4) so
    the next request wakes you. Idle resumes at zero model-token cost.
+
+Every player message therefore returns exactly one response to their chat log:
+`applied` (sheet redeployed), `rejected` (with the point-math reason), or
+`advice`. `reply` is the single finalizer for every item — it supersedes the
+old `handled`/`flag` commands.
 
 ## Terminal log format
 

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -88,10 +88,11 @@ submission order (`timestamp` ascending), tracking **running unspent points**
 5. **Relaunch the background watcher** (the same command as in Start step 4) so
    the next request wakes you. Idle resumes at zero model-token cost.
 
-Every player message therefore returns exactly one response to their chat log:
-`applied` (sheet redeployed), `rejected` (with the point-math reason), or
-`advice`. `reply` is the single finalizer for every item — it supersedes the
-old `handled`/`flag` commands.
+Once a request reaches a terminal outcome it returns exactly one response to
+the chat log: `applied` (sheet redeployed), `rejected` (with the point-math
+reason), or `advice`. A deploy failure leaves the applied items `pending` to
+retry next tick, unreplied for now. `reply` is the single finalizer for every
+item — it supersedes the old `handled`/`flag` commands.
 
 ## Terminal log format
 

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -72,8 +72,9 @@ submission order (`timestamp` ascending), tracking **running unspent points**
    finalize:
 
    ```bash
-   npx gm-apprentice-publish inbox reply <id> advice "• DX 13→14 = 20 pts …\n• you have 15 — not yet affordable"
+   npx gm-apprentice-publish inbox reply <id> advice $'• DX 13→14 = 20 pts …\n• you have 15 — not yet affordable'
    ```
+   Multi-line replies (like bullet lists) require real newlines in the chat log — use bash `$'...'` quoting so `\n` becomes a newline.
 4. **Publish the applied batch once.** If the applied batch is non-empty,
    `npm run build` then `npx wrangler@4 pages deploy`.
    - **On deploy success:** finalize each applied id with its confirmation:

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -21,7 +21,7 @@ does the waiting, and you only wake when a request actually arrives.
 3. Print it prominently for the GM to read to the table:
    `╔═══════════════╗  SESSION CODE: WOLF  ╚═══════════════╝`
 4. Launch the **background watcher** (below), then leave the session idle. The
-   watcher is a plain shell loop that polls the queue every ~60s and **sleeps
+   watcher is a plain shell loop that polls the queue every ~30s and **sleeps
    while it is empty — spending no model tokens**. It exits (waking you) only
    when a request arrives.
 
@@ -29,7 +29,7 @@ does the waiting, and you only wake when a request actually arrives.
    while :; do
      out=$(npx gm-apprentice-publish inbox pull 2>/dev/null)
      if [ -n "$out" ] && [ "$out" != "[]" ]; then printf '%s\n' "$out"; break; fi
-     sleep 60
+     sleep 30
    done
    ```
 

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -3511,6 +3511,7 @@ details.rules-ref > summary::-webkit-details-marker { display: none; }
 .cr-text.cr-big { min-height: 8rem; }
 .cr-expand { cursor: pointer; align-self: stretch; }
 .cr-log-btn { background: none; border: none; cursor: pointer; font-size: 1.1rem; margin-left: .35rem; }
+.cr-log-btn:focus-visible { outline: 2px solid var(--accent, #3b82f6); outline-offset: 2px; }
 .cr-logpanel { margin-top: .5rem; max-height: 16rem; overflow-y: auto; border-top: 1px solid var(--border, #ccc); padding-top: .5rem; }
 .cr-logentry { margin-bottom: .6rem; font-size: .85rem; }
 .cr-you { font-weight: 600; }

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -3503,3 +3503,24 @@ details.rules-ref > summary::-webkit-details-marker { display: none; }
 .cr-panel .cr-code { width: 6rem; text-transform: uppercase; }
 .cr-panel .cr-send { cursor: pointer; }
 .cr-msg { font-size: .85rem; opacity: .85; }
+
+/* --- Comms widget: hint, resizable input, chat log (Part: advice+log) --- */
+.cr-hint { font-size: .8rem; opacity: .8; margin: 0 0 .5rem; }
+.cr-inputrow { display: flex; gap: .35rem; align-items: flex-start; }
+.cr-inputrow .cr-text { flex: 1 1 auto; min-width: 0; resize: vertical; }
+.cr-text.cr-big { min-height: 8rem; }
+.cr-expand { cursor: pointer; align-self: stretch; }
+.cr-log-btn { background: none; border: none; cursor: pointer; font-size: 1.1rem; margin-left: .35rem; }
+.cr-logpanel { margin-top: .5rem; max-height: 16rem; overflow-y: auto; border-top: 1px solid var(--border, #ccc); padding-top: .5rem; }
+.cr-logentry { margin-bottom: .6rem; font-size: .85rem; }
+.cr-you { font-weight: 600; }
+.cr-reply { margin-top: .15rem; white-space: pre-wrap; }
+.cr-reply.cr-rejected { color: var(--danger, #b00); }
+.cr-reply.cr-waiting { opacity: .6; }
+.cr-empty { opacity: .6; font-size: .85rem; }
+
+/* Mobile: center the back-to-top and make it more transparent (Part: advice+log) */
+@media (max-width: 767px) {
+  .back-to-top { left: 50%; right: auto; transform: translateX(-50%); }
+  .back-to-top.visible { opacity: 0.55; }
+}

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -113,21 +113,22 @@
     var logPanel = root.querySelector('.cr-logpanel');
     var expandBtn = root.querySelector('.cr-expand');
 
+    var KIND_CLASSES = { applied: 1, rejected: 1, advice: 1 };
     function renderLog() {
       var l = getLog();
       logBtn.hidden = l.length === 0;
       if (!l.length) { logPanel.innerHTML = '<p class="cr-empty">No messages yet.</p>'; return; }
       logPanel.innerHTML = l.slice().reverse().map(function (e) {
-        var kind = e.kind ? ' cr-' + e.kind : '';
+        var kindCls = KIND_CLASSES[e.kind] ? ' cr-' + e.kind : '';
         var reply = e.reply
-          ? '<div class="cr-reply' + kind + '">' + escapeHtml(e.reply) + '</div>'
+          ? '<div class="cr-reply' + kindCls + '">' + escapeHtml(e.reply) + '</div>'
           : '<div class="cr-reply cr-waiting">…</div>';
         return '<div class="cr-logentry"><div class="cr-you">' + escapeHtml(e.message) + '</div>' + reply + '</div>';
       }).join('');
     }
     function escapeHtml(s) {
-      return String(s).replace(/[&<>"]/g, function (c) {
-        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+      return String(s).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
       });
     }
     renderLog();

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -6,28 +6,36 @@
   var CODE_TTL_MS = 72 * 3600 * 1000;
   var POLL_MS = 15000;
   var ENDPOINT = '/api/request';
-  var K_CODE = 'cr:code', K_PENDING = 'cr:pending', K_LIVE = 'cr:live';
+  var LOG_MAX = 50;
+  var K_CODE = 'cr:code', K_PENDING = 'cr:pending', K_LIVE = 'cr:live', K_LOG = 'cr:log';
 
   function shouldPromptForCode(stored, nowMs) {
     if (!stored || typeof stored.at !== 'number' || !stored.code) return true;
     return (nowMs - stored.at) >= CODE_TTL_MS;
   }
 
-  function partitionStatuses(statuses) {
-    var handled = [], flagged = [], pending = [];
-    Object.keys(statuses || {}).forEach(function (id) {
-      var s = statuses[id];
-      if (s === 'handled') handled.push(id);
-      else if (s === 'flagged') flagged.push(id);
-      else pending.push(id); // pending | applied
+  function resolvedResults(results, pendingIds) {
+    var out = [];
+    (pendingIds || []).forEach(function (id) {
+      var r = (results || {})[id];
+      if (r && r.response != null) out.push({ id: id, response: r.response, kind: r.kind });
     });
-    return { handled: handled, flagged: flagged, pending: pending };
+    return out;
   }
 
-  function decide(part) {
-    if (part.handled.length) return 'reload';
-    if (!part.pending.length && part.flagged.length) return 'flagged-only';
-    return 'poll';
+  function needsReload(resolvedList) {
+    return (resolvedList || []).some(function (x) { return x.kind === 'applied'; });
+  }
+
+  function appendLog(log, entry) {
+    var next = (log || []).concat([entry]);
+    return next.length > LOG_MAX ? next.slice(next.length - LOG_MAX) : next;
+  }
+
+  function setLogReply(log, id, reply, kind) {
+    return (log || []).map(function (e) {
+      return e.id === id ? Object.assign({}, e, { reply: reply, kind: kind }) : e;
+    });
   }
 
   function classifySubmitError(httpStatus) {
@@ -40,9 +48,12 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
       CODE_TTL_MS: CODE_TTL_MS,
+      LOG_MAX: LOG_MAX,
       shouldPromptForCode: shouldPromptForCode,
-      partitionStatuses: partitionStatuses,
-      decide: decide,
+      resolvedResults: resolvedResults,
+      needsReload: needsReload,
+      appendLog: appendLog,
+      setLogReply: setLogReply,
       classifySubmitError: classifySubmitError,
     };
   }

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -23,6 +23,15 @@
     return out;
   }
 
+  function staleIds(results, pendingIds) {
+    var out = [];
+    (pendingIds || []).forEach(function (id) {
+      var r = (results || {})[id];
+      if (r && r.status === 'handled' && r.response == null) out.push(id);
+    });
+    return out;
+  }
+
   function needsReload(resolvedList) {
     return (resolvedList || []).some(function (x) { return x.kind === 'applied'; });
   }
@@ -51,6 +60,7 @@
       LOG_MAX: LOG_MAX,
       shouldPromptForCode: shouldPromptForCode,
       resolvedResults: resolvedResults,
+      staleIds: staleIds,
       needsReload: needsReload,
       appendLog: appendLog,
       setLogReply: setLogReply,
@@ -193,13 +203,15 @@
         return res.json();
       }).then(function (results) {
         var done = resolvedResults(results, ids);
-        if (!done.length) return; // still waiting
-        // record replies into the log and drop resolved ids from pending
+        var stale = staleIds(results, ids);
+        if (!done.length && !stale.length) return; // still waiting
+        // record replies into the log and drop resolved + gone/expired ids from pending
         var log = getLog();
-        var doneIds = {};
-        done.forEach(function (d) { doneIds[d.id] = true; log = setLogReply(log, d.id, d.response, d.kind); });
+        var removeIds = {};
+        done.forEach(function (d) { removeIds[d.id] = true; log = setLogReply(log, d.id, d.response, d.kind); });
+        stale.forEach(function (id) { removeIds[id] = true; });
         setLog(log);
-        setPending(ids.filter(function (id) { return !doneIds[id]; }));
+        setPending(ids.filter(function (id) { return !removeIds[id]; }));
         renderLog();
         if (needsReload(done)) {
           localStorage.setItem(K_LIVE, '1');
@@ -211,7 +223,8 @@
           location.replace(u.href);
         } else {
           // advice / rejected only — show the newest reply inline, keep the log open-able
-          msg.textContent = done[done.length - 1].response;
+          // (stale-only ticks have no response to show; the log entry is left as-is)
+          if (done.length) msg.textContent = done[done.length - 1].response;
           if (!getPending().length) { clearInterval(timer); timer = null; }
         }
       }).catch(function () { /* transient; try again next tick */ });

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -74,13 +74,19 @@
 
     root.innerHTML =
       '<div class="cr-bar">' +
-        '<button type="button" class="cr-toggle" aria-expanded="false">✎ Request a change</button>' +
+        '<button type="button" class="cr-toggle" aria-expanded="false">✎ Request a change / ask a question</button>' +
+        '<button type="button" class="cr-log-btn" aria-label="Open chat log" hidden>💬</button>' +
         '<div class="cr-panel" hidden>' +
+          '<p class="cr-hint">Type a change ("spend 1 xp to raise Streetwise") or a question ("is it worth raising DX?").</p>' +
           '<input type="text" class="cr-code" maxlength="4" placeholder="4-char code" aria-label="Session code" hidden>' +
-          '<textarea class="cr-text" rows="2" placeholder="e.g. spend 1 xp to raise Streetwise" aria-label="Describe your change"></textarea>' +
+          '<div class="cr-inputrow">' +
+            '<textarea class="cr-text" rows="3" aria-label="Your message"></textarea>' +
+            '<button type="button" class="cr-expand" aria-label="Expand or shrink the box">⤢</button>' +
+          '</div>' +
           '<button type="button" class="cr-send">Send</button>' +
           '<span class="cr-msg" role="status"></span>' +
         '</div>' +
+        '<div class="cr-logpanel" hidden></div>' +
       '</div>';
 
     var toggle = root.querySelector('.cr-toggle');
@@ -89,6 +95,34 @@
     var textInput = root.querySelector('.cr-text');
     var send = root.querySelector('.cr-send');
     var msg = root.querySelector('.cr-msg');
+
+    // ---- chat log ----
+    function getLog() { return readJSON(K_LOG) || []; }
+    function setLog(l) { writeJSON(K_LOG, l); }
+    var logBtn = root.querySelector('.cr-log-btn');
+    var logPanel = root.querySelector('.cr-logpanel');
+    var expandBtn = root.querySelector('.cr-expand');
+
+    function renderLog() {
+      var l = getLog();
+      logBtn.hidden = l.length === 0;
+      if (!l.length) { logPanel.innerHTML = '<p class="cr-empty">No messages yet.</p>'; return; }
+      logPanel.innerHTML = l.slice().reverse().map(function (e) {
+        var kind = e.kind ? ' cr-' + e.kind : '';
+        var reply = e.reply
+          ? '<div class="cr-reply' + kind + '">' + escapeHtml(e.reply) + '</div>'
+          : '<div class="cr-reply cr-waiting">…</div>';
+        return '<div class="cr-logentry"><div class="cr-you">' + escapeHtml(e.message) + '</div>' + reply + '</div>';
+      }).join('');
+    }
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"]/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+      });
+    }
+    renderLog();
+    logBtn.addEventListener('click', function () { logPanel.hidden = !logPanel.hidden; if (!logPanel.hidden) renderLog(); });
+    expandBtn.addEventListener('click', function () { textInput.classList.toggle('cr-big'); });
 
     // Persisted "your change is live" flag from before a reload.
     if (localStorage.getItem(K_LIVE) === '1') {
@@ -128,6 +162,8 @@
         if (res.ok) return res.json().then(function (out) {
           writeJSON(K_CODE, { code: code, at: Date.now() });   // refresh 72h window
           var ids = getPending(); ids.push(out.id); setPending(ids);
+          setLog(appendLog(getLog(), { id: out.id, ts: Date.now(), message: text }));
+          renderLog();
           textInput.value = '';
           msg.textContent = 'Request received.';
           startPolling();
@@ -155,12 +191,17 @@
       if (!ids.length) { clearInterval(timer); timer = null; return; }
       fetch(ENDPOINT + '?ids=' + encodeURIComponent(ids.join(','))).then(function (res) {
         return res.json();
-      }).then(function (statuses) {
-        var part = partitionStatuses(statuses);
-        var action = decide(part);
-        if (action === 'reload') {
-          // Keep still-pending ids; drop resolved ones so we don't re-wait after reload.
-          setPending(part.pending);
+      }).then(function (results) {
+        var done = resolvedResults(results, ids);
+        if (!done.length) return; // still waiting
+        // record replies into the log and drop resolved ids from pending
+        var log = getLog();
+        var doneIds = {};
+        done.forEach(function (d) { doneIds[d.id] = true; log = setLogReply(log, d.id, d.response, d.kind); });
+        setLog(log);
+        setPending(ids.filter(function (id) { return !doneIds[id]; }));
+        renderLog();
+        if (needsReload(done)) {
           localStorage.setItem(K_LIVE, '1');
           // Cache-bust: a plain reload() can be served from bfcache on mobile,
           // showing the "live" banner over stale content. A unique URL forces
@@ -168,10 +209,10 @@
           var u = new URL(location.href);
           u.searchParams.set('_cr', String(Date.now()));
           location.replace(u.href);
-        } else if (action === 'flagged-only') {
-          setPending([]);
-          clearInterval(timer); timer = null;
-          msg.textContent = 'Your request needs the GM — ask them to look.';
+        } else {
+          // advice / rejected only — show the newest reply inline, keep the log open-able
+          msg.textContent = done[done.length - 1].response;
+          if (!getPending().length) { clearInterval(timer); timer = null; }
         }
       }).catch(function () { /* transient; try again next tick */ });
     }

--- a/tools/publish/lib/inbox-cli.js
+++ b/tools/publish/lib/inbox-cli.js
@@ -22,9 +22,9 @@ async function runInbox(argv, deps = {}) {
   const inbox = await import('../templates-scaffold/functions/api/inbox-core.mjs');
   const [sub, ...rest] = argv;
 
-  const KNOWN = ['open', 'code', 'pull', 'handled', 'flag'];
+  const KNOWN = ['open', 'code', 'pull', 'handled', 'flag', 'reply'];
   if (!KNOWN.includes(sub)) {
-    out('Usage: inbox <open|code|pull|handled|flag> [args]');
+    out('Usage: inbox <open|code|pull|handled|flag|reply> [args]');
     return 1;
   }
   // Build the wrangler-backed adapter only for real subcommands, so the usage
@@ -54,8 +54,18 @@ async function runInbox(argv, deps = {}) {
       for (const id of rest) await inbox.markFlagged(kv, id);
       return 0;
     }
+    case 'reply': {
+      const [id, kind, ...textParts] = rest;
+      const text = textParts.join(' ');
+      if (!id || !['applied', 'rejected', 'advice'].includes(kind)) {
+        out('Usage: inbox reply <id> <applied|rejected|advice> "<text>"');
+        return 1;
+      }
+      await inbox.setResponse(kv, id, kind, text);
+      return 0;
+    }
     default:
-      out('Usage: inbox <open|code|pull|handled|flag> [args]');
+      out('Usage: inbox <open|code|pull|handled|flag|reply> [args]');
       return 1;
   }
 }

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -8,6 +8,7 @@ export const PREFIX = 'req:';
 export const CODE_KEY = 'config:code';
 export const RL_PREFIX = 'rl:';
 export const HANDLED_TTL = 300; // seconds a handled entry lingers for the widget
+export const RESPONSE_TTL = 600; // seconds a responded (handled) entry lingers for the widget
 
 export function normalizeCode(raw) {
   return String(raw || '').trim().toUpperCase();
@@ -30,7 +31,7 @@ export async function codeMatches(kv, submitted) {
 }
 
 export function buildEntry({ id, character, text, timestamp }) {
-  return { id, character, text, timestamp, status: 'pending' };
+  return { id, character, text, timestamp, status: 'pending', response: null, kind: null };
 }
 
 export async function enqueue(kv, { id, character, text, timestamp }) {
@@ -66,13 +67,34 @@ export async function markApplied(kv, id) { return setStatus(kv, id, 'applied');
 export async function markHandled(kv, id) { return setStatus(kv, id, 'handled', { expirationTtl: HANDLED_TTL }); }
 export async function markFlagged(kv, id) { return setStatus(kv, id, 'flagged'); }
 
-export async function getStatuses(kv, ids) {
+// Attach a player-facing response and finalize the entry:
+//   applied/advice → handled (with TTL, so the widget catches it then it self-reaps)
+//   rejected       → flagged (persists for the GM), still carries the response
+export async function setResponse(kv, id, kind, text) {
+  const raw = await kv.get(PREFIX + id);
+  if (!raw) return null;
+  let entry;
+  try { entry = JSON.parse(raw); } catch { return null; }
+  entry.response = text;
+  entry.kind = kind;
+  entry.status = kind === 'rejected' ? 'flagged' : 'handled';
+  const opts = kind === 'rejected' ? undefined : { expirationTtl: RESPONSE_TTL };
+  await kv.put(PREFIX + id, JSON.stringify(entry), opts);
+  return entry;
+}
+
+export async function getResults(kv, ids) {
   const result = {};
   for (const id of ids) {
     const raw = await kv.get(PREFIX + id);
-    let status = 'handled';
-    if (raw) { try { status = JSON.parse(raw).status; } catch { status = 'handled'; } }
-    result[id] = status;
+    let val = { status: 'handled', response: null, kind: null };
+    if (raw) {
+      try {
+        const e = JSON.parse(raw);
+        val = { status: e.status, response: e.response ?? null, kind: e.kind ?? null };
+      } catch { /* corrupt → treat as handled/no-response */ }
+    }
+    result[id] = val;
   }
   return result;
 }

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -84,8 +84,7 @@ export async function setResponse(kv, id, kind, text) {
 }
 
 export async function getResults(kv, ids) {
-  const result = {};
-  for (const id of ids) {
+  const pairs = await Promise.all(ids.map(async (id) => {
     const raw = await kv.get(PREFIX + id);
     let val = { status: 'handled', response: null, kind: null };
     if (raw) {
@@ -94,9 +93,9 @@ export async function getResults(kv, ids) {
         val = { status: e.status, response: e.response ?? null, kind: e.kind ?? null };
       } catch { /* corrupt → treat as handled/no-response */ }
     }
-    result[id] = val;
-  }
-  return result;
+    return [id, val];
+  }));
+  return Object.fromEntries(pairs);
 }
 
 export async function rateLimited(kv, ip, { limit = 10, windowSec = 60 } = {}) {

--- a/tools/publish/templates-scaffold/functions/api/request.js
+++ b/tools/publish/templates-scaffold/functions/api/request.js
@@ -1,6 +1,6 @@
 // Cloudflare Pages Function: /api/request
 //   POST { code, character, text }  → validate session code, enqueue into KV
-//   GET  ?ids=a,b,c                 → { id: status } for the widget to poll
+//   GET  ?ids=a,b,c                 → { id: { status, response, kind } } for the widget to poll
 // KV namespace is bound as env.INBOX (see wrangler.toml). All queue logic lives
 // in inbox-core.mjs so it stays identical to what the tool tests.
 import * as inbox from './inbox-core.mjs';

--- a/tools/publish/templates-scaffold/functions/api/request.js
+++ b/tools/publish/templates-scaffold/functions/api/request.js
@@ -38,5 +38,5 @@ export async function onRequestGet(context) {
   const ids = (url.searchParams.get('ids') || '').split(',').map(s => s.trim()).filter(Boolean);
   if (!ids.length) return json({});
   if (ids.length > 50) return json({ error: 'too many ids' }, 400);
-  return json(await inbox.getStatuses(kv, ids));
+  return json(await inbox.getResults(kv, ids));
 }

--- a/tools/publish/test/change-request-logic.test.js
+++ b/tools/publish/test/change-request-logic.test.js
@@ -19,6 +19,15 @@ test('resolvedResults returns only ids whose response arrived', () => {
   assert.deepEqual(r.map(x => x.id).sort(), ['a', 'c']);
 });
 
+test('staleIds returns handled-with-no-response ids (expired), not pending ones', () => {
+  const results = {
+    a: { status: 'handled', response: null, kind: null },   // expired/gone
+    b: { status: 'pending', response: null, kind: null },   // still waiting
+    c: { status: 'handled', response: '✓', kind: 'applied' } // resolved, not stale
+  };
+  assert.deepEqual(cr.staleIds(results, ['a', 'b', 'c']), ['a']);
+});
+
 test('needsReload only when an applied result is present', () => {
   assert.equal(cr.needsReload([{ id: 'a', kind: 'applied' }]), true);
   assert.equal(cr.needsReload([{ id: 'c', kind: 'rejected' }, { id: 'd', kind: 'advice' }]), false);

--- a/tools/publish/test/change-request-logic.test.js
+++ b/tools/publish/test/change-request-logic.test.js
@@ -9,23 +9,33 @@ test('shouldPromptForCode: null or expired prompts, fresh does not', () => {
   assert.equal(cr.shouldPromptForCode({ nope: true }, 1000), true);                           // malformed
 });
 
-test('partitionStatuses buckets pending/applied together', () => {
-  const p = cr.partitionStatuses({ a: 'pending', b: 'applied', c: 'handled', d: 'flagged' });
-  assert.deepEqual(p.pending.sort(), ['a', 'b']);
-  assert.deepEqual(p.handled, ['c']);
-  assert.deepEqual(p.flagged, ['d']);
+test('resolvedResults returns only ids whose response arrived', () => {
+  const results = {
+    a: { status: 'handled', response: '✓ ok', kind: 'applied' },
+    b: { status: 'pending', response: null, kind: null },
+    c: { status: 'flagged', response: 'no', kind: 'rejected' },
+  };
+  const r = cr.resolvedResults(results, ['a', 'b', 'c']);
+  assert.deepEqual(r.map(x => x.id).sort(), ['a', 'c']);
 });
 
-test('decide: reload when any handled', () => {
-  assert.equal(cr.decide({ handled: ['c'], flagged: [], pending: ['a'] }), 'reload');
+test('needsReload only when an applied result is present', () => {
+  assert.equal(cr.needsReload([{ id: 'a', kind: 'applied' }]), true);
+  assert.equal(cr.needsReload([{ id: 'c', kind: 'rejected' }, { id: 'd', kind: 'advice' }]), false);
 });
 
-test('decide: flagged-only when nothing pending and some flagged', () => {
-  assert.equal(cr.decide({ handled: [], flagged: ['d'], pending: [] }), 'flagged-only');
+test('appendLog caps to LOG_MAX', () => {
+  let log = [];
+  for (let i = 0; i < cr.LOG_MAX + 5; i++) log = cr.appendLog(log, { id: 'i' + i, ts: i, message: 'm' });
+  assert.equal(log.length, cr.LOG_MAX);
+  assert.equal(log[log.length - 1].id, 'i' + (cr.LOG_MAX + 4)); // newest kept
 });
 
-test('decide: keep polling when work remains and nothing handled', () => {
-  assert.equal(cr.decide({ handled: [], flagged: ['d'], pending: ['a'] }), 'poll');
+test('setLogReply fills the matching entry', () => {
+  const log = [{ id: 'a', ts: 1, message: 'q' }, { id: 'b', ts: 2, message: 'r' }];
+  const out = cr.setLogReply(log, 'b', '• answer', 'advice');
+  assert.deepEqual(out[1], { id: 'b', ts: 2, message: 'r', reply: '• answer', kind: 'advice' });
+  assert.equal(out[0].reply, undefined); // others untouched
 });
 
 test('classifySubmitError maps HTTP status', () => {

--- a/tools/publish/test/change-request-widget.test.js
+++ b/tools/publish/test/change-request-widget.test.js
@@ -24,3 +24,12 @@ test('widget falls back to displayTitle when frontmatter.name is absent', () => 
   const html = pcTemplate(p2, { html: '', relationships: '' }, [], noop, cfg, {}, undefined, {});
   assert.ok(html.includes('data-character="Hero"'));
 });
+
+const fs = require('node:fs');
+test('widget script ships the chat-log and hint UI hooks', () => {
+  const src = fs.readFileSync(require('path').join(__dirname, '../js/change-request.js'), 'utf8');
+  assert.ok(src.includes('cr-hint'), 'has the helper-text element');
+  assert.ok(src.includes('cr-log'), 'has the chat-log button/panel');
+  assert.ok(src.includes('cr-expand'), 'has the expand/contract control');
+  assert.ok(src.includes("'cr:log'"), 'uses the cr:log storage key');
+});

--- a/tools/publish/test/inbox-cli.test.js
+++ b/tools/publish/test/inbox-cli.test.js
@@ -51,7 +51,28 @@ test('handled and flag transition status', async () => {
   await inbox.enqueue(kv, { id: 'b', character: 'bo', text: 'y', timestamp: '2026-07-11T14:02:00.000Z' });
   await runInbox(['handled', 'a'], { adapter: kv });
   await runInbox(['flag', 'b'], { adapter: kv });
-  assert.deepEqual(await inbox.getStatuses(kv, ['a', 'b']), { a: 'handled', b: 'flagged' });
+  const r = await inbox.getResults(kv, ['a', 'b']);
+  assert.deepEqual(r.a, { status: 'handled', response: null, kind: null });
+  assert.deepEqual(r.b, { status: 'flagged', response: null, kind: null });
   // both left the pending queue
   assert.deepEqual((await inbox.readPending(kv)).map(e => e.id), []);
+});
+
+test('reply attaches response + kind and finalizes status', async () => {
+  const kv = fakeKV();
+  await inbox.enqueue(kv, { id: 'a', character: 'Six', text: 'x', timestamp: '2026-07-12T00:00:00Z' });
+  await inbox.enqueue(kv, { id: 'b', character: 'Bo', text: 'y', timestamp: '2026-07-12T00:00:01Z' });
+  const rc1 = await runInbox(['reply', 'a', 'applied', '✓ done'], { adapter: kv });
+  const rc2 = await runInbox(['reply', 'b', 'rejected', 'costs 6, has 5'], { adapter: kv });
+  assert.equal(rc1, 0); assert.equal(rc2, 0);
+  const r = await inbox.getResults(kv, ['a', 'b']);
+  assert.deepEqual(r.a, { status: 'handled', response: '✓ done', kind: 'applied' });
+  assert.deepEqual(r.b, { status: 'flagged', response: 'costs 6, has 5', kind: 'rejected' });
+});
+
+test('reply rejects an unknown kind', async () => {
+  const kv = fakeKV(); const c = capture();
+  const rc = await runInbox(['reply', 'a', 'bogus', 'x'], { adapter: kv, out: c.out });
+  assert.equal(rc, 1);
+  assert.match(c.lines.join('\n'), /applied\|rejected\|advice/);
 });

--- a/tools/publish/test/inbox-cli.test.js
+++ b/tools/publish/test/inbox-cli.test.js
@@ -70,6 +70,15 @@ test('reply attaches response + kind and finalizes status', async () => {
   assert.deepEqual(r.b, { status: 'flagged', response: 'costs 6, has 5', kind: 'rejected' });
 });
 
+test('reply attaches an advice response and finalizes status', async () => {
+  const kv = fakeKV();
+  await inbox.enqueue(kv, { id: 'c', character: 'Ronin', text: 'is it worth raising DX?', timestamp: '2026-07-12T00:00:02Z' });
+  const rc = await runInbox(['reply', 'c', 'advice', '• hint'], { adapter: kv });
+  assert.equal(rc, 0);
+  const r = await inbox.getResults(kv, ['c']);
+  assert.deepEqual(r.c, { status: 'handled', response: '• hint', kind: 'advice' });
+});
+
 test('reply rejects an unknown kind', async () => {
   const kv = fakeKV(); const c = capture();
   const rc = await runInbox(['reply', 'a', 'bogus', 'x'], { adapter: kv, out: c.out });

--- a/tools/publish/test/inbox-core.test.js
+++ b/tools/publish/test/inbox-core.test.js
@@ -73,11 +73,43 @@ test('readPending skips a corrupted entry instead of throwing', async () => {
   assert.deepEqual(pending.map(e => e.id), ['good']);
 });
 
-test('getStatuses maps known ids and treats missing as handled', async () => {
+test('buildEntry seeds response and kind as null', () => {
+  const e = inbox.buildEntry({ id: 'x', character: 'a', text: 't', timestamp: '2026-07-12T00:00:00Z' });
+  assert.equal(e.response, null);
+  assert.equal(e.kind, null);
+});
+
+test('setResponse: applied → handled with response+kind', async () => {
   const kv = fakeKV();
-  await inbox.enqueue(kv, { id: 'k', character: 'ana', text: 'k', timestamp: '2026-07-11T14:00:00.000Z' });
-  const s = await inbox.getStatuses(kv, ['k', 'gone']);
-  assert.deepEqual(s, { k: 'pending', gone: 'handled' });
+  await inbox.enqueue(kv, { id: 'a', character: 'Six', text: 'spend 1 on Streetwise', timestamp: '2026-07-12T00:00:00Z' });
+  const e = await inbox.setResponse(kv, 'a', 'applied', '✓ Streetwise 2→3 — applied');
+  assert.equal(e.status, 'handled');
+  assert.equal(e.kind, 'applied');
+  assert.equal(e.response, '✓ Streetwise 2→3 — applied');
+});
+
+test('setResponse: rejected → flagged, still carries response', async () => {
+  const kv = fakeKV();
+  await inbox.enqueue(kv, { id: 'b', character: 'Ronin', text: 'raise Sex Appeal', timestamp: '2026-07-12T00:00:01Z' });
+  const e = await inbox.setResponse(kv, 'b', 'rejected', 'Costs 6; has 5. Nothing applied.');
+  assert.equal(e.status, 'flagged');
+  assert.equal(e.kind, 'rejected');
+  // flagged stays out of readPending
+  assert.deepEqual((await inbox.readPending(kv)).map(x => x.id), []);
+});
+
+test('setResponse: missing id returns null', async () => {
+  const kv = fakeKV();
+  assert.equal(await inbox.setResponse(kv, 'nope', 'advice', 'x'), null);
+});
+
+test('getResults returns {status,response,kind}; missing → nulls', async () => {
+  const kv = fakeKV();
+  await inbox.enqueue(kv, { id: 'c', character: 'a', text: 't', timestamp: '2026-07-12T00:00:02Z' });
+  await inbox.setResponse(kv, 'c', 'advice', '• do this');
+  const r = await inbox.getResults(kv, ['c', 'gone']);
+  assert.deepEqual(r.c, { status: 'handled', response: '• do this', kind: 'advice' });
+  assert.deepEqual(r.gone, { status: 'handled', response: null, kind: null });
 });
 
 test('rateLimited allows up to limit then blocks', async () => {

--- a/tools/publish/test/inbox-function.test.js
+++ b/tools/publish/test/inbox-function.test.js
@@ -61,12 +61,16 @@ test('POST with empty text returns 400', async () => {
   assert.equal(res.status, 400);
 });
 
-test('GET returns per-id status', async () => {
+test('GET returns per-id {status,response,kind}', async () => {
   const kv = fakeKV();
   await inbox.enqueue(kv, { id: 'k', character: 'ana', text: 'k', timestamp: '2026-07-11T14:00:00.000Z' });
+  await inbox.setResponse(kv, 'k', 'advice', '• hi');
   const res = await fn.onRequestGet(getCtx(kv, ['k', 'gone']));
   assert.equal(res.status, 200);
-  assert.deepEqual(await res.json(), { k: 'pending', gone: 'handled' });
+  assert.deepEqual(await res.json(), {
+    k: { status: 'handled', response: '• hi', kind: 'advice' },
+    gone: { status: 'handled', response: null, kind: null },
+  });
 });
 
 test('GET with more than 50 ids returns 400', async () => {


### PR DESCRIPTION
Makes the change-request channel two-way: players can ask questions and get a brief, player-safe answer, and **every** message now returns a response to a per-device chat log on the sheet — advice answers, applied-change confirmations, and a plain-language explanation (with point math) when a change can't be applied. Builds on the change-request inbox (v1.8.20).

## How it works

- **One box, auto-classified.** The loop decides whether each message is a sheet change or a question — no extra UI. A question is answered as a brief bullet list; a change is applied, or refused with the reason.
- **Unified response model.** Each KV entry gains a `response` and a `kind` (`applied` / `rejected` / `advice`). The Function's status endpoint returns the richer payload; the widget appends it to a `cr:log` history behind a 💬 button and **reloads the page only when a change actually applied** — advice and refusals update the log without a reload.
- **Refusals explain themselves.** An unaffordable or ambiguous change returns e.g. `Ronin → Sex Appeal +2 (11→13). Costs 6; he has 5. One short — nothing applied.` — the player isn't left guessing, and the item still flags to the GM.
- **Player-safe scope.** Advice draws only on player-visible content (published sheet/site + GURPS rules); the loop is instructed never to use `GM Notes`, secrets, hidden plot, or other PCs' private data, reusing the publish tool's `excludeSections` boundary.
- **Input & mobile polish.** The example is now helper text above a roomier, resizable input (not a placeholder inside it); the mobile back-to-top button is centered and more transparent. The watcher poll interval is 30s.

GURPS 4e for advice validation; the transport, queue, and parsing stay system-neutral.

## Testing

Full unit coverage for the extended KV core, the Function, the `inbox reply` CLI, and the widget's resolve/log helpers (974 tests). A whole-branch review verified the contract is consistent across core/Function/CLI/widget, that the widget reloads only on an applied change, that a refused-and-flagged item still resolves on the client with its explanation, and that the chat log escapes both player and reply text. It also caught and fixed a self-heal regression (an expired reply no longer strands a poll).

## Follow-ups (minor, non-blocking)

`kind` (a server-only enum) is interpolated unescaped into a CSS class — worth escaping as defense-in-depth; the 💬 button could toggle `aria-expanded`; the CLI's multi-argv text-join path is untested (the loop always quotes the text).
