### PR TITLE
Eliminate kv.list from party board and inbox; adaptive board poll

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.27",
+  "version": "1.8.28",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.28] — 2026-07-18
+
+Publish tool 1.11.7.
+
+### Fixed
+
+- GURPS party board no longer exhausts the Cloudflare KV free-tier list quota.
+  The board polled `/api/loadout-list` every 5 seconds and that endpoint ran a
+  `kv.list()` on every poll; the free tier allows only 1,000 list operations per
+  day, so a single open party-board tab drained the day's quota in about 1h23m
+  (after which the board silently stopped updating until UTC midnight). The
+  loadout Functions now maintain a per-campaign `roster:<campaignId>` index on
+  write and read party state with plain `kv.get()` calls — **zero `kv.list()`** —
+  and the board polls every 60 seconds only while a game is actively running
+  (activity = a player edit advancing state, a keypress/pointer press, or the tab
+  becoming visible), going dormant after 15 idle minutes and never fetching while
+  the tab is hidden. Migration is self-healing and needs no backfill: the roster
+  starts empty and each player is registered the first time they save (the roster
+  key's TTL is refreshed on every save so it never expires under an active
+  party); pre-existing per-player keys stay valid.
+- Change-request inbox no longer runs a `kv.list()` on every poll of the GM
+  loop. `readPending` now reads a single `config:req-index` key and fetches each
+  request by id; `enqueue` maintains the index. The index is seeded once from a
+  single `kv.list()` the first time it is missing, so a site upgraded from an
+  earlier deployment recovers any in-flight pending requests without losing them,
+  and never lists again afterwards.
+- **Existing deployed sites keep running the old, quota-burning Functions until
+  updated** — re-copy `functions/api/loadout-core.mjs`, `functions/api/loadout.js`,
+  `functions/api/loadout-list.js`, `functions/api/inbox-core.mjs`, and
+  `js/gurps-party.js` from the scaffold and redeploy (see the Cloudflare Pages
+  guide). Closing the party-board tab stops the loadout burn immediately in the
+  meantime.
+
+---
+
 ## [1.8.27] — 2026-07-18
 
 Publish tool 1.11.6.

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -208,6 +208,32 @@ needed. Sites scaffolded with a newer `gm-publish init` get it automatically;
 **existing sites must hand-copy** `functions/api/loadout-list.js` (and re-deploy)
 the same way they copied `functions/api/loadout.js` for SP1.
 
+> **KV list-quota fix — existing sites must refresh the loadout + inbox Functions
+> and redeploy.** Early builds had the party board poll the list endpoint every 5
+> seconds, and both that endpoint and the change-request inbox used `kv.list()` on
+> every poll. Cloudflare's free tier allows only **1,000 list operations per
+> day**, so one party-board tab left open exhausted the day's quota in about
+> 1h23m (after which the board stops updating until the quota resets at UTC
+> midnight); a long inbox-loop session added to the same burn. The fix removes
+> `kv.list()` from both hot paths — the party board maintains a per-campaign
+> `roster:<campaignId>` index (written on save, read with plain gets) and the
+> inbox maintains a `config:req-index` key — and slows the board to a 60-second
+> poll that only runs while a game is actually in progress. To adopt it, re-copy
+> from the scaffold: `functions/api/loadout-core.mjs`, `functions/api/loadout.js`,
+> `functions/api/loadout-list.js`, `functions/api/inbox-core.mjs`, and the roster
+> page's `js/gurps-party.js`, then redeploy. A site still running the **old**
+> Functions keeps burning the list quota until it is updated; the two versions do
+> not need to match across deploys, but the old one is not fixed until you
+> redeploy the new files. **Migration is automatic and needs no backfill:** the
+> party roster starts empty and each member is added the first time they save
+> (which happens seconds into any session), the roster key's TTL is refreshed on
+> every save so it never expires under an active party, and every pre-existing
+> per-player key stays valid. The inbox index is seeded once from a single
+> `kv.list()` the first time it is missing, so any in-flight pending requests on
+> an upgraded site are recovered rather than lost, and it never lists again after
+> that. **Immediate mitigation while you wait to redeploy:** closing the
+> party-board tab stops the burn right away, and the quota resets at UTC midnight.
+
 > **Existing sites — set the project name first.** Open `wrangler.toml` and set
 > `name` to your **existing** Cloudflare Pages project name (the one you first
 > ran `pages project create` with, e.g. `dead-end`). The scaffold fills `name`

--- a/tools/publish/js/gurps-party.js
+++ b/tools/publish/js/gurps-party.js
@@ -62,7 +62,62 @@
     };
   }
 
-  var api = { groupLatestByPc, rowCells };
+  // Freshest updatedAt across every state — how the poller detects a live game.
+  function maxUpdatedAt(statesByKey) {
+    var mx = 0;
+    Object.keys(statesByKey || {}).forEach(function (key) {
+      var st = statesByKey[key];
+      var at = (st && typeof st.updatedAt === 'number') ? st.updatedAt : 0;
+      if (at > mx) mx = at;
+    });
+    return mx;
+  }
+
+  // Adaptive poll scheduler. The board used to setInterval(poll, 5000), which
+  // one open tab left running for hours — each poll is a kv.list on the free
+  // tier's 1,000/day cap. Now it polls every 60s only while "active", and goes
+  // silent otherwise. Active = interacted-or-edited within the idle window.
+  // Deps (now/setTimer/clearTimer/isHidden/poll) are injected so it is testable
+  // with a fake clock; the browser bootstrap passes the real ones.
+  //   poll() must return a Promise resolving to the states map (or undefined).
+  function createPoller(opts) {
+    var now = opts.now, setTimer = opts.setTimer, clearTimer = opts.clearTimer;
+    var isHidden = opts.isHidden || function () { return false; };
+    var doPoll = opts.poll;
+    var POLL_MS = opts.pollMs || 60000;
+    var IDLE_MS = opts.idleMs || 15 * 60 * 1000;
+    var lastActivity = now();
+    var lastMax = 0;
+    var timer = null;
+
+    function active() { return (now() - lastActivity) < IDLE_MS; }
+    function clear() { if (timer !== null) { clearTimer(timer); timer = null; } }
+    function schedule() {
+      clear();
+      if (!isHidden() && active()) timer = setTimer(tick, POLL_MS);
+    }
+    function tick() { timer = null; run(); }
+    function run() {
+      if (isHidden()) { clear(); return; }   // dormant while backgrounded
+      return Promise.resolve(doPoll()).then(finish, finish);
+    }
+    function finish(states) {
+      // A newer max updatedAt means a player edited during play → keep polling.
+      if (states && typeof states === 'object') {
+        var mx = maxUpdatedAt(states);
+        if (mx > lastMax) { lastMax = mx; lastActivity = now(); }
+      }
+      schedule();
+    }
+    function interact() {           // visible again / keydown → poll now, resume
+      lastActivity = now();
+      clear();
+      if (!isHidden()) run();
+    }
+    return { start: run, stop: clear, interact: interact, isActive: active };
+  }
+
+  var api = { groupLatestByPc, rowCells, maxUpdatedAt, createPoller };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   root.__gurpsParty = api;
 
@@ -96,20 +151,38 @@
     }
 
     var inFlight = false;
+    // Resolves with the states map (so the scheduler can spot a live game) or
+    // undefined when the poll was skipped/failed — either way it keeps last-good.
     function poll() {
-      if (document.hidden || inFlight) return;
+      if (document.hidden || inFlight) return Promise.resolve(undefined);
       inFlight = true;
-      fetch('/api/loadout-list?campaign=' + encodeURIComponent(manifest.campaignId))
+      return fetch('/api/loadout-list?campaign=' + encodeURIComponent(manifest.campaignId))
         .then(function (r) { if (!r.ok) throw new Error('loadout-list ' + r.status); return r.json(); })
         .then(function (j) {
           if (!j || !j.states || typeof j.states !== 'object') throw new Error('bad loadout-list payload');
           paint(j.states);
+          return j.states;
         })
-        .catch(function () { /* keep last-good */ })
-        .then(function () { inFlight = false; });
+        .catch(function () { return undefined; /* keep last-good */ })
+        .then(function (states) { inFlight = false; return states; });
     }
-    poll();
-    setInterval(poll, 5000);
-    document.addEventListener('visibilitychange', function () { if (!document.hidden) poll(); });
+
+    var poller = api.createPoller({
+      now: function () { return Date.now(); },
+      setTimer: function (fn, ms) { return setTimeout(fn, ms); },
+      clearTimer: function (id) { clearTimeout(id); },
+      isHidden: function () { return document.hidden; },
+      poll: poll,
+      pollMs: 60000,
+      idleMs: 15 * 60 * 1000,
+    });
+    poller.start();
+    // Becoming visible, a keypress, or a pointer press on the board all count as
+    // activity: poll now and resume the 60s cadence. Hiding lets the next tick
+    // fall dormant. (A visible board with no interaction and no player edits for
+    // 15 min goes silent by design — any of these events revives it.)
+    document.addEventListener('visibilitychange', function () { if (!document.hidden) poller.interact(); });
+    document.addEventListener('keydown', function () { poller.interact(); });
+    document.addEventListener('pointerdown', function () { poller.interact(); });
   });
 })(typeof window !== 'undefined' ? window : this);

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -6,9 +6,59 @@
 
 export const PREFIX = 'req:';
 export const CODE_KEY = 'config:code';
+export const INDEX_KEY = 'config:req-index'; // JSON array of request ids; lets readPending skip kv.list()
 export const RL_PREFIX = 'rl:';
 export const HANDLED_TTL = 300; // seconds a handled entry lingers for the widget
 export const RESPONSE_TTL = 600; // seconds a responded (handled) entry lingers for the widget
+
+// The request index removes kv.list() from the change-request loop's hot path.
+// The GM's inbox loop polls readPending repeatedly during a session; on the free
+// tier that was one list per poll against a 1,000-lists/day cap. Now enqueue
+// records each id in a single index key and readPending fans out plain gets.
+// readIndex returns null ONLY when the key is truly absent (never seeded) — an
+// emptied index is stored as `[]` — so ensureIndex can tell a cold start apart
+// from an inbox that has simply been drained.
+async function readIndex(kv) {
+  const raw = await kv.get(INDEX_KEY);
+  if (raw == null) return null;
+  try {
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeIndex(kv, ids) {
+  await kv.put(INDEX_KEY, JSON.stringify(ids));
+}
+
+// Return the current index, seeding it ONCE from a single kv.list() the first
+// time it is missing. This is the migration bridge: a site upgraded from a
+// pre-index deployment may already hold pending `req:` entries, and seeding
+// recovers them so none are silently lost. After the seed the key exists (even
+// if empty), so this never lists again.
+async function ensureIndex(kv) {
+  const existing = await readIndex(kv);
+  if (existing !== null) return existing;
+  const { keys } = await kv.list({ prefix: PREFIX });
+  const seeded = keys.map(({ name }) => name.slice(PREFIX.length));
+  // Re-read right before writing: a concurrent enqueue may have created the index
+  // while we were listing, so union rather than clobber its ids.
+  const landed = await readIndex(kv);
+  const merged = landed === null ? seeded : [...new Set([...landed, ...seeded])];
+  await writeIndex(kv, merged);
+  return merged;
+}
+
+// Add an id to the index, re-reading immediately before the write and unioning so
+// a concurrent enqueue's id is not clobbered. KV offers no compare-and-set, so a
+// cross-edge simultaneous write can still race in theory; players sharing one
+// table (hence one edge, with read-your-writes) are covered in practice.
+async function addToIndex(kv, id) {
+  const cur = (await readIndex(kv)) || [];
+  if (!cur.includes(id)) { cur.push(id); await writeIndex(kv, cur); }
+}
 
 export function normalizeCode(raw) {
   return String(raw || '').trim().toUpperCase();
@@ -37,18 +87,36 @@ export function buildEntry({ id, character, text, timestamp }) {
 export async function enqueue(kv, { id, character, text, timestamp }) {
   const entry = buildEntry({ id, character, text, timestamp });
   await kv.put(PREFIX + id, JSON.stringify(entry));
+  await ensureIndex(kv);       // guarantee the index exists (seeds on migration)
+  await addToIndex(kv, id);
   return entry;
 }
 
+// Read every pending/applied request WITHOUT kv.list() on the steady-state path.
+// One get for the index, then one get per id. Ids are dropped from the index
+// when their entry is terminal for this view: null (a handled entry that has
+// self-reaped via TTL) or `flagged` (rejected — persists with no TTL and is
+// never re-surfaced here, so it would otherwise cost a get on every poll
+// forever). The prune re-reads the index immediately before writing and removes
+// only those specific ids, so an enqueue that landed since our first read is
+// preserved.
 export async function readPending(kv) {
+  const ids = await ensureIndex(kv);
   const out = [];
-  const { keys } = await kv.list({ prefix: PREFIX });
-  for (const { name } of keys) {
-    const raw = await kv.get(name);
-    if (!raw) continue;
+  const drop = [];
+  for (const id of ids) {
+    const raw = await kv.get(PREFIX + id);
+    if (!raw) { drop.push(id); continue; }
     let entry;
-    try { entry = JSON.parse(raw); } catch { continue; }
+    try { entry = JSON.parse(raw); } catch { continue; } // corrupt but present → keep in index
     if (entry.status === 'pending' || entry.status === 'applied') out.push(entry);
+    else if (entry.status === 'flagged') drop.push(id);
+  }
+  if (drop.length) {
+    const dropSet = new Set(drop);
+    const current = (await readIndex(kv)) || [];
+    const cleaned = current.filter((id) => !dropSet.has(id));
+    if (cleaned.length !== current.length) await writeIndex(kv, cleaned);
   }
   return out.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
 }

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -41,8 +41,19 @@ async function writeIndex(kv, ids) {
 async function ensureIndex(kv) {
   const existing = await readIndex(kv);
   if (existing !== null) return existing;
-  const { keys } = await kv.list({ prefix: PREFIX });
-  const seeded = keys.map(({ name }) => name.slice(PREFIX.length));
+  // Cloudflare KV paginates list(): a single page caps at ~1,000 keys and an
+  // empty `keys` array does NOT mean "done" — only `list_complete` does. Follow
+  // the cursor so a pre-index inbox with more than one page seeds every req: key
+  // rather than silently dropping the tail. (The in-memory test adapter returns
+  // no cursor, so this collapses to a single list there.)
+  const seeded = [];
+  let cursor;
+  for (;;) {
+    const page = await kv.list({ prefix: PREFIX, cursor });
+    for (const { name } of (page.keys || [])) seeded.push(name.slice(PREFIX.length));
+    if (page.list_complete || !page.cursor) break;
+    cursor = page.cursor;
+  }
   // Re-read right before writing: a concurrent enqueue may have created the index
   // while we were listing, so union rather than clobber its ids.
   const landed = await readIndex(kv);

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -63,9 +63,19 @@ async function ensureIndex(kv) {
 }
 
 // Add an id to the index, re-reading immediately before the write and unioning so
-// a concurrent enqueue's id is not clobbered. KV offers no compare-and-set, so a
-// cross-edge simultaneous write can still race in theory; players sharing one
-// table (hence one edge, with read-your-writes) are covered in practice.
+// a concurrent enqueue's id is not clobbered on the same edge.
+//
+// KNOWN LIMITATION — accepted best-effort, NOT self-healing. KV has no
+// compare-and-set, so two enqueues on DIFFERENT edges can each read the same
+// index snapshot and write back only their own id; the last write drops the
+// other. Unlike the loadout roster (registerMember runs on every save, so a
+// clobbered member re-registers), an enqueue runs once: the orphaned req:<id> is
+// stored but, since ensureIndex re-lists only on cold start (index key absent),
+// it is never rediscovered by readPending. This is an intentional trade-off for
+// a zero-infra, free-tier design (Durable Objects are out of scope). Co-located
+// players share one edge (read-your-writes) and are unaffected; a request lost to
+// a cross-edge race is recovered by the player resubmitting. A periodic
+// list()+union reconciliation could close the gap if this proves to matter.
 async function addToIndex(kv, id) {
   const cur = (await readIndex(kv)) || [];
   if (!cur.includes(id)) { cur.push(id); await writeIndex(kv, cur); }

--- a/tools/publish/templates-scaffold/functions/api/loadout-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/loadout-core.mjs
@@ -1,10 +1,37 @@
 // Pure KV logic for player loadout state. Bound to the same INBOX namespace as
 // the change-request inbox, under a distinct `loadout:` key prefix.
 export const PREFIX = 'loadout:';
+export const ROSTER_PREFIX = 'roster:';
 export const TTL = 60 * 60 * 24 * 30; // 30 days — bounds orphaned keys
 
 export function isValidKey(key) {
   return typeof key === 'string' && key.startsWith(PREFIX) && key.length <= 200;
+}
+
+// roster:<campaignId> holds the JSON array of member keys for a campaign, so the
+// GM board can fan out reads WITHOUT kv.list() (the free tier caps lists at
+// 1,000/day — a single open board burned them in ~1h23m). Member key shape is
+// loadout:<campaignId>:<pc>:<player>, so the campaign is segment 1.
+export function rosterKey(campaignId) {
+  return ROSTER_PREFIX + campaignId;
+}
+
+function campaignOfKey(key) {
+  if (!isValidKey(key)) return null;
+  const parts = key.split(':'); // ['loadout', '<campaign>', '<pc>', '<player>']
+  const campaign = parts[1];
+  return isValidCampaign(campaign) ? campaign : null;
+}
+
+async function readRoster(kv, campaignId) {
+  const raw = await kv.get(rosterKey(campaignId));
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
 }
 
 export async function readState(kv, key) {
@@ -21,17 +48,45 @@ export function isValidCampaign(id) {
   return typeof id === 'string' && id.length >= 1 && id.length <= 100 && !id.includes(':');
 }
 
-// Read every stored state under loadout:<campaignId>: — READ ONLY, no writes.
-// Caps at `limit` keys (a party is a handful; the cap defends against runaway growth).
-export async function listStates(kv, campaignId, limit = 200) {
-  const prefix = PREFIX + campaignId + ':';
-  const listed = await kv.list({ prefix });
-  const names = (listed.keys || []).slice(0, limit).map((k) => k.name);
+// Add a member key to its campaign roster and refresh the roster's TTL. The
+// re-put happens on EVERY save, not just when the key is new: member state keys
+// refresh their own 30-day TTL on every writeState, so the roster index must be
+// refreshed just as often — otherwise a long-running campaign with stable
+// membership would let roster:<id> expire while its member keys live on, and the
+// board would read an empty roster and render blank. Membership itself only
+// grows when a genuinely new key appears.
+export async function registerMember(kv, memberKey) {
+  const campaignId = campaignOfKey(memberKey);
+  if (!campaignId) return;
+  const roster = await readRoster(kv, campaignId);
+  if (!roster.includes(memberKey)) roster.push(memberKey);
+  await kv.put(rosterKey(campaignId), JSON.stringify(roster), { expirationTtl: TTL });
+}
+
+// Read every party member's stored state — READ ONLY of member states, no
+// kv.list(). One get for the roster (empty/absent → {}), then one get per
+// member key. Members that resolve null (TTL-expired) or unparseable-but-null
+// are skipped. If any resolved null, the roster is pruned so dead device keys
+// don't accumulate forever — but the prune RE-READS the roster immediately
+// before writing and removes only the confirmed-dead keys, so a registerMember
+// that landed since our first read (KV is eventually consistent, so this window
+// is not just same-instant) is preserved rather than clobbered.
+export async function getStates(kv, campaignId) {
+  const roster = await readRoster(kv, campaignId);
   const out = {};
-  for (const name of names) {
-    const raw = await kv.get(name);
-    if (!raw) continue;
-    try { out[name] = JSON.parse(raw); } catch { /* skip malformed */ }
+  const dead = [];
+  for (const key of roster) {
+    const raw = await kv.get(key);
+    if (!raw) { dead.push(key); continue; }
+    try { out[key] = JSON.parse(raw); } catch { /* skip malformed but keep the key */ }
+  }
+  if (dead.length) {
+    const deadSet = new Set(dead);
+    const current = await readRoster(kv, campaignId);
+    const cleaned = current.filter((k) => !deadSet.has(k));
+    if (cleaned.length !== current.length) {
+      await kv.put(rosterKey(campaignId), JSON.stringify(cleaned), { expirationTtl: TTL });
+    }
   }
   return out;
 }

--- a/tools/publish/templates-scaffold/functions/api/loadout-list.js
+++ b/tools/publish/templates-scaffold/functions/api/loadout-list.js
@@ -12,6 +12,6 @@ export async function onRequestGet(context) {
   const { request, env } = context;
   const campaign = new URL(request.url).searchParams.get('campaign');
   if (!core.isValidCampaign(campaign)) return json({}, 400);
-  const states = await core.listStates(env.INBOX, campaign);
+  const states = await core.getStates(env.INBOX, campaign);
   return json({ states });
 }

--- a/tools/publish/templates-scaffold/functions/api/loadout.js
+++ b/tools/publish/templates-scaffold/functions/api/loadout.js
@@ -26,5 +26,8 @@ export async function onRequestPut(context) {
   }
   const state = { ...body.state, updatedAt: Date.now() };
   await core.writeState(env.INBOX, body.key, state);
+  // Record this member in the campaign roster so the GM board can read party
+  // state without kv.list(). Writes at most once per member.
+  await core.registerMember(env.INBOX, body.key);
   return json({ ok: true });
 }

--- a/tools/publish/test/gurps-party.test.js
+++ b/tools/publish/test/gurps-party.test.js
@@ -3,6 +3,33 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const gp = require('../js/gurps-party.js');
 
+// Deterministic clock + single-shot timer registry for the poll scheduler.
+function fakeClock() {
+  let t = 0, seq = 1;
+  const timers = new Map();
+  return {
+    now() { return t; },
+    setTimer(fn, ms) { const id = seq++; timers.set(id, { fn, at: t + ms }); return id; },
+    clearTimer(id) { timers.delete(id); },
+    pending() { return timers.size; },
+    async advance(ms) {
+      t += ms;
+      // Fire every timer due at/before t, draining microtasks after each so the
+      // poll's .then(finish→schedule) chain settles before the next fires.
+      for (;;) {
+        const due = [...timers.entries()].filter(([, x]) => x.at <= t).sort((a, b) => a[1].at - b[1].at);
+        if (!due.length) break;
+        const [id, x] = due[0];
+        timers.delete(id);
+        x.fn();
+        await new Promise((r) => setImmediate(r));
+      }
+    },
+  };
+}
+const flush = () => new Promise((r) => setImmediate(r));
+const MIN = 60000, IDLE = 15 * 60 * 1000;
+
 test('groupLatestByPc picks the max-updatedAt state per pcSlug', () => {
   const states = {
     'loadout:c:six:d1': { v: 'v1', hp: { cur: 9, max: 13 }, updatedAt: 100 },
@@ -56,4 +83,86 @@ test('rowCells: reeling only → reeling class, no ST arrow', () => {
   assert.equal(c.rowClass, 'reeling');
   assert.doesNotMatch(c.status, /Tired/);
   assert.doesNotMatch(c.st, /→|base/);   // ST unchanged under reeling → plain
+});
+
+test('maxUpdatedAt returns the freshest updatedAt across states, 0 when none', () => {
+  assert.equal(gp.maxUpdatedAt({}), 0);
+  assert.equal(gp.maxUpdatedAt({ a: { updatedAt: 100 }, b: { updatedAt: 300 }, c: {} }), 300);
+  assert.equal(gp.maxUpdatedAt(null), 0);
+});
+
+function makePoller(clk, opts) {
+  let polls = 0;
+  const poller = gp.createPoller(Object.assign({
+    now: clk.now, setTimer: clk.setTimer, clearTimer: clk.clearTimer,
+    isHidden: () => false,
+    poll() { polls++; return Promise.resolve({}); },
+    pollMs: MIN, idleMs: IDLE,
+  }, opts));
+  return { poller, polls: () => polls };
+}
+
+test('scheduler polls every 60s while active', async () => {
+  const clk = fakeClock();
+  const { poller, polls } = makePoller(clk);
+  poller.start(); await flush();
+  assert.equal(polls(), 1);            // immediate poll on start
+  await clk.advance(MIN);
+  assert.equal(polls(), 2);            // +1 at 60s
+  await clk.advance(MIN);
+  assert.equal(polls(), 3);            // +1 at 120s
+  assert.equal(clk.pending(), 1);      // exactly one timer armed
+});
+
+test('scheduler goes silent after 15 min with no activity', async () => {
+  const clk = fakeClock();
+  const { poller, polls } = makePoller(clk);
+  poller.start(); await flush();
+  for (let i = 0; i < 20; i++) await clk.advance(MIN);   // run well past the idle window
+  const frozen = polls();
+  assert.equal(clk.pending(), 0);      // no timer armed → dormant
+  await clk.advance(MIN * 10);
+  assert.equal(polls(), frozen);       // stays silent
+});
+
+test('scheduler resumes immediately on interaction after going idle', async () => {
+  const clk = fakeClock();
+  const { poller, polls } = makePoller(clk);
+  poller.start(); await flush();
+  for (let i = 0; i < 20; i++) await clk.advance(MIN);
+  assert.equal(clk.pending(), 0);
+  const before = polls();
+  poller.interact(); await flush();
+  assert.equal(polls(), before + 1);   // interaction polls right away
+  assert.equal(clk.pending(), 1);      // and re-arms the 60s loop
+  await clk.advance(MIN);
+  assert.equal(polls(), before + 2);
+});
+
+test('scheduler never fetches while hidden, wakes on becoming visible', async () => {
+  const clk = fakeClock();
+  let hidden = true;
+  const { poller, polls } = makePoller(clk, { isHidden: () => hidden });
+  poller.start(); await flush();
+  assert.equal(polls(), 0);            // hidden → no fetch
+  assert.equal(clk.pending(), 0);      // and no timer churning
+  hidden = false;
+  poller.interact(); await flush();    // visibilitychange→visible is an interaction
+  assert.equal(polls(), 1);
+  assert.equal(clk.pending(), 1);
+});
+
+test('advancing state keeps the board active past the idle window', async () => {
+  const clk = fakeClock();
+  let n = 0;
+  // Each poll reports a newer updatedAt → a live game → activity keeps refreshing.
+  const poller = gp.createPoller({
+    now: clk.now, setTimer: clk.setTimer, clearTimer: clk.clearTimer, isHidden: () => false,
+    poll() { n++; return Promise.resolve({ pc: { updatedAt: n * 1000000 } }); },
+    pollMs: MIN, idleMs: IDLE,
+  });
+  poller.start(); await flush();
+  for (let i = 0; i < 20; i++) await clk.advance(MIN);   // 20 min of live edits
+  assert.equal(n, 21);                 // still polling every minute
+  assert.equal(clk.pending(), 1);
 });

--- a/tools/publish/test/inbox-core.test.js
+++ b/tools/publish/test/inbox-core.test.js
@@ -162,6 +162,69 @@ test('ensureIndex seed unions an index a concurrent enqueue created mid-migratio
   assert.deepEqual(JSON.parse(store.get(inbox.INDEX_KEY)).sort(), ['x', 'y']);
 });
 
+// KV whose list() paginates like Cloudflare: `pageSize` keys per call, exposing
+// `cursor` + `list_complete`. A seed that reads only the first page would miss
+// the tail here.
+function paginatingKV(entries = {}, pageSize = 2) {
+  const store = new Map(Object.entries(entries));
+  const counts = { list: 0, get: 0, put: 0 };
+  return {
+    counts,
+    _store: store,
+    async get(k) { counts.get++; return store.has(k) ? store.get(k) : null; },
+    async put(k, v) { counts.put++; store.set(k, v); },
+    async delete(k) { store.delete(k); },
+    async list({ prefix = '', cursor } = {}) {
+      counts.list++;
+      const all = [...store.keys()].filter(k => k.startsWith(prefix)).sort();
+      const start = cursor ? parseInt(cursor, 10) : 0;
+      const slice = all.slice(start, start + pageSize);
+      const next = start + pageSize;
+      const list_complete = next >= all.length;
+      return { keys: slice.map(name => ({ name })), list_complete, cursor: list_complete ? undefined : String(next) };
+    },
+  };
+}
+
+test('cold-start seed follows the KV cursor and recovers every pre-index req: key', async () => {
+  const entries = {};
+  for (let i = 1; i <= 5; i++) {
+    entries['req:m' + i] = JSON.stringify(
+      inbox.buildEntry({ id: 'm' + i, character: 'a', text: 't', timestamp: '2026-07-11T14:0' + i + ':00.000Z' }));
+  }
+  const kv = paginatingKV(entries, 2);   // 5 keys spread over 3 pages
+  const pending = await inbox.readPending(kv);
+  assert.deepEqual(pending.map(e => e.id).sort(), ['m1', 'm2', 'm3', 'm4', 'm5']); // tail not dropped
+  assert.equal(kv.counts.list, 3);       // walked all three pages via the cursor
+  assert.deepEqual(JSON.parse(kv._store.get(inbox.INDEX_KEY)).sort(), ['m1', 'm2', 'm3', 'm4', 'm5']);
+});
+
+test('readPending prune re-reads the index and preserves a concurrently-enqueued id', async () => {
+  // 'a' is flagged (terminal) so the prune drops it. Between readPending's first
+  // index read and its pre-prune re-read, a concurrent enqueue lands 'new'. The
+  // re-read+filter must drop only 'a' and keep 'new'.
+  const store = new Map();
+  store.set('req:a', JSON.stringify({ ...inbox.buildEntry({ id: 'a', character: 'x', text: 't', timestamp: '2026-07-11T00:00:00Z' }), status: 'flagged' }));
+  store.set(inbox.INDEX_KEY, JSON.stringify(['a']));
+  let idxGets = 0;
+  const kv = {
+    async get(k) {
+      if (k === inbox.INDEX_KEY) {
+        idxGets++;
+        if (idxGets === 2) {   // concurrent enqueue lands just before the prune write
+          store.set('req:new', JSON.stringify(inbox.buildEntry({ id: 'new', character: 'y', text: 't', timestamp: '2026-07-11T00:01:00Z' })));
+          store.set(k, JSON.stringify(['a', 'new']));
+        }
+      }
+      return store.has(k) ? store.get(k) : null;
+    },
+    async put(k, v) { store.set(k, v); },
+    async list() { return { keys: [] }; },
+  };
+  await inbox.readPending(kv);
+  assert.deepEqual(JSON.parse(store.get(inbox.INDEX_KEY)).sort(), ['new']);   // 'a' dropped, 'new' kept
+});
+
 test('readPending drops a flagged (terminal, no-TTL) id from the index', async () => {
   const kv = countingKV();
   await inbox.enqueue(kv, { id: 'a', character: 'ana', text: 'x', timestamp: '2026-07-11T14:00:00.000Z' });

--- a/tools/publish/test/inbox-core.test.js
+++ b/tools/publish/test/inbox-core.test.js
@@ -73,6 +73,121 @@ test('readPending skips a corrupted entry instead of throwing', async () => {
   assert.deepEqual(pending.map(e => e.id), ['good']);
 });
 
+// KV that COUNTS list ops, to prove the inbox stops listing on every poll.
+function countingKV(entries = {}) {
+  const store = new Map(Object.entries(entries));
+  const counts = { list: 0, get: 0, put: 0, delete: 0 };
+  return {
+    counts,
+    _store: store,
+    async get(k) { counts.get++; return store.has(k) ? store.get(k) : null; },
+    async put(k, v) { counts.put++; store.set(k, v); },
+    async delete(k) { counts.delete++; store.delete(k); },
+    async list({ prefix } = {}) {
+      counts.list++;
+      return { keys: [...store.keys()].filter(k => !prefix || k.startsWith(prefix)).map(name => ({ name })) };
+    },
+  };
+}
+
+test('steady-state readPending never lists — it reads the req index', async () => {
+  const kv = countingKV();
+  await inbox.enqueue(kv, { id: 'a', character: 'ana', text: 'a', timestamp: '2026-07-11T14:01:00.000Z' });
+  await inbox.enqueue(kv, { id: 'b', character: 'bo', text: 'b', timestamp: '2026-07-11T14:02:00.000Z' });
+  const listsAfterEnqueue = kv.counts.list;
+  const p1 = await inbox.readPending(kv);
+  const p2 = await inbox.readPending(kv);
+  assert.deepEqual(p1.map(e => e.id), ['a', 'b']);
+  assert.deepEqual(p2.map(e => e.id), ['a', 'b']);
+  assert.equal(kv.counts.list, listsAfterEnqueue);   // polling adds zero lists
+});
+
+test('cold-start readPending seeds the index from ONE list, then never lists again', async () => {
+  // A site upgraded from a pre-index deployment: req: entries already exist, no
+  // index key yet. The first read must recover them (via a single list) and seed
+  // the index; subsequent reads must not list.
+  const kv = countingKV({
+    'req:old1': JSON.stringify(inbox.buildEntry({ id: 'old1', character: 'ana', text: 'x', timestamp: '2026-07-11T14:00:00.000Z' })),
+    'req:old2': JSON.stringify(inbox.buildEntry({ id: 'old2', character: 'bo', text: 'y', timestamp: '2026-07-11T14:01:00.000Z' })),
+  });
+  const p1 = await inbox.readPending(kv);
+  assert.deepEqual(p1.map(e => e.id).sort(), ['old1', 'old2']);   // nothing lost on migration
+  assert.equal(kv.counts.list, 1);   // seeded with exactly one list
+  await inbox.readPending(kv);
+  await inbox.readPending(kv);
+  assert.equal(kv.counts.list, 1);   // and never again
+});
+
+test('enqueue re-reads the index before writing and preserves a concurrently-added id', async () => {
+  // The index starts empty; a second enqueue "lands" between our ensureIndex
+  // read and our pre-write re-read. The re-read+union must keep both ids.
+  const store = new Map([[inbox.INDEX_KEY, JSON.stringify([])]]);
+  let idxGets = 0;
+  const kv = {
+    async get(k) {
+      if (k === inbox.INDEX_KEY) { idxGets++; if (idxGets === 2) store.set(k, JSON.stringify(['other'])); }
+      return store.has(k) ? store.get(k) : null;
+    },
+    async put(k, v) { store.set(k, v); },
+    async list() { return { keys: [] }; },
+  };
+  await inbox.enqueue(kv, { id: 'mine', character: 'a', text: 't', timestamp: '2026-07-11T00:00:00Z' });
+  assert.deepEqual(JSON.parse(store.get(inbox.INDEX_KEY)).sort(), ['mine', 'other']);
+});
+
+test('ensureIndex seed unions an index a concurrent enqueue created mid-migration', async () => {
+  // Pre-index site with an existing entry 'x'; a concurrent enqueue lands 'y'
+  // (both req:y and the index) while our seed is listing. The seed must union,
+  // not clobber. Injected on the seed's pre-write re-read (2nd index get).
+  const store = new Map([
+    ['req:x', JSON.stringify(inbox.buildEntry({ id: 'x', character: 'a', text: 't', timestamp: '2026-07-11T00:00:00Z' }))],
+  ]);
+  let idxGets = 0;
+  const kv = {
+    async get(k) {
+      if (k === inbox.INDEX_KEY) {
+        idxGets++;
+        if (idxGets === 2) {   // concurrent enqueue completes just before our seed write
+          store.set('req:y', JSON.stringify(inbox.buildEntry({ id: 'y', character: 'b', text: 't', timestamp: '2026-07-11T00:01:00Z' })));
+          store.set(k, JSON.stringify(['y']));
+        }
+      }
+      return store.has(k) ? store.get(k) : null;
+    },
+    async put(k, v) { store.set(k, v); },
+    async list({ prefix } = {}) { return { keys: [...store.keys()].filter(k => !prefix || k.startsWith(prefix)).map(name => ({ name })) }; },
+  };
+  const pending = await inbox.readPending(kv);
+  assert.deepEqual(pending.map(e => e.id).sort(), ['x', 'y']);   // neither lost
+  assert.deepEqual(JSON.parse(store.get(inbox.INDEX_KEY)).sort(), ['x', 'y']);
+});
+
+test('readPending drops a flagged (terminal, no-TTL) id from the index', async () => {
+  const kv = countingKV();
+  await inbox.enqueue(kv, { id: 'a', character: 'ana', text: 'x', timestamp: '2026-07-11T14:00:00.000Z' });
+  await inbox.enqueue(kv, { id: 'b', character: 'bo', text: 'y', timestamp: '2026-07-11T14:01:00.000Z' });
+  await inbox.markFlagged(kv, 'b');
+  const listsBefore = kv.counts.list;
+  const pending = await inbox.readPending(kv);
+  assert.deepEqual(pending.map(e => e.id), ['a']);
+  assert.deepEqual(JSON.parse(kv._store.get(inbox.INDEX_KEY)), ['a']);   // flagged 'b' removed
+  assert.equal(kv.counts.list, listsBefore);
+  // 'b' is still fetchable by id for the player's widget.
+  assert.equal((await inbox.getResults(kv, ['b'])).b.status, 'flagged');
+});
+
+test('readPending prunes a reaped (TTL-expired) id from the index without listing', async () => {
+  const kv = countingKV();
+  await inbox.enqueue(kv, { id: 'live', character: 'ana', text: 'x', timestamp: '2026-07-11T14:00:00.000Z' });
+  await inbox.enqueue(kv, { id: 'gone', character: 'bo', text: 'y', timestamp: '2026-07-11T14:01:00.000Z' });
+  await kv.delete('req:gone');   // simulate TTL reap of a handled entry
+  const listsBefore = kv.counts.list;
+  const pending = await inbox.readPending(kv);
+  assert.deepEqual(pending.map(e => e.id), ['live']);
+  assert.deepEqual(JSON.parse(kv._store.get(inbox.INDEX_KEY)), ['live']);   // dead id dropped
+  assert.equal(kv.counts.list, listsBefore);
+});
+
 test('buildEntry seeds response and kind as null', () => {
   const e = inbox.buildEntry({ id: 'x', character: 'a', text: 't', timestamp: '2026-07-12T00:00:00Z' });
   assert.equal(e.response, null);

--- a/tools/publish/test/loadout-function.test.js
+++ b/tools/publish/test/loadout-function.test.js
@@ -9,10 +9,14 @@ before(async () => {
 
 function fakeKV() {
   const store = new Map();
+  const counts = { list: 0, get: 0, put: 0, delete: 0 };
   return {
-    async get(k) { return store.has(k) ? store.get(k) : null; },
-    async put(k, v) { store.set(k, v); },
-    async delete(k) { store.delete(k); },
+    store,
+    counts,
+    async get(k) { counts.get++; return store.has(k) ? store.get(k) : null; },
+    async put(k, v) { counts.put++; store.set(k, v); },
+    async delete(k) { counts.delete++; store.delete(k); },
+    async list() { counts.list++; return { keys: [] }; },
   };
 }
 function putCtx(kv, body) {
@@ -59,4 +63,18 @@ test('PUT rejects an array state', async () => {
 test('GET of an unknown key returns empty object', async () => {
   const res = await fn.onRequestGet(getCtx(fakeKV(), 'loadout:c:p:none'));
   assert.deepEqual(await res.json(), {});
+});
+
+test('PUT registers the member in the campaign roster (no duplicates), never lists', async () => {
+  const kv = fakeKV();
+  const state = { v: 'v1', items: {}, hp: null, fp: null };
+  await fn.onRequestPut(putCtx(kv, { key: 'loadout:c:six:d1', state }));
+  assert.deepEqual(JSON.parse(kv.store.get('roster:c')), ['loadout:c:six:d1']);
+  const putsAfterFirst = kv.counts.put;
+  // A second write from the same member must not grow the roster, but does re-put
+  // it to refresh its TTL (state write + roster-TTL refresh = two puts).
+  await fn.onRequestPut(putCtx(kv, { key: 'loadout:c:six:d1', state }));
+  assert.deepEqual(JSON.parse(kv.store.get('roster:c')), ['loadout:c:six:d1']);
+  assert.equal(kv.counts.put, putsAfterFirst + 2);
+  assert.equal(kv.counts.list, 0);
 });

--- a/tools/publish/test/loadout-list.test.js
+++ b/tools/publish/test/loadout-list.test.js
@@ -8,13 +8,20 @@ before(async () => {
   core = await import('../templates-scaffold/functions/api/loadout-core.mjs');
 });
 
-function fakeKV(entries = {}) {
+// Fake KV that COUNTS every operation. `list` is present so a stray caller would
+// work — but the read path must never touch it, which the tests assert.
+function countingKV(entries = {}) {
   const store = new Map(Object.entries(entries));
+  const counts = { list: 0, get: 0, put: 0, delete: 0 };
   return {
-    async get(k) { return store.has(k) ? store.get(k) : null; },
-    async put(k, v) { store.set(k, v); },
-    async list({ prefix }) {
-      return { keys: [...store.keys()].filter(k => k.startsWith(prefix)).map(name => ({ name })) };
+    counts,
+    _store: store,
+    async get(k) { counts.get++; return store.has(k) ? store.get(k) : null; },
+    async put(k, v) { counts.put++; store.set(k, v); },
+    async delete(k) { counts.delete++; store.delete(k); },
+    async list({ prefix } = {}) {
+      counts.list++;
+      return { keys: [...store.keys()].filter(k => k.startsWith(prefix || '')).map(name => ({ name })) };
     },
   };
 }
@@ -29,36 +36,117 @@ test('isValidCampaign rejects colons and empty', () => {
   assert.equal(core.isValidCampaign('x'.repeat(101)), false);
 });
 
-test('listStates returns only keys under the campaign prefix, parsed', async () => {
-  const kv = fakeKV({
+test('getStates reads the roster index and each member — never lists', async () => {
+  const kv = countingKV({
+    'roster:space-game': JSON.stringify(['loadout:space-game:six:d1', 'loadout:space-game:rock:d9']),
     'loadout:space-game:six:d1': JSON.stringify({ v: 'v1', hp: { cur: 4, max: 13 } }),
     'loadout:space-game:rock:d9': JSON.stringify({ v: 'v1', hp: { cur: 3, max: 10 } }),
     'loadout:other-game:zed:d1': JSON.stringify({ v: 'v1' }),
-    'req:not-a-loadout': 'x',
   });
-  const out = await core.listStates(kv, 'space-game');
+  const out = await core.getStates(kv, 'space-game');
   assert.deepEqual(Object.keys(out).sort(), ['loadout:space-game:rock:d9', 'loadout:space-game:six:d1']);
   assert.equal(out['loadout:space-game:six:d1'].hp.cur, 4);
+  assert.equal(kv.counts.list, 0);   // the whole point of this fix
 });
 
-test('listStates skips unparseable values', async () => {
-  const kv = fakeKV({ 'loadout:c:p:d': '{bad json', 'loadout:c:q:d': JSON.stringify({ v: 'v1' }) });
-  const out = await core.listStates(kv, 'c');
+test('getStates returns {} with no list for an empty/missing roster', async () => {
+  const kv = countingKV();
+  const out = await core.getStates(kv, 'nobody-here');
+  assert.deepEqual(out, {});
+  assert.equal(kv.counts.list, 0);
+  assert.equal(kv.counts.put, 0);   // read path does not write when nothing is stale
+});
+
+test('getStates skips members that resolve to null or unparseable values', async () => {
+  const kv = countingKV({
+    'roster:c': JSON.stringify(['loadout:c:p:d', 'loadout:c:q:d', 'loadout:c:gone:d']),
+    'loadout:c:p:d': '{bad json',
+    'loadout:c:q:d': JSON.stringify({ v: 'v1' }),
+    // loadout:c:gone:d absent → resolves null (e.g. TTL-expired)
+  });
+  const out = await core.getStates(kv, 'c');
   assert.deepEqual(Object.keys(out), ['loadout:c:q:d']);
+  assert.equal(kv.counts.list, 0);
 });
 
-test('GET returns states for a valid campaign', async () => {
-  const kv = fakeKV({ 'loadout:c:p:d': JSON.stringify({ v: 'v1', hp: { cur: 1, max: 9 } }) });
+test('getStates prunes stale keys from the roster with a single put', async () => {
+  const kv = countingKV({
+    'roster:c': JSON.stringify(['loadout:c:live:d', 'loadout:c:gone:d']),
+    'loadout:c:live:d': JSON.stringify({ v: 'v1' }),
+  });
+  await core.getStates(kv, 'c');
+  assert.equal(kv.counts.put, 1);   // roster rewritten once to drop the dead key
+  assert.deepEqual(JSON.parse(kv._store.get('roster:c')), ['loadout:c:live:d']);
+});
+
+test('getStates prune re-reads the roster and preserves a concurrently-added member', async () => {
+  // Simulate a registerMember landing between getStates' first roster read and
+  // its prune write: the pre-prune re-read sees a newer member ('b') that the
+  // prune must not clobber while it drops the dead key ('gone').
+  const store = new Map([
+    ['loadout:c:a:d', JSON.stringify({ v: 'v1' })],
+  ]);
+  let rosterReads = 0;
+  const kv = {
+    counts: { list: 0, get: 0, put: 0 },
+    async get(k) {
+      this.counts.get++;
+      if (k === 'roster:c') {
+        rosterReads++;
+        const keys = rosterReads === 1
+          ? ['loadout:c:a:d', 'loadout:c:gone:d']
+          : ['loadout:c:a:d', 'loadout:c:gone:d', 'loadout:c:b:d']; // 'b' registered concurrently
+        return JSON.stringify(keys);
+      }
+      return store.has(k) ? store.get(k) : null;
+    },
+    async put(k, v) { this.counts.put++; store.set(k, v); },
+    async list() { this.counts.list++; return { keys: [] }; },
+  };
+  await core.getStates(kv, 'c');
+  assert.deepEqual(JSON.parse(store.get('roster:c')).sort(), ['loadout:c:a:d', 'loadout:c:b:d']);
+  assert.equal(kv.counts.list, 0);
+});
+
+test('registerMember appends new keys and refreshes the roster TTL without duplicating', async () => {
+  const kv = countingKV();
+  await core.registerMember(kv, 'loadout:c:six:d1');
+  assert.deepEqual(JSON.parse(kv._store.get('roster:c')), ['loadout:c:six:d1']);
+  const putsAfterFirst = kv.counts.put;
+  // Re-registering an existing member re-puts the roster (to keep its TTL ahead of
+  // the member keys, which refresh on every save) but must NOT grow it.
+  await core.registerMember(kv, 'loadout:c:six:d1');
+  assert.equal(kv.counts.put, putsAfterFirst + 1);   // one TTL-refresh put
+  assert.deepEqual(JSON.parse(kv._store.get('roster:c')), ['loadout:c:six:d1']);   // no duplicate
+  // A different member appends.
+  await core.registerMember(kv, 'loadout:c:rock:d9');
+  assert.deepEqual(JSON.parse(kv._store.get('roster:c')).sort(), ['loadout:c:rock:d9', 'loadout:c:six:d1']);
+  assert.equal(kv.counts.list, 0);
+});
+
+test('registerMember ignores an invalid key without writing', async () => {
+  const kv = countingKV();
+  await core.registerMember(kv, 'req:not-a-loadout');
+  await core.registerMember(kv, 'loadout:');   // no campaign segment
+  assert.equal(kv.counts.put, 0);
+});
+
+test('GET returns states for a valid campaign, no list calls', async () => {
+  const kv = countingKV({
+    'roster:c': JSON.stringify(['loadout:c:p:d']),
+    'loadout:c:p:d': JSON.stringify({ v: 'v1', hp: { cur: 1, max: 9 } }),
+  });
   const res = await fn.onRequestGet(getCtx(kv, 'campaign=c'));
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.states['loadout:c:p:d'].hp.cur, 1);
+  assert.equal(kv.counts.list, 0);
 });
 
 test('GET rejects an invalid/missing campaign with 400', async () => {
-  const res = await fn.onRequestGet(getCtx(fakeKV(), 'campaign=a:b'));
+  const res = await fn.onRequestGet(getCtx(countingKV(), 'campaign=a:b'));
   assert.equal(res.status, 400);
-  const res2 = await fn.onRequestGet(getCtx(fakeKV(), ''));
+  const res2 = await fn.onRequestGet(getCtx(countingKV(), ''));
   assert.equal(res2.status, 400);
 });
 
@@ -66,4 +154,8 @@ test('the Function module exposes no write handler', () => {
   assert.equal(typeof fn.onRequestGet, 'function');
   assert.equal(fn.onRequestPut, undefined);
   assert.equal(fn.onRequestPost, undefined);
+});
+
+test('listStates is gone — no kv.list caller remains in the loadout path', () => {
+  assert.equal(core.listStates, undefined);
 });

--- a/tools/publish/test/loadout-list.test.js
+++ b/tools/publish/test/loadout-list.test.js
@@ -131,6 +131,18 @@ test('registerMember ignores an invalid key without writing', async () => {
   assert.equal(kv.counts.put, 0);
 });
 
+test('overlapping registerMember on one edge keeps both members (read-your-writes)', async () => {
+  // Two co-located players register in quick succession. On a single edge KV is
+  // read-your-writes, so the second read already reflects the first member, and
+  // the union keeps both. (Truly simultaneous cross-edge adds are the documented
+  // KV residual — no CAS is available — and self-heal: a clobbered member is
+  // re-added on their next save, which happens on every board poll/change.)
+  const kv = countingKV({ 'roster:c': JSON.stringify(['loadout:c:rock:d9']) });
+  await core.registerMember(kv, 'loadout:c:six:d1');
+  assert.deepEqual(JSON.parse(kv._store.get('roster:c')).sort(), ['loadout:c:rock:d9', 'loadout:c:six:d1']);
+  assert.equal(kv.counts.list, 0);
+});
+
 test('GET returns states for a valid campaign, no list calls', async () => {
   const kv = countingKV({
     'roster:c': JSON.stringify(['loadout:c:p:d']),


### PR DESCRIPTION
## Problem

The GURPS party board loaded `js/gurps-party.js`, which polled `/api/loadout-list` every 5 seconds. That endpoint ran a `kv.list()` on every poll, and the change-request inbox's `readPending` listed on every poll of the GM loop too. Cloudflare's KV free tier caps list operations at **1,000/day**, so a single open party-board tab drained the day's quota in about **1h23m**, after which the board silently stopped updating until the quota reset at UTC midnight.

## Fix

**Loadout board — zero `kv.list`.** `loadout-core` maintains a per-campaign `roster:<campaignId>` index written on each save (`registerMember`), and `getStates` fans out plain `kv.get()` calls. `listStates` is deleted. The roster's TTL is refreshed on every save so it never expires under an active party; stale device keys are pruned with a re-read-before-write so a concurrent registration is not clobbered.

**Inbox loop — one seed-list ever.** `readPending` reads a single `config:req-index` key and gets each request by id; `enqueue` maintains the index. The index is seeded once from a single `kv.list()` the first time it is missing (the migration bridge for sites upgraded from a pre-index deployment — no in-flight pending request is lost), then never lists again. Concurrent-enqueue and seed writes re-read + union to avoid lost updates; flagged (rejected, no-TTL) entries are dropped from the index so they don't accumulate.

**Adaptive board cadence.** `setInterval(poll, 5000)` is replaced by an injectable `createPoller`: 60s cadence only while active (a state edit advancing `updatedAt`, a keypress/pointer press, or the tab becoming visible), dormant after 15 idle minutes, and never fetching while the tab is hidden.

Migration is self-healing and needs no backfill.

## Deployment note

**Existing deployed sites keep running the old, quota-burning Functions until updated.** They must re-copy `functions/api/loadout-core.mjs`, `functions/api/loadout.js`, `functions/api/loadout-list.js`, `functions/api/inbox-core.mjs`, and `js/gurps-party.js` from the scaffold and redeploy (documented in the Cloudflare Pages guide and CHANGELOG). Closing the party-board tab stops the loadout burn immediately in the meantime.

## Testing

- Full publish suite: **1118 tests pass**; schema validation (41 files) and markdownlint clean.
- Counting fake-KV asserts **zero `kv.list`** on the loadout read path and one-time-only on the inbox path.
- Fake-clock scheduler tests cover the 60s cadence, idle silence, interaction resume, and hidden handling.
- E2E: loadout roster self-heals from empty and the board reads latest state with 0 lists; inbox cold-start recovers pre-existing pending entries and stays at 1 list across many polls.

Versions: plugin `1.8.28`, publish tool `1.11.7`.