### PR TITLE
Trust the player: XP grants and a "GM said OK" override

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.21",
+  "version": "1.8.22",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.22] — 2026-07-12
+
+### Changed
+- The change-request loop now trusts the player by default: XP grants and
+  narrative edits always apply, and a player can push an unaffordable change
+  through by adding "GM said OK" (or "do it anyway") — the change applies with
+  Unspent Points shown as a deficit, and every override is logged to the GM's
+  terminal. Ambiguous requests still ask which was meant. The widget hints at
+  the override.
+
 ## [1.8.21] — 2026-07-12
 
 ### Added

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -49,20 +49,36 @@ submission order (`timestamp` ascending), tracking **running unspent points**
 1. **Classify** the `text`: a **sheet change** (imperative — spend/add/set/
    raise/remove/note) or a **question** (interrogative / advice-seeking). If
    genuinely unsure, treat it as a question — never edit the sheet on a guess.
-2. **Change → apply or refuse.** Validate against GURPS costs using
-   `ttrpg-expert`'s references (`systems/gurps-4e/character-generation.md`,
-   `character-sheet.md`, `skills-*.md`, `traits-*.md`). Attributes: ST/HT
-   10/level, DX/IQ 20/level; skills and traits per those references.
-   - **Affordable & unambiguous:** edit the PC's `.md` — raise the attribute/
-     skill, add the equipment, grant/adjust XP, or edit the narrative field —
-     decrement running unspent points, and collect the id into the applied
-     batch. Log a `✓` line. (Its response comes after the deploy.)
-   - **Unaffordable / over-budget / ambiguous:** do **not** edit. Finalize now
-     with a plain-language explanation and the point math, and log a `⚠` line:
+2. **Change → apply, or refuse only when you must.** Default to trusting the
+   player. Validate spends against GURPS costs using `ttrpg-expert`'s references
+   (`systems/gurps-4e/character-generation.md`, `character-sheet.md`,
+   `skills-*.md`, `traits-*.md`). Attributes: ST/HT 10/level, DX/IQ 20/level;
+   skills/traits per those references. Then:
+   - **Grants and narrative edits — always apply.** Adding XP to the character's
+     own pool ("add 5 xp", "give me 3 points") or editing notes/current-status is
+     trusted self-service: apply it, never flag it. An XP grant raises Unspent
+     Points (and Total Points Earned). Collect into the applied batch; log a `✓`.
+   - **Affordable & unambiguous spend — apply.** Edit the `.md`, decrement running
+     unspent points, collect into the applied batch; log a `✓`.
+   - **Player override — apply even if unaffordable.** If the request carries a
+     trust signal — natural-language GM-approval or insistence such as "the GM
+     said it's OK", "GM approved", "GM said to", "do it anyway", "override", "GM
+     okayed it" — apply the spend even when it's over budget. Edit the `.md` and
+     decrement Unspent Points **allowing it to go negative** — write the negative
+     value into the Points Summary / Identity "Unspent Points" field so the
+     deficit shows honestly on the sheet. Collect into the applied batch. Log a
+     prominent **`⚠ OVERRIDE`** terminal line (character · what changed · resulting
+     unspent) so you always see what was pushed through on the player's word.
+   - **Unaffordable with no override — refuse politely.** Apply nothing; finalize
+     with the point-math explanation so the player knows exactly how short they
+     are and can re-send with an override:
 
      ```bash
-     npx gm-apprentice-publish inbox reply <id> rejected "Ronin → Sex Appeal +2 (11→13). Costs 6; he has 5. One short — nothing applied."
+     npx gm-apprentice-publish inbox reply <id> rejected "Ronin → Sex Appeal +2 (11→13). Costs 6; he has 5. One short — nothing applied. Send it again with \"GM said OK\" to override."
      ```
+   - **Ambiguous — ask, don't guess.** If you genuinely can't tell *what* the
+     player means (which skill, which item), do not edit — reply asking which they
+     meant. An override bypasses affordability, never an unknown target.
 3. **Question → answer** using **player-safe scope only** — the published
    sheet/site + GURPS rules + the character's own non-GM sections. NEVER use
    `GM Notes`, `DM Notes`, `Player Notes`, `Source References`,
@@ -81,6 +97,12 @@ submission order (`timestamp` ascending), tracking **running unspent points**
 
      ```bash
      npx gm-apprentice-publish inbox reply <id> applied "✓ Streetwise 2→3 — applied"
+     ```
+
+     An override's confirmation names the override and the resulting deficit:
+
+     ```bash
+     npx gm-apprentice-publish inbox reply <id> applied "✓ Six → DX 13→14 — GM override applied; Unspent now −5 (reconcile when you can)."
      ```
    - **On deploy failure:** do **not** reply — the entries stay `pending`
      (nothing else marks them) and are pulled again on the next watcher cycle.

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -76,9 +76,18 @@ submission order (`timestamp` ascending), tracking **running unspent points**
      ```bash
      npx gm-apprentice-publish inbox reply <id> rejected "Ronin → Sex Appeal +2 (11→13). Costs 6; he has 5. One short — nothing applied. Send it again with \"GM said OK\" to override."
      ```
+
+     Then log a `⚠` line (character · what was asked · "can't afford — nothing applied").
    - **Ambiguous — ask, don't guess.** If you genuinely can't tell *what* the
-     player means (which skill, which item), do not edit — reply asking which they
-     meant. An override bypasses affordability, never an unknown target.
+     player means (which skill, which item), do not edit. Finalize with a
+     **`rejected`** reply asking which they meant:
+
+     ```bash
+     npx gm-apprentice-publish inbox reply <id> rejected "Which skill did you mean — Guns (Pistol) or Gunner? Send it again naming one."
+     ```
+
+     Then log a `⚠` line (character · the ambiguous request · "needs clarification").
+     An override bypasses affordability, never an unknown target.
 3. **Question → answer** using **player-safe scope only** — the published
    sheet/site + GURPS rules + the character's own non-GM sections. NEVER use
    `GM Notes`, `DM Notes`, `Player Notes`, `Source References`,

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -87,7 +87,7 @@
         '<button type="button" class="cr-toggle" aria-expanded="false">✎ Request a change / ask a question</button>' +
         '<button type="button" class="cr-log-btn" aria-label="Open chat log" hidden>💬</button>' +
         '<div class="cr-panel" hidden>' +
-          '<p class="cr-hint">Type a change ("spend 1 xp to raise Streetwise") or a question ("is it worth raising DX?").</p>' +
+          '<p class="cr-hint">Type a change ("spend 1 xp to raise Streetwise") or a question ("is it worth raising DX?"). Can\'t afford something but the GM okayed it? Add "GM said OK" and it\'ll go through anyway.</p>' +
           '<input type="text" class="cr-code" maxlength="4" placeholder="4-char code" aria-label="Session code" hidden>' +
           '<div class="cr-inputrow">' +
             '<textarea class="cr-text" rows="3" aria-label="Your message"></textarea>' +


### PR DESCRIPTION
Loosens the change-request loop's approval logic to trust the player more, especially around XP.

## What changes

- **Grants and narrative edits always apply.** Adding XP to one's own pool ("add 5 xp"), or editing notes/status, is trusted self-service — applied, never flagged. (There was never an authority gate; this makes the intent explicit so a cautious loop stops second-guessing it.)
- **"GM said OK / do it anyway" override.** A player can push an otherwise-unaffordable change through by adding a trust signal — "the GM said it's OK", "GM approved", "do it anyway", "override". The change applies with **Unspent Points shown as a deficit** (e.g. `−5`) so the sheet is honest, and every override is logged as a `⚠ OVERRIDE` line in the GM's terminal — trust, but visible.
- **Ambiguity still asks.** An override bypasses affordability, never an unknown target — if the loop can't tell *which* skill or item is meant, it still asks (finalized as a `rejected` clarification reply) rather than editing on a guess. Plain refusals and ambiguous asks are also logged to the GM terminal.
- **Widget hint.** The input's helper text now tells players they can add "GM said OK" to push a change through.

Almost entirely the loop workflow doc (`change-request-loop.md`), plus the one hint line. GURPS 4e.

## Testing

Full suite stays green (975); the change is workflow prose (loop-Claude-guided) plus a static hint string. Gated by skill-creator validation, schema, and markdownlint. A whole-diff review caught and fixed a regression where the rewrite had dropped the terminal-log instruction for the refusal/ambiguous paths.
