### PR TITLE
Unified live-state persistence + CoC investigator live tracking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.28",
+  "version": "1.8.29",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.29] — 2026-07-18
+
+Publish tool 1.11.8.
+
+### Added
+
+- Shared live-state store (`js/live-state.js`) that persists per-device sheet
+  state to Cloudflare KV with a localStorage fallback, behind one opaque-blob
+  interface reused by every system's live client.
+- Call of Cthulhu investigator sheet live tracking: HP/MP pips, SAN/Luck/
+  Reputation steppers, condition chips, and per-skill experience ticks now
+  persist and restore across reloads (`js/coc-live.js`).
+
+### Changed
+
+- Unified live-state persistence across systems: current state now lives in KV,
+  with localStorage and then the vault's authored values as fallbacks, and is no
+  longer discarded on a site rebuild. The GURPS live client and party board were
+  migrated onto the shared store, so a stale-build member now shows current KV
+  values rather than authored defaults.
+
+---
+
 ## [1.8.28] — 2026-07-18
 
 Publish tool 1.11.7.

--- a/tools/publish/js/coc-live.js
+++ b/tools/publish/js/coc-live.js
@@ -1,0 +1,198 @@
+/* CoC investigator live tracking: persist the SP1 status-bar controls (HP/MP
+   pips, SAN/Luck/Reputation steps, condition chips) and per-skill experience
+   ticks to the shared live-state store. Bookkeeping, not a rules engine — the
+   only derived output is two advisory notes. Pure helpers are exported for Node
+   tests; the DOM bootstrap runs only in a browser. Mirrors js/gurps-live.js. */
+(function (root) {
+  'use strict';
+
+  function cocNotes(vals) {
+    var notes = [];
+    var hp = vals && vals.hp, san = vals && vals.san;
+    if (hp && hp.cur != null && hp.cur <= 0) notes.push('0 HP — unconscious / dying (CON roll)');
+    if (san && san.cur === 0) notes.push('Sanity 0 — permanently insane');
+    return notes;
+  }
+
+  function reassocTicks(ticks, skillNames) {
+    var out = {};
+    if (!ticks) return out;
+    var live = {};
+    (skillNames || []).forEach(function (n) { live[n] = true; });
+    Object.keys(ticks).forEach(function (n) { if (ticks[n] && live[n]) out[n] = true; });
+    return out;
+  }
+
+  function clampScalar(n, max) {
+    var x = Math.round(Number(n));
+    if (isNaN(x)) x = 0;
+    if (x < 0) x = 0;
+    if (max != null && x > max) x = max;
+    return x;
+  }
+
+  var api = { cocNotes: cocNotes, reassocTicks: reassocTicks, clampScalar: clampScalar };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  root.__cocLive = api;
+
+  // --- DOM bootstrap (browser only) ---
+  if (typeof document === 'undefined') return;
+
+  // The five chips are authored in CONDITION_CHIPS order (coc/layout.js).
+  var COND_KEYS = ['temporaryInsanity', 'indefiniteInsanity', 'majorWound', 'unconscious', 'dying'];
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var el = document.getElementById('coc-live-data');
+    if (!el || !root.__liveState) return;
+    var data;
+    try { data = JSON.parse(el.textContent); } catch (e) { return; }
+    if (!data || !data.campaignId) return;
+
+    var store = root.__liveState.createStore({ campaignId: data.campaignId, pcSlug: data.pcSlug });
+    var bar = document.querySelector('.statusbar');
+    if (!bar) return;
+
+    function q(sel) { return bar.querySelector(sel); }
+    function pipTrack(track) { return bar.querySelector('.pips[data-track="' + track + '"]'); }
+
+    function readScalar(field) {
+      var b = q('[data-' + field + ']');
+      if (!b) return null;
+      var n = parseInt(b.textContent, 10);
+      return isNaN(n) ? null : n;
+    }
+    function maxFor(field) {
+      var b = q('[data-' + field + ']');
+      var cell = b && b.closest ? b.closest('.sb-num') : null;
+      var m = cell ? parseInt(cell.getAttribute('data-max'), 10) : NaN;
+      return isNaN(m) ? null : m;
+    }
+    function pipCount(track) {
+      var t = pipTrack(track);
+      if (!t) return null;
+      return t.querySelectorAll('.pip.on').length;
+    }
+    function skillButtons() {
+      return Array.prototype.slice.call(document.querySelectorAll('.skill[data-skill] .exp'));
+    }
+    function skillName(btn) {
+      var row = btn.closest('.skill');
+      return row ? row.getAttribute('data-skill') : null;
+    }
+
+    // Gather current DOM -> opaque blob (the store's payload).
+    function readState() {
+      var conditions = {};
+      Array.prototype.forEach.call(bar.querySelectorAll('.cond-chip'), function (chip, i) {
+        if (COND_KEYS[i]) conditions[COND_KEYS[i]] = chip.classList.contains('on');
+      });
+      var ticks = {};
+      skillButtons().forEach(function (btn) {
+        if (btn.getAttribute('aria-pressed') === 'true') { var n = skillName(btn); if (n) ticks[n] = true; }
+      });
+      var blob = {
+        v: data.buildVersion,
+        hp: pipCount('hp'), mp: pipCount('mp'),
+        san: readScalar('san'), luck: readScalar('luck'),
+        conditions: conditions, ticks: ticks,
+      };
+      if (q('[data-rep]')) blob.rep = readScalar('rep');
+      return blob;
+    }
+
+    function setPips(track, n) {
+      var t = pipTrack(track);
+      if (!t || n == null) return;
+      Array.prototype.forEach.call(t.querySelectorAll('.pip'), function (p, i) {
+        var on = i < n;
+        p.classList.toggle('on', on);
+        p.setAttribute('aria-pressed', on ? 'true' : 'false');
+      });
+    }
+    function setScalar(field, val) {
+      var b = q('[data-' + field + ']');
+      if (b && val != null) b.textContent = clampScalar(val, maxFor(field));
+    }
+
+    // Apply an opaque blob -> DOM. Structural-drift safety: ticks apply only to
+    // skills that still exist; scalars clamp to the authored max.
+    function applyState(blob) {
+      if (!blob) return;
+      if (blob.hp != null) setPips('hp', blob.hp);
+      if (blob.mp != null) setPips('mp', blob.mp);
+      setScalar('san', blob.san);
+      setScalar('luck', blob.luck);
+      if (blob.rep != null) setScalar('rep', blob.rep);
+      if (blob.conditions) {
+        Array.prototype.forEach.call(bar.querySelectorAll('.cond-chip'), function (chip, i) {
+          if (COND_KEYS[i]) chip.classList.toggle('on', !!blob.conditions[COND_KEYS[i]]);
+        });
+      }
+      var ticks = reassocTicks(blob.ticks, data.skills || []);
+      skillButtons().forEach(function (btn) {
+        var n = skillName(btn);
+        btn.setAttribute('aria-pressed', n && ticks[n] ? 'true' : 'false');
+      });
+      renderNotes();
+    }
+
+    function defaults() {
+      var conditions = {};
+      COND_KEYS.forEach(function (k) { conditions[k] = !!(data.conditions && data.conditions[k]); });
+      var blob = {
+        v: data.buildVersion,
+        hp: data.hp ? data.hp.cur : null, mp: data.mp ? data.mp.cur : null,
+        san: data.san ? data.san.cur : null, luck: data.luck ? data.luck.cur : null,
+        conditions: conditions, ticks: {},
+      };
+      if (data.rep) blob.rep = data.rep.cur;
+      return blob;
+    }
+
+    function renderNotes() {
+      var host = q('.sb-live-notes');
+      if (!host) {
+        host = document.createElement('p');
+        host.className = 'sb-live-notes';
+        host.hidden = true;
+        bar.appendChild(host);
+      }
+      var notes = cocNotes({ hp: { cur: pipCount('hp') }, san: { cur: readScalar('san') } });
+      host.hidden = notes.length === 0;
+      host.textContent = notes.join('  •  ');
+    }
+
+    function change() { store.save(readState()); renderNotes(); }
+
+    // Wire controls.
+    ['hp', 'mp'].forEach(function (track) {
+      var t = pipTrack(track);
+      if (!t) return;
+      Array.prototype.forEach.call(t.querySelectorAll('.pip'), function (pip, i) {
+        pip.addEventListener('click', function () { setPips(track, i + 1); change(); });
+      });
+    });
+    ['san', 'luck', 'rep'].forEach(function (field) {
+      var b = q('[data-' + field + ']');
+      var cell = b && b.closest ? b.closest('.sb-num') : null;
+      if (!cell) return;
+      var dn = cell.querySelector('.step.dn'), up = cell.querySelector('.step.up');
+      if (dn) dn.addEventListener('click', function () { setScalar(field, (readScalar(field) || 0) - 1); change(); });
+      if (up) up.addEventListener('click', function () { setScalar(field, (readScalar(field) || 0) + 1); change(); });
+    });
+    Array.prototype.forEach.call(bar.querySelectorAll('.cond-chip'), function (chip) {
+      chip.addEventListener('click', function () { chip.classList.toggle('on'); change(); });
+    });
+    skillButtons().forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var on = btn.getAttribute('aria-pressed') !== 'true';
+        btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        change();
+      });
+    });
+
+    // Initial state: localStorage cache -> authored defaults; then late KV wins.
+    applyState(store.readCache() || defaults());
+    store.hydrate(function (state) { applyState(state); });
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tools/publish/js/coc-live.js
+++ b/tools/publish/js/coc-live.js
@@ -31,7 +31,22 @@
     return x;
   }
 
-  var api = { cocNotes: cocNotes, reassocTicks: reassocTicks, clampScalar: clampScalar };
+  // Tapping a pip sets the track to that pip's ordinal (index+1), EXCEPT tapping
+  // the current topmost filled pip drops the track by one — the only gesture that
+  // lets a track fall (down to 0). Mirrors the approved sheet mockup.
+  function pipTarget(filled, clickedIndex) {
+    var target = clickedIndex + 1;
+    return filled === target ? clickedIndex : target;
+  }
+
+  // Sanity-bar fill percentage. 0 when the value or max is missing.
+  function barPct(val, max) {
+    if (val == null || !max) return 0;
+    return Math.round((Number(val) / Number(max)) * 100);
+  }
+
+  var api = { cocNotes: cocNotes, reassocTicks: reassocTicks, clampScalar: clampScalar,
+    pipTarget: pipTarget, barPct: barPct };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   root.__cocLive = api;
 
@@ -108,10 +123,22 @@
         p.classList.toggle('on', on);
         p.setAttribute('aria-pressed', on ? 'true' : 'false');
       });
+      // Keep the prominent numeric readout (<b data-hp>/<b data-mp>) in sync with
+      // the filled pip count — on tap and on restore from cache/KV.
+      var out = q('[data-' + track + ']');
+      if (out) out.textContent = n;
     }
     function setScalar(field, val) {
       var b = q('[data-' + field + ']');
-      if (b && val != null) b.textContent = clampScalar(val, maxFor(field));
+      if (!b || val == null) return;
+      var max = maxFor(field);
+      var v = clampScalar(val, max);
+      b.textContent = v;
+      // Sanity has a progress bar that must track the number (Luck/Rep have none).
+      if (field === 'san') {
+        var fill = bar.querySelector('.sanbar .fill');
+        if (fill) fill.style.width = barPct(v, max) + '%';
+      }
     }
 
     // Apply an opaque blob -> DOM. Structural-drift safety: ticks apply only to
@@ -169,7 +196,7 @@
       var t = pipTrack(track);
       if (!t) return;
       Array.prototype.forEach.call(t.querySelectorAll('.pip'), function (pip, i) {
-        pip.addEventListener('click', function () { setPips(track, i + 1); change(); });
+        pip.addEventListener('click', function () { setPips(track, pipTarget(pipCount(track), i)); change(); });
       });
     });
     ['san', 'luck', 'rep'].forEach(function (field) {

--- a/tools/publish/js/gurps-live.js
+++ b/tools/publish/js/gurps-live.js
@@ -77,7 +77,8 @@
   // falls back to defaults exactly as the per-sheet client does.
   function deriveLive(pc, state) {
     const items = pc.items || [];
-    const fresh = state && state.v === pc.buildVersion;
+    // KV present -> current. Freshness = a usable state blob, not a build match.
+    const fresh = !!(state && typeof state === 'object' && state.items);
     let checked, vitals;
     if (fresh) {
       checked = state.items || {};
@@ -119,55 +120,20 @@
     try { data = JSON.parse(el.textContent); } catch (e) { return; }
     if (!data || !data.levels) return;
 
-    var LOADOUT_KEY = 'loadout:' + data.campaignId + ':' + data.pcSlug;
     var toggles = Array.prototype.slice.call(document.querySelectorAll('.eq-toggle'));
     var panel = document.querySelector('.gl-status-panel');
     var vitalInputs = { hp: document.querySelector('[data-gl-vital="hp"]'), fp: document.querySelector('[data-gl-vital="fp"]') };
-
-    function playerKey() {
-      try {
-        var cr = JSON.parse(localStorage.getItem('cr:code') || 'null');
-        if (cr && cr.code) return cr.code;
-      } catch (e) {}
-      var d = localStorage.getItem('loadout:device');
-      if (!d) { d = 'd' + Date.now().toString(36); localStorage.setItem('loadout:device', d); }
-      return d;
-    }
-    var KV_KEY = LOADOUT_KEY + ':' + playerKey();
-    // Partition the local cache by the same player identity as KV, so two players
-    // sharing one browser (or one player before/after entering a session code)
-    // never read each other's stored loadout.
-    var LS_KEY = KV_KEY;
+    var store = root.__liveState.createStore({ campaignId: data.campaignId, pcSlug: data.pcSlug });
 
     function defaults() {
       var m = {}; (data.items || []).forEach(function (it) { m[it.key] = !!it.defaultCarried; }); return m;
     }
     function readLocal() {
-      try {
-        var s = JSON.parse(localStorage.getItem(LS_KEY) || 'null');
-        if (s && s.v === data.buildVersion && s.items) return s.items;
-      } catch (e) {}
-      return null;
+      var s = store.readCache();
+      return s && s.items ? s.items : null;
     }
-    function writeLocal(checked, vit) {
-      localStorage.setItem(LS_KEY, JSON.stringify({ v: data.buildVersion, items: checked, hp: vit.hp, fp: vit.fp }));
-    }
-    // Coalesce + serialize remote writes: keep only the latest pending state and
-    // send it after the current PUT resolves. Independent per-keystroke fetches
-    // could otherwise reach KV out of order and leave it holding a stale value.
-    var kvInFlight = false, kvPending = null;
-    function syncKV(checked, vit) {
-      kvPending = { v: data.buildVersion, items: checked, hp: vit.hp, fp: vit.fp };
-      if (kvInFlight) return;
-      (function flush() {
-        if (!kvPending) return;
-        var state = kvPending; kvPending = null; kvInFlight = true;
-        var done = function () { kvInFlight = false; flush(); };
-        try {
-          fetch('/api/loadout', { method: 'PUT', headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ key: KV_KEY, state: state }) }).then(done, done);
-        } catch (e) { kvInFlight = false; }
-      })();
+    function persist(checked, vit) {
+      store.save({ v: data.buildVersion, items: checked, hp: vit.hp, fp: vit.fp });
     }
     function currentVitals() {
       var v = data.vitals || null;
@@ -186,7 +152,7 @@
     }
     function setText(id, val) { var n = document.getElementById(id); if (n) n.textContent = val; }
 
-    function recalc(persist) {
+    function recalc(doPersist) {
       var checked = currentChecked();
       var vit = currentVitals();
       var total = api.sumCarriedWeight(data.items, checked);
@@ -214,8 +180,8 @@
         if (pa && w.parry) pa.textContent = w.parry.cur;
       });
       if (panel && vit) renderPanel(api.vitalsView(r, vit));
-      if (persist && vit) { writeLocal(checked, { hp: vit.hp.cur, fp: vit.fp.cur }); syncKV(checked, { hp: vit.hp.cur, fp: vit.fp.cur }); }
-      else if (persist) { writeLocal(checked, { hp: null, fp: null }); syncKV(checked, { hp: null, fp: null }); }
+      if (doPersist && vit) persist(checked, { hp: vit.hp.cur, fp: vit.fp.cur });
+      else if (doPersist) persist(checked, { hp: null, fp: null });
     }
 
     function renderPanel(view) {
@@ -252,37 +218,28 @@
     // Initial state: KV -> localStorage -> defaults.
     var initial = readLocal() || defaults();
     (function seedCachedVitals() {
-      try {
-        var s = JSON.parse(localStorage.getItem(LS_KEY) || 'null');
-        if (s && s.v === data.buildVersion) {
-          if (vitalInputs.hp && s.hp != null) vitalInputs.hp.value = s.hp;
-          if (vitalInputs.fp && s.fp != null) vitalInputs.fp.value = s.fp;
-        }
-      } catch (e) {}
+      var s = store.readCache();
+      if (s) {
+        if (vitalInputs.hp && s.hp != null) vitalInputs.hp.value = s.hp;
+        if (vitalInputs.fp && s.fp != null) vitalInputs.fp.value = s.fp;
+      }
     })();
     applyChecked(initial);
     var readout = document.querySelector('.gl-readout'); if (readout) readout.hidden = false;
     document.documentElement.classList.add('gl-active');
     recalc(false);
-    // Late KV hydration must not clobber a toggle the player made while the GET
-    // was in flight; and remote state we accept should seed the local cache.
-    var locallyChanged = false;
-    try {
-      fetch('/api/loadout?key=' + encodeURIComponent(KV_KEY)).then(function (res) { return res.json(); })
-        .then(function (j) {
-          if (!locallyChanged && j && j.state && j.state.v === data.buildVersion && j.state.items) {
-            applyChecked(j.state.items);
-            if (vitalInputs.hp && j.state.hp != null) vitalInputs.hp.value = j.state.hp;
-            if (vitalInputs.fp && j.state.fp != null) vitalInputs.fp.value = j.state.fp;
-            var vNow = currentVitals();
-            writeLocal(j.state.items, vNow ? { hp: vNow.hp.cur, fp: vNow.fp.cur } : { hp: null, fp: null });
-            recalc(false);
-          }
-        })
-        .catch(function () {});
-    } catch (e) {}
+    // Late KV hydration: the store skips this if the player already changed a
+    // control, and seeds the local cache with any accepted remote state.
+    store.hydrate(function (state) {
+      if (state && state.items) {
+        applyChecked(state.items);
+        if (vitalInputs.hp && state.hp != null) vitalInputs.hp.value = state.hp;
+        if (vitalInputs.fp && state.fp != null) vitalInputs.fp.value = state.fp;
+        recalc(false);
+      }
+    });
 
-    toggles.forEach(function (t) { t.addEventListener('change', function () { locallyChanged = true; recalc(true); }); });
+    toggles.forEach(function (t) { t.addEventListener('change', function () { recalc(true); }); });
     Array.prototype.slice.call(document.querySelectorAll('.gl-step')).forEach(function (btn) {
       btn.addEventListener('click', function () {
         var kind = btn.getAttribute('data-gl-step');
@@ -291,12 +248,12 @@
         if (!input) return;
         var n = parseInt(input.value, 10); if (isNaN(n)) n = 0;
         input.value = n + delta;
-        locallyChanged = true; recalc(true);
+        recalc(true);
       });
     });
     ['hp', 'fp'].forEach(function (kind) {
       var input = vitalInputs[kind];
-      if (input) input.addEventListener('input', function () { locallyChanged = true; recalc(true); });
+      if (input) input.addEventListener('input', function () { recalc(true); });
     });
     var reset = document.getElementById('gl-reset');
     if (reset) reset.addEventListener('click', function () {
@@ -305,8 +262,6 @@
         if (vitalInputs.hp) vitalInputs.hp.value = data.vitals.hp.cur;
         if (vitalInputs.fp) vitalInputs.fp.value = data.vitals.fp.cur;
       }
-      localStorage.removeItem(LS_KEY);
-      locallyChanged = true;
       recalc(true);
     });
   });

--- a/tools/publish/js/live-state.js
+++ b/tools/publish/js/live-state.js
@@ -1,0 +1,90 @@
+/* Shared live-session state store. Identity + persistence + hydration for any
+   system's per-device sheet state. The state blob is OPAQUE here — clients
+   (gurps-live.js, coc-live.js) own its shape and their own DOM wiring/recalc.
+   Persistence rule: KV present -> current; else localStorage; else the client's
+   authored defaults. No buildVersion gate. Pure helpers are exported for Node
+   tests; nothing here touches the DOM. Mirrors the plumbing formerly inline in
+   js/gurps-live.js. */
+(function (root) {
+  'use strict';
+
+  var PREFIX = 'loadout:';
+
+  function playerKey(storage) {
+    try {
+      var cr = JSON.parse(storage.getItem('cr:code') || 'null');
+      if (cr && cr.code) return cr.code;
+    } catch (e) {}
+    var d = storage.getItem('loadout:device');
+    if (!d) { d = 'd' + Date.now().toString(36); storage.setItem('loadout:device', d); }
+    return d;
+  }
+
+  function kvKey(campaignId, pcSlug, player) {
+    return PREFIX + campaignId + ':' + pcSlug + ':' + player;
+  }
+
+  function createStore(opts) {
+    var storage = opts.storage || root.localStorage;
+    var fetchImpl = opts.fetch || (root.fetch ? root.fetch.bind(root) : null);
+    var player = playerKey(storage);
+    var key = kvKey(opts.campaignId, opts.pcSlug, player);
+    var locallyChanged = false;
+    var inFlight = false, pending = null;
+
+    function readCache() {
+      try {
+        var s = JSON.parse(storage.getItem(key) || 'null');
+        return s && typeof s === 'object' ? s : null;
+      } catch (e) { return null; }
+    }
+
+    // Coalesce + serialize remote writes: keep only the latest pending blob and
+    // send it after the current PUT resolves, so out-of-order writes never leave
+    // KV holding a stale value.
+    function syncKV(blob) {
+      pending = blob;
+      if (inFlight || !fetchImpl) return;
+      (function flush() {
+        if (!pending) return;
+        var body = pending; pending = null; inFlight = true;
+        var done = function () { inFlight = false; flush(); };
+        try {
+          fetchImpl('/api/loadout', {
+            method: 'PUT', headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ key: key, state: body }),
+          }).then(done, done);
+        } catch (e) { inFlight = false; }
+      })();
+    }
+
+    function save(blob) {
+      locallyChanged = true;
+      try { storage.setItem(key, JSON.stringify(blob)); } catch (e) {}
+      syncKV(blob);
+    }
+
+    // Late KV read must not clobber a control the player touched while the GET was
+    // in flight (locallyChanged guard). Accepted remote state seeds the cache.
+    function hydrate(onState) {
+      if (!fetchImpl) return;
+      try {
+        fetchImpl('/api/loadout?key=' + encodeURIComponent(key))
+          .then(function (res) { return res.json(); })
+          .then(function (j) {
+            if (!locallyChanged && j && j.state && typeof j.state === 'object') {
+              try { storage.setItem(key, JSON.stringify(j.state)); } catch (e) {}
+              onState(j.state);
+            }
+          })
+          .catch(function () {});
+      } catch (e) {}
+    }
+
+    return { key: key, player: player, readCache: readCache, save: save, hydrate: hydrate };
+  }
+
+  var api = { playerKey: playerKey, kvKey: kvKey, createStore: createStore };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  root.__liveState = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tools/publish/lib/templates/coc/index.js
+++ b/tools/publish/lib/templates/coc/index.js
@@ -1,15 +1,18 @@
 const { parseCoC } = require('./parse');
 const { buildStatusBar, buildSheet, buildRecord, buildEquipment } = require('./layout');
+const { buildCoCLiveData } = require('./live-data');
 
 function renderCoCSheet(frontmatter, sections, meta) {
   const system = (meta && meta.system) || (frontmatter && frontmatter.system) || 'coc-7e';
   const model = parseCoC(frontmatter, sections || [], system);
+  const statusBarHtml = buildStatusBar(model);
   return {
     sheetHtml: buildSheet(model),
     recordHtml: buildRecord(model, sections || []),
     equipmentHtml: buildEquipment(model, sections || []),
-    statusBarHtml: buildStatusBar(model),
-    liveData: null, // SP2
+    statusBarHtml,
+    // No status bar → no mutable vitals → nothing to wire.
+    liveData: statusBarHtml ? buildCoCLiveData(model, meta) : null,
   };
 }
 

--- a/tools/publish/lib/templates/coc/layout.js
+++ b/tools/publish/lib/templates/coc/layout.js
@@ -194,7 +194,8 @@ function buildPortraitRow(backstory) {
 
 function skillRow(s) {
   const dev = s && s.developed ? ' dev' : '';
-  return `<div class="skill${dev}"><button type="button" class="exp" aria-pressed="false" ` +
+  return `<div class="skill${dev}" data-skill="${escapeHtml(String((s && s.name) || ''))}">` +
+    `<button type="button" class="exp" aria-pressed="false" ` +
     `aria-label="Experience check: ${escapeHtml(String((s && s.name) || ''))}"></button>` +
     `<span class="sname">${nameHtml(s.name)}</span>` +
     `<span class="reg">${pad2(s.reg)}</span>` +

--- a/tools/publish/lib/templates/coc/live-data.js
+++ b/tools/publish/lib/templates/coc/live-data.js
@@ -1,0 +1,25 @@
+// tools/publish/lib/templates/coc/live-data.js
+// Build-time: parsed CoC model -> the live-tracking blob consumed by
+// js/coc-live.js. Authored values here are the vault fallback (used only when
+// KV and localStorage are both empty). The mount (pc.js via live-mount.js)
+// decides the script + island id; this module owns only the data.
+function buildCoCLiveData(model, meta) {
+  if (!meta) return null;
+  const d = (model && model.derived) || {};
+  const hp = d.hp || {}, mp = d.mp || {}, san = d.sanity || {}, luck = d.luck || {};
+  const rep = model && model.reputation;
+  return {
+    campaignId: meta.campaignId,
+    pcSlug: meta.pcSlug,
+    buildVersion: meta.buildVersion, // informational; never gates hydration
+    hp: { cur: hp.cur, max: hp.max },
+    mp: { cur: mp.cur, max: mp.max },
+    san: { cur: san.cur, max: san.max, start: san.start },
+    luck: { cur: luck.cur },
+    rep: rep ? { cur: rep.current } : null,
+    conditions: (model && model.conditions) || {},
+    skills: (model && model.skills || []).map((s) => s.name),
+  };
+}
+
+module.exports = { buildCoCLiveData };

--- a/tools/publish/lib/templates/gurps/live-data.js
+++ b/tools/publish/lib/templates/gurps/live-data.js
@@ -149,9 +149,9 @@ function buildLiveData(model, meta) {
   };
 }
 
-function liveDataScript(data) {
+function liveDataScript(data, domId) {
   const json = JSON.stringify(data).replace(/</g, '\\u003c');
-  return `<script type="application/json" id="gurps-live-data">${json}</script>`;
+  return `<script type="application/json" id="${domId}">${json}</script>`;
 }
 
 module.exports = { buildLiveData, liveDataScript, buildVitals };

--- a/tools/publish/lib/templates/live-mount.js
+++ b/tools/publish/lib/templates/live-mount.js
@@ -1,0 +1,24 @@
+// Maps a campaign's system id to its live-tracking client. Single source of
+// truth so pc.js does not hard-code any one system. Keys mirror pc-registry.js.
+const CLIENTS = {
+  'gurps-4e': { script: 'gurps-live.js', domId: 'gurps-live-data' },
+  'gurps': { script: 'gurps-live.js', domId: 'gurps-live-data' },
+  'coc-7e': { script: 'coc-live.js', domId: 'coc-live-data' },
+  'coc': { script: 'coc-live.js', domId: 'coc-live-data' },
+  'regency-cthulhu': { script: 'coc-live.js', domId: 'coc-live-data' },
+};
+
+function clientFor(system) {
+  if (!system) return null;
+  return CLIENTS[String(system).toLowerCase()] || null;
+}
+
+// Ordered <script src> hrefs: the shared store must load before the client that
+// reads window.__liveState. Empty when the system has no live client.
+function liveScriptHrefs(rootHref, system) {
+  const c = clientFor(system);
+  if (!c) return [];
+  return [rootHref + 'js/live-state.js', rootHref + 'js/' + c.script];
+}
+
+module.exports = { clientFor, liveScriptHrefs };

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -4,6 +4,7 @@ const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
 const { excerptFromMarkdown } = require('../excerpt');
 const { liveDataScript } = require('./gurps/live-data');
+const { liveScriptHrefs, clientFor } = require('./live-mount');
 
 const DEFAULT_META_FIELDS = ['occupation', 'age', 'nationality'];
 
@@ -319,7 +320,8 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
 
   let sheetContent;
   if (systemHtml) {
-    const island = systemLiveData ? '\n' + liveDataScript(systemLiveData) : '';
+    const liveClient = systemLiveData ? clientFor(publishConfig.system) : null;
+    const island = liveClient ? '\n' + liveDataScript(systemLiveData, liveClient.domId) : '';
     sheetContent = `${systemHtml}\n${sectionNav}\n${accordions}\n${processedContent.relationships}${island}`;
   } else {
     sheetContent = `${sectionNav}\n${accordions}\n${processedContent.relationships}`;
@@ -428,7 +430,7 @@ ${tabScript()}`;
     scripts: [
       ...clientScripts(page.outputPath),
       rootPath(page.outputPath) + 'js/change-request.js',
-      ...(systemLiveData ? [rootPath(page.outputPath) + 'js/gurps-live.js'] : []),
+      ...liveScriptHrefs(rootPath(page.outputPath), publishConfig.system),
     ],
   });
 }

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -362,6 +362,8 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
     const sealUrl = crestKey
       ? (((portraitImg({ portrait: crestKey }, page.outputPath, imageMap || {}) || '').match(/src="([^"]+)"/) || [])[1] || '')
       : '';
+    const cocLiveClient = systemLiveData ? clientFor(publishConfig.system) : null;
+    const cocIsland = cocLiveClient ? '\n' + liveDataScript(systemLiveData, cocLiveClient.domId) : '';
     const cocBody = buildCocBody({
       page, fm, publishConfig,
       displayTitle: page.displayTitle,
@@ -371,7 +373,7 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
       portraitUrl, sealUrl, crWidget,
       equipmentContent, storyContent, journeyContent,
       leftoverSections: sheetSections,
-    });
+    }) + cocIsland;
     return baseShell({
       title: page.displayTitle,
       siteTitle: config.siteTitle,
@@ -387,6 +389,7 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
         ...clientScripts(page.outputPath),
         rootPath(page.outputPath) + 'js/change-request.js',
         rootPath(page.outputPath) + 'js/coc-sheet.js',
+        ...liveScriptHrefs(rootPath(page.outputPath), publishConfig.system),
       ],
     });
   }

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.7",
+  "version": "1.11.8",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/coc-live-data.test.js
+++ b/tools/publish/test/coc-live-data.test.js
@@ -1,0 +1,51 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { buildCoCLiveData } = require('../lib/templates/coc/live-data');
+
+const META = { campaignId: 'camp', pcSlug: 'ada', buildVersion: 'v1', system: 'coc-7e' };
+
+function model(over = {}) {
+  return Object.assign({
+    derived: {
+      hp: { cur: 9, max: 11 },
+      mp: { cur: 14, max: 14 },
+      sanity: { cur: 55, max: 99, start: 60 },
+      luck: { cur: 48, start: 65 },
+    },
+    reputation: null,
+    conditions: { temporaryInsanity: false, indefiniteInsanity: false, majorWound: false, unconscious: false, dying: false },
+    skills: [{ name: 'Spot Hidden', reg: 45 }, { name: 'Library Use', reg: 60 }],
+  }, over);
+}
+
+test('buildCoCLiveData maps derived vitals, conditions, and skill names', () => {
+  const d = buildCoCLiveData(model(), META);
+  assert.equal(d.campaignId, 'camp');
+  assert.equal(d.pcSlug, 'ada');
+  assert.deepEqual(d.hp, { cur: 9, max: 11 });
+  assert.deepEqual(d.mp, { cur: 14, max: 14 });
+  assert.deepEqual(d.san, { cur: 55, max: 99, start: 60 });
+  assert.deepEqual(d.luck, { cur: 48 });
+  assert.equal(d.rep, null);
+  assert.deepEqual(d.conditions, model().conditions);
+  assert.deepEqual(d.skills, ['Spot Hidden', 'Library Use']);
+});
+
+test('buildCoCLiveData includes rep only when a Reputation track exists', () => {
+  const d = buildCoCLiveData(model({ reputation: { current: 50, start: 50 } }), META);
+  assert.deepEqual(d.rep, { cur: 50 });
+});
+
+test('buildCoCLiveData returns null without meta (no KV key derivable)', () => {
+  assert.equal(buildCoCLiveData(model(), null), null);
+});
+
+const { buildSheet } = require('../lib/templates/coc/layout');
+
+test('skill rows carry a stable data-skill attribute for tick serialization', () => {
+  const html = buildSheet({
+    identity: {}, chars: {}, combat: {}, backstory: [], weapons: [],
+    skills: [{ name: 'Spot Hidden', reg: 45, half: 22, fifth: 9, developed: false }],
+  });
+  assert.match(html, /data-skill="Spot Hidden"/);
+});

--- a/tools/publish/test/coc-live.test.js
+++ b/tools/publish/test/coc-live.test.js
@@ -1,0 +1,25 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const cl = require('../js/coc-live.js');
+
+test('cocNotes flags 0-or-below HP and 0 Sanity, nothing when healthy', () => {
+  assert.deepEqual(cl.cocNotes({ hp: { cur: 9 }, san: { cur: 55 } }), []);
+  assert.deepEqual(cl.cocNotes({ hp: { cur: 0 }, san: { cur: 55 } }), ['0 HP — unconscious / dying (CON roll)']);
+  assert.deepEqual(cl.cocNotes({ hp: { cur: -2 }, san: { cur: 55 } }), ['0 HP — unconscious / dying (CON roll)']);
+  assert.deepEqual(cl.cocNotes({ hp: { cur: 9 }, san: { cur: 0 } }), ['Sanity 0 — permanently insane']);
+});
+
+test('reassocTicks keeps ticks whose skill still exists and drops the rest', () => {
+  const ticks = { 'Spot Hidden': true, 'Obscure Skill': true };
+  assert.deepEqual(cl.reassocTicks(ticks, ['Spot Hidden', 'Library Use']), { 'Spot Hidden': true });
+  assert.deepEqual(cl.reassocTicks({}, ['Spot Hidden']), {});
+  assert.deepEqual(cl.reassocTicks(null, ['Spot Hidden']), {});
+});
+
+test('clampScalar clamps to [0, max] and floors when max is null', () => {
+  assert.equal(cl.clampScalar(5, 10), 5);
+  assert.equal(cl.clampScalar(-3, 10), 0);
+  assert.equal(cl.clampScalar(14, 10), 10);
+  assert.equal(cl.clampScalar(-1, null), 0);
+  assert.equal(cl.clampScalar(7, null), 7);
+});

--- a/tools/publish/test/coc-live.test.js
+++ b/tools/publish/test/coc-live.test.js
@@ -23,3 +23,19 @@ test('clampScalar clamps to [0, max] and floors when max is null', () => {
   assert.equal(cl.clampScalar(-1, null), 0);
   assert.equal(cl.clampScalar(7, null), 7);
 });
+
+test('pipTarget sets to the tapped ordinal, but drops one when tapping the topmost filled pip', () => {
+  assert.equal(cl.pipTarget(3, 5), 6);   // 4 filled shown as 3? tap 6th pip → raise to 6
+  assert.equal(cl.pipTarget(6, 5), 5);   // 6 filled, tap the 6th (topmost) → drop to 5
+  assert.equal(cl.pipTarget(1, 0), 0);   // 1 filled, tap the 1st (topmost) → drop to 0
+  assert.equal(cl.pipTarget(0, 0), 1);   // empty, tap the 1st → raise to 1
+  assert.equal(cl.pipTarget(2, 4), 5);   // tap above the fill → set to that ordinal
+});
+
+test('barPct is value/max as a rounded percent, 0 when value or max is missing', () => {
+  assert.equal(cl.barPct(46, 92), 50);
+  assert.equal(cl.barPct(92, 92), 100);
+  assert.equal(cl.barPct(0, 92), 0);
+  assert.equal(cl.barPct(null, 92), 0);
+  assert.equal(cl.barPct(46, 0), 0);
+});

--- a/tools/publish/test/gurps-party-derive.test.js
+++ b/tools/publish/test/gurps-party-derive.test.js
@@ -68,12 +68,12 @@ test('deriveLive honors 0 HP (not treated as absent by ||)', () => {
   assert.deepEqual(v.hp, { cur: 0, max: 13 });    // 0 honored; || would fall back to authored 13
 });
 
-test('deriveLive ignores stale state (buildVersion mismatch) → authored defaults', () => {
-  const state = { v: 'OLD', items: { Armor: true, Pack: true }, hp: { cur: 1, max: 13 }, fp: { cur: 1, max: 12 } };
+test('deriveLive uses present state regardless of buildVersion (KV = current)', () => {
+  const state = { v: 'OLD', items: { Armor: true, Pack: true }, hp: 1, fp: 1, updatedAt: 100 };
   const v = gl.deriveLive(pc(), state);
-  assert.equal(v.encLevel, 0);            // stale items ignored → defaults (Pack only)
-  assert.equal(v.reeling, false);          // stale hp/fp ignored → healthy
-  assert.deepEqual(v.move, { base: 6, enc: 6, cur: 6 });
+  assert.equal(v.encLevel, 2);             // Armor+Pack = 55 lb → Medium, applied
+  assert.equal(v.reeling, true);           // hp 1 honored → reeling
+  assert.deepEqual(v.hp, { cur: 1, max: 13 });
 });
 
 test('deriveLive on a PC with no vitals returns null vitals and null st', () => {

--- a/tools/publish/test/integration/build-coc.test.js
+++ b/tools/publish/test/integration/build-coc.test.js
@@ -46,6 +46,13 @@ describe('build integration — CoC PC', () => {
     assert.match(html, /class="era">Regency Cthulhu · in the year 1814</);
   });
   it('loads the CoC client script', () => assert.match(html, /js\/coc-sheet\.js/));
+  it('wires live tracking: emits the coc-live-data island and loads live-state + coc-live', () => {
+    assert.match(html, /id="coc-live-data"/);
+    const iLS = html.indexOf('js/live-state.js');
+    const iCL = html.indexOf('js/coc-live.js');
+    assert.ok(iLS > -1 && iCL > -1, 'both live scripts included');
+    assert.ok(iLS < iCL, 'live-state.js loads before coc-live.js');
+  });
   it('routes a non-consumed section (Connections) into the Record instead of dropping it', () => {
     assert.match(html, /<summary>Connections<\/summary>/);
     assert.ok(html.includes('a London bookseller who asks no questions'));

--- a/tools/publish/test/live-data.test.js
+++ b/tools/publish/test/live-data.test.js
@@ -91,8 +91,8 @@ test('returns null when no encumbrance table or no weighted items', () => {
   assert.equal(buildLiveData(m, { campaignId: 'c', pcSlug: 'p', buildVersion: 'v' }), null);
 });
 
-test('liveDataScript embeds JSON under the expected id', () => {
-  const html = liveDataScript({ buildVersion: 'v', items: [] });
+test('liveDataScript embeds JSON under the given id', () => {
+  const html = liveDataScript({ buildVersion: 'v', items: [] }, 'gurps-live-data');
   assert.match(html, /<script type="application\/json" id="gurps-live-data">/);
   assert.match(html, /"buildVersion":"v"/);
 });

--- a/tools/publish/test/live-mount.test.js
+++ b/tools/publish/test/live-mount.test.js
@@ -1,0 +1,24 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const lm = require('../lib/templates/live-mount');
+
+test('clientFor maps GURPS and CoC system ids to their clients', () => {
+  assert.deepEqual(lm.clientFor('gurps-4e'), { script: 'gurps-live.js', domId: 'gurps-live-data' });
+  assert.deepEqual(lm.clientFor('gurps'), { script: 'gurps-live.js', domId: 'gurps-live-data' });
+  assert.deepEqual(lm.clientFor('coc-7e'), { script: 'coc-live.js', domId: 'coc-live-data' });
+  assert.deepEqual(lm.clientFor('regency-cthulhu'), { script: 'coc-live.js', domId: 'coc-live-data' });
+});
+
+test('clientFor is case-insensitive and null for unknown systems', () => {
+  assert.deepEqual(lm.clientFor('CoC-7e'), { script: 'coc-live.js', domId: 'coc-live-data' });
+  assert.equal(lm.clientFor('dnd-5e'), null);
+  assert.equal(lm.clientFor(null), null);
+});
+
+test('liveScriptHrefs orders live-state before the system client', () => {
+  assert.deepEqual(lm.liveScriptHrefs('../', 'coc-7e'), ['../js/live-state.js', '../js/coc-live.js']);
+});
+
+test('liveScriptHrefs is empty for a system without a live client', () => {
+  assert.deepEqual(lm.liveScriptHrefs('../', 'dnd-5e'), []);
+});

--- a/tools/publish/test/live-state.test.js
+++ b/tools/publish/test/live-state.test.js
@@ -1,0 +1,89 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const ls = require('../js/live-state.js');
+
+function fakeStorage(init) {
+  const m = Object.assign({}, init);
+  return {
+    getItem: (k) => (k in m ? m[k] : null),
+    setItem: (k, v) => { m[k] = String(v); },
+    removeItem: (k) => { delete m[k]; },
+    _m: m,
+  };
+}
+
+// A fetch double whose promises resolve only when the test calls .resolve().
+function deferredFetch() {
+  const calls = [];
+  function f(url, opts) {
+    let resolve;
+    const p = new Promise((r) => { resolve = r; });
+    calls.push({ url, opts, resolve: () => resolve({ json: () => Promise.resolve({}) }) });
+    return p;
+  }
+  f.calls = calls;
+  return f;
+}
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test('playerKey prefers the cr:code session code', () => {
+  const s = fakeStorage({ 'cr:code': JSON.stringify({ code: 'ABCD' }) });
+  assert.equal(ls.playerKey(s), 'ABCD');
+});
+
+test('playerKey generates and persists a device id when no code', () => {
+  const s = fakeStorage({});
+  const id = ls.playerKey(s);
+  assert.match(id, /^d[a-z0-9]+$/);
+  assert.equal(ls.playerKey(s), id); // stable across calls
+});
+
+test('kvKey has the loadout:<campaign>:<pc>:<player> shape', () => {
+  assert.equal(ls.kvKey('camp', ' ada-lovelace', 'ABCD'), 'loadout:camp: ada-lovelace:ABCD');
+});
+
+test('save writes localStorage and PUTs {key,state} to /api/loadout', async () => {
+  const s = fakeStorage({ 'loadout:device': 'dX' });
+  const f = deferredFetch();
+  const store = ls.createStore({ campaignId: 'c', pcSlug: 'p', storage: s, fetch: f });
+  store.save({ hp: 3 });
+  assert.deepEqual(JSON.parse(s.getItem(store.key)), { hp: 3 });
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].url, '/api/loadout');
+  assert.equal(f.calls[0].opts.method, 'PUT');
+  assert.deepEqual(JSON.parse(f.calls[0].opts.body), { key: store.key, state: { hp: 3 } });
+});
+
+test('save coalesces: two rapid saves -> one in-flight PUT, then the latest', async () => {
+  const s = fakeStorage({ 'loadout:device': 'dX' });
+  const f = deferredFetch();
+  const store = ls.createStore({ campaignId: 'c', pcSlug: 'p', storage: s, fetch: f });
+  store.save({ hp: 1 });
+  store.save({ hp: 2 }); // coalesced while #1 in flight
+  assert.equal(f.calls.length, 1);
+  f.calls[0].resolve();
+  await tick();
+  assert.equal(f.calls.length, 2);
+  assert.deepEqual(JSON.parse(f.calls[1].opts.body).state, { hp: 2 });
+});
+
+test('hydrate applies remote state when no local change has occurred', async () => {
+  const s = fakeStorage({ 'loadout:device': 'dX' });
+  const f = (url) => Promise.resolve({ json: () => Promise.resolve({ state: { hp: 7 } }) });
+  const store = ls.createStore({ campaignId: 'c', pcSlug: 'p', storage: s, fetch: f });
+  let got = null;
+  store.hydrate((blob) => { got = blob; });
+  await tick(); await tick();
+  assert.deepEqual(got, { hp: 7 });
+});
+
+test('hydrate is skipped once a local save has happened', async () => {
+  const s = fakeStorage({ 'loadout:device': 'dX' });
+  const f = (url) => Promise.resolve({ json: () => Promise.resolve({ state: { hp: 7 } }) });
+  const store2 = ls.createStore({ campaignId: 'c', pcSlug: 'p', storage: s, fetch: f });
+  store2.save({ hp: 1 });             // sets locallyChanged on store2
+  let got = 'untouched';
+  store2.hydrate((blob) => { got = blob; });
+  await tick(); await tick();
+  assert.equal(got, 'untouched');
+});


### PR DESCRIPTION
SP2 of the CoC investigator sheet track. Wires the SP1 status-bar controls to per-device persistence and unifies the live-state model across systems.

## What this does

- **Shared live-state store** (`js/live-state.js`) — one opaque-blob interface owning identity, coalesced KV writes, and hydration. Fallback order is **KV → localStorage → vault**: current state lives in KV, and is no longer discarded on a site rebuild. `buildVersion` no longer gates persistence; structural drift is handled by matching state entries to still-existing skill names / item keys.
- **GURPS migrated onto the store** — `gurps-live.js` drops its `buildVersion` freshness gate (a stale-build party-board member now shows current KV values rather than authored defaults) and reuses the shared plumbing (net −45 lines).
- **System-aware mount** (`lib/templates/live-mount.js`) — a system→client map replaces the hard-coded GURPS wiring in `pc.js`, across both the generic and the CoC folio branches.
- **CoC live client** (`js/coc-live.js` + `coc/live-data.js`) — HP/MP pips, SAN/Luck/Reputation steppers, condition chips, and cross-session skill experience ticks persist and restore. Skill ticks are name-keyed so they survive rebuilds (they feed the end-of-adventure Advancement flow in a later sub-project). Two advisory reminders only (HP ≤ 0, Sanity 0); no rules engine.

## Testing

- Full publish suite green (1142 tests), including new unit coverage for the store, the mount map, the CoC live-data blob, and the CoC client helpers, plus an integration assertion that a built CoC page emits the island and loads both scripts in order.
- Schema validation and markdownlint clean for touched files.
- Verified end-to-end with headless builds of the GURPS and CoC fixtures.

## Notes

- The pip/sanity DOM sync was reconciled against the approved sheet interaction contract (tap-to-drop pips, numeric readout + sanity-bar fill stay in step), with the logic extracted into tested pure helpers.
- The session-end state writeback and the Advancement flow are a separate follow-up sub-project; this PR only makes the state persist and the ticks durable.