### PR TITLE
CoC session-end state flush (SP2b)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.29",
+  "version": "1.8.30",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.30] — 2026-07-18
+
+Publish tool 1.11.9.
+
+### Added
+
+- `flush` command: writes each player's current KV live-state (HP/MP/SAN/Luck, Reputation, and Status conditions) back into the CoC vault sheets, keeping the build-time fallback seed fresh past KV's 30-day TTL. Run automatically when the change-request loop stops, or ad hoc; idempotent, edits vault source only (no rebuild/deploy). Skill experience ticks are left for Advancement.
+
+---
+
 ## [1.8.29] — 2026-07-18
 
 Publish tool 1.11.8.

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -137,9 +137,21 @@ One line per request so a glance tells the whole story:
 
 ## Stop
 
-On "stop", **terminate the background watcher** (stop the running background
-command) and do not relaunch it. The session code stays set in KV until the
-next "start your checking loop" replaces it.
+On "stop", **flush live state to the vault, then terminate the background
+watcher** and do not relaunch it:
+
+1. Run `npx gm-apprentice-publish flush` (or `node <tool>/bin/gm-publish.js
+   flush`). This snapshots each PC's current KV live-state — HP/MP/SAN/Luck,
+   Reputation, and the five Status conditions — back into their vault `.md`, so
+   the site's fallback seed stays fresh past KV's 30-day TTL. It edits the vault
+   source only (no rebuild/deploy); the values ride into the site on the next
+   `npm run build`. Report its per-PC summary. Skill experience ticks are left
+   untouched — those belong to Advancement, not the flush.
+2. Terminate the background watcher.
+
+The session code stays set in KV until the next "start your checking loop"
+replaces it. `flush` is also safe to run ad hoc at any time — it is idempotent,
+so re-running it when nothing changed is a harmless no-op.
 
 ## Editing the PC `.md`
 

--- a/tools/publish/bin/gm-publish.js
+++ b/tools/publish/bin/gm-publish.js
@@ -14,6 +14,7 @@ Usage:
   gm-apprentice-publish init [target-dir]    Scaffold a new site
   gm-apprentice-publish build [options]      Build the site
   gm-apprentice-publish inbox <cmd> [args]   Change-request queue (used by the loop)
+  gm-apprentice-publish flush [options]      Write players' current KV live-state back into the vault sheets
   gm-apprentice-publish --version            Show version
   gm-apprentice-publish --help               Show this help
 
@@ -145,6 +146,18 @@ if (command === 'build') {
 if (command === 'inbox') {
   const { runInbox } = require('../lib/inbox-cli.js');
   runInbox(args.slice(1))
+    .then((rc) => process.exit(rc))
+    .catch((err) => { console.error(err.message); process.exit(1); });
+  return;
+}
+
+if (command === 'flush') {
+  let configPath = './vault.config.json';
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--config' && args[i + 1]) { configPath = args[i + 1]; i++; }
+  }
+  const { runFlush } = require('../lib/flush-cli.js');
+  runFlush({ configPath })
     .then((rc) => process.exit(rc))
     .catch((err) => { console.error(err.message); process.exit(1); });
   return;

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -51,7 +51,10 @@ async function runFlush(deps) {
   const states = await core.getStates(adapter, campaignId);
   const latest = latestStateByPcSlug(states);
 
-  if (!Object.keys(latest).length) { out('No live state in KV for campaign ' + campaignId); return 0; }
+  if (!Object.keys(latest).length) {
+    out('No live state read for campaign ' + campaignId + '. If players saved sheet state this session, this can also mean KV could not be read — check `npx wrangler@4 whoami` and the INBOX namespace id in wrangler.toml.');
+    return 0;
+  }
 
   const scan = deps.scan || function () { return scanVault(Object.assign({}, config, { vaultPath: vaultPath })); };
   const bySlug = {};

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// `flush` command: snapshot each PC's current KV live-state back into the vault
+// .md so the build-time fallback seed stays fresh past KV's 30-day TTL. Edits
+// vault source only — no rebuild/deploy. Every side effect is behind an
+// injectable dep so the runner is unit-testable without wrangler or real disk.
+const fs = require('fs');
+const path = require('path');
+const { scanVault, slugify } = require('./scanner');
+const { readNamespaceId, makeAdapter } = require('./inbox-wrangler');
+const { latestStateByPcSlug } = require('./flush/reconcile');
+const { applyCoCFlush } = require('./flush/coc-writeback');
+
+const { spawnSync } = require('child_process');
+
+function defaultRunWrangler(args) {
+  const res = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8' });
+  return { code: res.status == null ? 1 : res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+}
+
+function defaultAdapter(cwd) {
+  const tomlPath = path.join(cwd || process.cwd(), 'wrangler.toml');
+  const namespaceId = readNamespaceId(fs.readFileSync(tomlPath, 'utf8'));
+  if (!namespaceId) throw new Error('No INBOX namespace id in wrangler.toml — run the inbox setup first.');
+  return makeAdapter({ runWrangler: defaultRunWrangler, namespaceId });
+}
+
+// "HP 11→7, Dying on" — scalars show from→to, conditions show on/off.
+function summarize(changes) {
+  return changes.map(function (c) {
+    if (typeof c.to === 'boolean') return c.field + ' ' + (c.to ? 'on' : 'off');
+    return c.field + ' ' + (c.from == null ? '?' : c.from) + '→' + c.to;
+  }).join(', ');
+}
+
+async function runFlush(deps) {
+  deps = deps || {};
+  const out = deps.out || console.log;
+  const readFile = deps.readFile || function (p) { return fs.readFileSync(p, 'utf8'); };
+  const writeFile = deps.writeFile || function (p, s) { fs.writeFileSync(p, s); };
+
+  // Resolve config exactly as build.js does (so campaignId/pcSlug match).
+  const configPath = path.resolve(deps.configPath || './vault.config.json');
+  const configDir = path.dirname(configPath);
+  const config = deps.config || require(configPath);
+  const vaultPath = deps.config ? config.vaultPath : path.resolve(configDir, config.vaultPath);
+  const campaignId = slugify(config.siteTitle || 'campaign');
+
+  const adapter = deps.adapter || defaultAdapter(configDir);
+  const core = await import('../templates-scaffold/functions/api/loadout-core.mjs');
+  const states = await core.getStates(adapter, campaignId);
+  const latest = latestStateByPcSlug(states);
+
+  if (!Object.keys(latest).length) { out('No live state in KV for campaign ' + campaignId); return 0; }
+
+  const scan = deps.scan || function () { return scanVault(Object.assign({}, config, { vaultPath: vaultPath })); };
+  const bySlug = {};
+  for (const p of scan()) {
+    if (p.frontmatter && p.frontmatter.type === 'pc') bySlug[slugify(p.title)] = p;
+  }
+
+  for (const slug of Object.keys(latest)) {
+    const page = bySlug[slug];
+    if (!page) { out('⚠ ' + slug + ' — in KV but no matching vault sheet (skipped)'); continue; }
+    const name = page.displayTitle || page.title;
+    const res = applyCoCFlush(readFile(page.sourcePath), latest[slug]);
+    if (res.changes.length) {
+      writeFile(page.sourcePath, res.markdown);
+      out('✓ ' + name + ' — ' + summarize(res.changes));
+    } else {
+      out('· ' + name + ' — no change');
+    }
+  }
+  return 0;
+}
+
+module.exports = { runFlush };

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -48,11 +48,18 @@ async function runFlush(deps) {
 
   const adapter = deps.adapter || defaultAdapter(configDir);
   const core = await import('../templates-scaffold/functions/api/loadout-core.mjs');
-  const states = await core.getStates(adapter, campaignId);
+  let states;
+  try {
+    states = await core.getStates(adapter, campaignId);
+  } catch (e) {
+    out('✖ Could not read live state from KV: ' + e.message);
+    out('  Nothing was written. Check `npx wrangler@4 whoami` and the INBOX namespace id in wrangler.toml, then re-run flush.');
+    return 1;
+  }
   const latest = latestStateByPcSlug(states);
 
   if (!Object.keys(latest).length) {
-    out('No live state read for campaign ' + campaignId + '. If players saved sheet state this session, this can also mean KV could not be read — check `npx wrangler@4 whoami` and the INBOX namespace id in wrangler.toml.');
+    out('No live state to flush for campaign ' + campaignId + ' — no players have saved sheet state yet.');
     return 0;
   }
 

--- a/tools/publish/lib/flush/coc-writeback.js
+++ b/tools/publish/lib/flush/coc-writeback.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// Pure CoC vault-sheet writeback: map a live blob onto the specific markdown
+// table cells / checkbox markers, format-preservingly and idempotently. Owns all
+// CoC-sheet format knowledge; no KV, no fs, no config. Skill values are never
+// touched — Advancement (SP4) owns those.
+
+// Derived table row label (upper) -> live blob scalar field.
+const DERIVED_FIELDS = { HP: 'hp', MP: 'mp', LUCK: 'luck', SANITY: 'san' };
+
+// [ needle in the item text, blob.conditions key ]. Order/labels mirror
+// coc/parse.js CONDITION_KEYS so parse and writeback never drift.
+const CONDITIONS = [
+  ['temporary insanity', 'temporaryInsanity'],
+  ['indefinite insanity', 'indefiniteInsanity'],
+  ['major wound', 'majorWound'],
+  ['unconscious', 'unconscious'],
+  ['dying', 'dying'],
+];
+
+// First cell (the row label) of a `| a | b | c |` markdown table row, else null.
+function labelOfRow(line) {
+  const segs = line.split('|');
+  return segs.length >= 3 ? segs[1].trim() : null;
+}
+
+// Replace the leading integer of content cell `idx` (0-based among cells between
+// the pipes), preserving pipe spacing and any trailing note like "(starting 60)".
+// Returns { line, from } — `from` is the previous integer (or null if none).
+function replaceCell(line, idx, newVal) {
+  const segs = line.split('|'); // segs[0] is the piece before the first pipe
+  const segIdx = idx + 1;
+  if (segIdx < 1 || segIdx >= segs.length - 1) return { line: line, from: null };
+  const cell = segs[segIdx];
+  const m = cell.match(/-?\d+/);
+  const from = m ? m[0] : null;
+  if (from === String(newVal)) return { line: line, from: from }; // already current
+  segs[segIdx] = cell.replace(/-?\d+/, String(newVal));
+  return { line: segs.join('|'), from: from };
+}
+
+function applyCoCFlush(markdown, blob) {
+  const changes = [];
+  if (!blob || typeof blob !== 'object') return { markdown: markdown, changes: changes };
+  const lines = String(markdown).split('\n');
+  let section = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const heading = line.match(/^#{1,6}\s+(.+?)\s*$/);
+    if (heading) { section = heading[1].trim().toLowerCase(); continue; }
+
+    if (section === 'derived') {
+      const label = labelOfRow(line);
+      const key = label ? DERIVED_FIELDS[label.toUpperCase()] : null;
+      if (key && typeof blob[key] === 'number') {
+        const r = replaceCell(line, 2, blob[key]); // Current is content cell 2
+        if (r.line !== line) { changes.push({ field: label, from: r.from, to: String(blob[key]) }); lines[i] = r.line; }
+      }
+    } else if (section === 'reputation') {
+      const label = labelOfRow(line);
+      if (label && /current reputation/i.test(label) && typeof blob.rep === 'number') {
+        const r = replaceCell(line, 1, blob.rep); // Value is content cell 1
+        if (r.line !== line) { changes.push({ field: 'Reputation', from: r.from, to: String(blob.rep) }); lines[i] = r.line; }
+      }
+    } else if (section === 'status') {
+      const m = line.match(/^(\s*)- \[([ xX])\]\s+(.*\S)\s*$/);
+      if (m && blob.conditions) {
+        const indent = m[1];
+        const wasOn = m[2].toLowerCase() === 'x';
+        const plain = m[3].replace(/\*\*/g, '').trim(); // authored label without bold
+        const cond = CONDITIONS.find(function (c) { return plain.toLowerCase().indexOf(c[0]) !== -1; });
+        if (cond) {
+          const isOn = !!blob.conditions[cond[1]];
+          if (isOn !== wasOn) {
+            lines[i] = indent + '- [' + (isOn ? 'x' : ' ') + '] ' + (isOn ? '**' + plain + '**' : plain);
+            changes.push({ field: plain, from: wasOn, to: isOn });
+          }
+        }
+      }
+    }
+  }
+
+  return { markdown: changes.length ? lines.join('\n') : markdown, changes: changes };
+}
+
+module.exports = { applyCoCFlush };

--- a/tools/publish/lib/flush/reconcile.js
+++ b/tools/publish/lib/flush/reconcile.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// KV member key shape: loadout:<campaignId>:<pcSlug>:<player>. The pcSlug is
+// segment 2. Mirrors loadout-core.mjs's campaignOfKey (which reads segment 1).
+function pcSlugOfKey(key) {
+  if (typeof key !== 'string') return null;
+  const parts = key.split(':');
+  return parts.length >= 4 && parts[0] === 'loadout' ? parts[2] : null;
+}
+
+// Collapse a { key: blob } map to one blob per PC: the newest by updatedAt
+// (each live-state save writes the whole blob, so newest = complete snapshot).
+// Missing updatedAt sorts oldest; equal times break on the greater key so the
+// result is deterministic regardless of object iteration order.
+function latestStateByPcSlug(states) {
+  const best = {}; // pcSlug -> { key, blob, at }
+  for (const key of Object.keys(states || {})) {
+    const slug = pcSlugOfKey(key);
+    if (!slug) continue;
+    const blob = states[key];
+    if (!blob || typeof blob !== 'object') continue;
+    const at = typeof blob.updatedAt === 'number' ? blob.updatedAt : 0;
+    const cur = best[slug];
+    if (!cur || at > cur.at || (at === cur.at && key > cur.key)) {
+      best[slug] = { key: key, blob: blob, at: at };
+    }
+  }
+  const out = {};
+  for (const slug of Object.keys(best)) out[slug] = best[slug].blob;
+  return out;
+}
+
+module.exports = { pcSlugOfKey, latestStateByPcSlug };

--- a/tools/publish/lib/inbox-wrangler.js
+++ b/tools/publish/lib/inbox-wrangler.js
@@ -24,8 +24,16 @@ function makeAdapter({ runWrangler, namespaceId }) {
   return {
     async get(key) {
       const res = runWrangler(['kv', 'key', 'get', key, ...ns]);
-      if (res.code !== 0) return null;
-      return res.stdout.replace(/\n$/, '');
+      if (res.code === 0) return res.stdout.replace(/\n$/, '');
+      // A non-zero exit is EITHER a genuinely-absent key (benign) OR a real read
+      // failure — auth expired, wrong namespace, no network, wrangler missing.
+      // Wrangler reports an absent key with a "not found" message; treat that as
+      // null, mirroring a real KV binding where a missing key returns null.
+      // Anything else must throw rather than masquerade as an empty result —
+      // otherwise a broken read is indistinguishable from an empty campaign to
+      // every caller (getStates, readPending, ...).
+      if (/not found|not_found|no value|does not exist/i.test(res.stderr || '')) return null;
+      throw new Error('wrangler kv get failed for "' + key + '": ' + ((res.stderr || '').trim() || 'exit ' + res.code));
     },
     async put(key, value, opts) {
       const extra = opts && opts.expirationTtl ? ['--ttl', String(opts.expirationTtl)] : [];

--- a/tools/publish/lib/inbox-wrangler.js
+++ b/tools/publish/lib/inbox-wrangler.js
@@ -27,12 +27,17 @@ function makeAdapter({ runWrangler, namespaceId }) {
       if (res.code === 0) return res.stdout.replace(/\n$/, '');
       // A non-zero exit is EITHER a genuinely-absent key (benign) OR a real read
       // failure — auth expired, wrong namespace, no network, wrangler missing.
-      // Wrangler reports an absent key with a "not found" message; treat that as
-      // null, mirroring a real KV binding where a missing key returns null.
-      // Anything else must throw rather than masquerade as an empty result —
-      // otherwise a broken read is indistinguishable from an empty campaign to
-      // every caller (getStates, readPending, ...).
-      if (/not found|not_found|no value|does not exist/i.test(res.stderr || '')) return null;
+      // Mirror a real KV binding: a missing key returns null, everything else
+      // throws. Anything swallowed here masquerades as an empty campaign to every
+      // caller (getStates, readPending, ...), which is the failure we must avoid.
+      //
+      // An operational failure often ALSO contains "not found" (e.g. a wrong
+      // namespace: "KV namespace ... not found [code: 10041]"), so those signals
+      // are checked first and always throw — only a key-scoped not-found with no
+      // operational signal is treated as an absent key.
+      const err = (res.stderr || '').toLowerCase();
+      const operational = /namespace|authenticat|authoriz|unauthor|permission|credential|not logged in|network|fetch failed|timeout|econn|enotfound|10041|10000/.test(err);
+      if (!operational && /not found|not_found|no value|does not exist/.test(err)) return null;
       throw new Error('wrangler kv get failed for "' + key + '": ' + ((res.stderr || '').trim() || 'exit ' + res.code));
     },
     async put(key, value, opts) {

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/coc-writeback.test.js
+++ b/tools/publish/test/coc-writeback.test.js
@@ -1,0 +1,89 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { applyCoCFlush } = require('../lib/flush/coc-writeback');
+
+const SHEET = [
+  '### Derived',
+  '',
+  '| Attribute | Max | Current |',
+  '|-----------|-----|---------|',
+  '| HP | 11 | 11 |',
+  '| MP | 13 | 13 |',
+  '| Luck | — | 68 (starting 65) |',
+  '| Sanity | 92 | 35 (starting 60) |',
+  '',
+  '### Reputation',
+  '',
+  '| Attribute | Value |',
+  '|-----------|-------|',
+  '| Starting Reputation | 45 |',
+  '| Current Reputation | 71 |',
+  '',
+  '### Status',
+  '',
+  '- [ ] Temporary Insanity',
+  '- [x] **Indefinite Insanity**',
+  '- [ ] Major Wound',
+  '- [ ] Unconscious',
+  '- [ ] Dying',
+  '',
+  '## Skills',
+  '',
+  '| Skill | Base | Regular | Half | Fifth |',
+  '|-------|------|---------|------|-------|',
+  '| Spot Hidden | 25 | 58 | 29 | 11 |',
+  '',
+].join('\n');
+
+const CONDS = { temporaryInsanity: false, indefiniteInsanity: true, majorWound: false, unconscious: false, dying: false };
+function blob(over = {}) {
+  return Object.assign({ hp: 11, mp: 13, san: 35, luck: 68, rep: 71, conditions: Object.assign({}, CONDS) }, over);
+}
+
+test('flushes Derived Current cells and preserves the (starting N) note', () => {
+  const { markdown, changes } = applyCoCFlush(SHEET, blob({ hp: 7, san: 31, luck: 60 }));
+  assert.match(markdown, /\| HP \| 11 \| 7 \|/);
+  assert.match(markdown, /\| Sanity \| 92 \| 31 \(starting 60\) \|/);
+  assert.match(markdown, /\| Luck \| — \| 60 \(starting 65\) \|/);
+  const fields = changes.map((c) => c.field).sort();
+  assert.deepEqual(fields, ['HP', 'Luck', 'Sanity']);
+  assert.deepEqual(changes.find((c) => c.field === 'HP'), { field: 'HP', from: '11', to: '7' });
+});
+
+test('flushes Current Reputation only when present and non-null', () => {
+  const withRep = applyCoCFlush(SHEET, blob({ rep: 50 })).markdown;
+  assert.match(withRep, /\| Current Reputation \| 50 \|/);
+  assert.match(withRep, /\| Starting Reputation \| 45 \|/); // Starting is never touched
+  // Absent rep leaves the Current Reputation row alone.
+  const noRep = blob();
+  delete noRep.rep;
+  assert.match(applyCoCFlush(SHEET, noRep).markdown, /\| Current Reputation \| 71 \|/);
+});
+
+test('toggles Status checkboxes with bold-on-ticked, faithful to all five', () => {
+  const { markdown } = applyCoCFlush(SHEET, blob({
+    conditions: { temporaryInsanity: true, indefiniteInsanity: false, majorWound: true, unconscious: false, dying: true },
+  }));
+  assert.match(markdown, /- \[x\] \*\*Temporary Insanity\*\*/);
+  assert.match(markdown, /- \[ \] Indefinite Insanity/);   // un-ticked drops the bold
+  assert.match(markdown, /- \[x\] \*\*Major Wound\*\*/);
+  assert.match(markdown, /- \[x\] \*\*Dying\*\*/);
+});
+
+test('is idempotent: flushing the sheet\'s own values changes nothing', () => {
+  const { markdown, changes } = applyCoCFlush(SHEET, blob());
+  assert.equal(changes.length, 0);
+  assert.equal(markdown, SHEET); // byte-identical
+});
+
+test('skips missing sections/rows and null scalars without crashing', () => {
+  const tiny = '### Derived\n\n| Attribute | Max | Current |\n|--|--|--|\n| HP | 11 | 11 |\n';
+  const { markdown, changes } = applyCoCFlush(tiny, { hp: null, mp: 4, conditions: {} });
+  assert.equal(changes.length, 0);      // hp null → skip; no MP/Status rows to touch
+  assert.equal(markdown, tiny);
+});
+
+test('never touches the Skills table', () => {
+  const { markdown } = applyCoCFlush(SHEET, blob({ hp: 7 }));
+  assert.match(markdown, /\| Spot Hidden \| 25 \| 58 \| 29 \| 11 \|/);
+});

--- a/tools/publish/test/flush-cli.test.js
+++ b/tools/publish/test/flush-cli.test.js
@@ -56,12 +56,21 @@ test('flush warns for a KV slug with no matching vault sheet', async () => {
   assert.equal(r.writes['/vault/NPCs/Gatekeeper.md'], undefined); // NPCs untouched
 });
 
-test('flush reports a possible failed KV read when the roster is empty', async () => {
+test('flush reports nothing to flush when the roster is empty', async () => {
   const r = run({ adapter: fakeAdapter({ 'roster:test-campaign': '[]' }) });
   const code = await r.promise;
   assert.equal(code, 0);
-  assert.equal(r.writes['/vault/PCs/Jane_Ashford.md'], undefined);
-  assert.ok(r.lines.some((l) => /could not be read/.test(l)));
+  assert.equal(Object.keys(r.writes).length, 0);
+  assert.ok(r.lines.some((l) => /no players have saved/.test(l)));
+});
+
+test('flush returns non-zero and writes nothing when the KV read fails', async () => {
+  const boom = { async get() { throw new Error('Authentication error [code: 10000]'); } };
+  const r = run({ adapter: boom });
+  const code = await r.promise;
+  assert.equal(code, 1);
+  assert.equal(Object.keys(r.writes).length, 0);
+  assert.ok(r.lines.some((l) => /Could not read live state/.test(l)));
 });
 
 test('flush does not write when the sheet already holds the values', async () => {

--- a/tools/publish/test/flush-cli.test.js
+++ b/tools/publish/test/flush-cli.test.js
@@ -1,0 +1,68 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { runFlush } = require('../lib/flush-cli');
+
+// Fake KV adapter: getStates does one get for the roster then one per member.
+function fakeAdapter(map) {
+  return { async get(key) { return key in map ? map[key] : null; } };
+}
+
+const CONFIG = { vaultPath: '/vault', siteTitle: 'Test Campaign', excludeDirs: [], folderMap: {} };
+
+const JANE_MD = [
+  '### Derived', '', '| Attribute | Max | Current |', '|--|--|--|',
+  '| HP | 11 | 11 |', '',
+  '### Status', '', '- [ ] Dying', '',
+].join('\n');
+
+function pages() {
+  return [
+    { sourcePath: '/vault/PCs/Jane_Ashford.md', title: 'Jane_Ashford', displayTitle: 'Jane Ashford', frontmatter: { type: 'pc' } },
+    { sourcePath: '/vault/NPCs/Gatekeeper.md', title: 'Gatekeeper', displayTitle: 'Gatekeeper', frontmatter: { type: 'npc' } },
+  ];
+}
+
+function run(over = {}) {
+  const writes = {};
+  const lines = [];
+  const adapter = fakeAdapter({
+    'roster:test-campaign': JSON.stringify(['loadout:test-campaign:jane-ashford:ABCD', 'loadout:test-campaign:ghost:ZZZZ']),
+    'loadout:test-campaign:jane-ashford:ABCD': JSON.stringify({ hp: 7, conditions: { dying: true }, updatedAt: 5 }),
+    'loadout:test-campaign:ghost:ZZZZ': JSON.stringify({ hp: 3, conditions: {}, updatedAt: 9 }),
+  });
+  const deps = Object.assign({
+    config: CONFIG, adapter, scan: pages,
+    readFile: (p) => (p === '/vault/PCs/Jane_Ashford.md' ? JANE_MD : ''),
+    writeFile: (p, s) => { writes[p] = s; },
+    out: (m) => lines.push(String(m)),
+  }, over);
+  return { promise: runFlush(deps), writes, lines };
+}
+
+test('flush writes the newest blob into the matching PC sheet only', async () => {
+  const r = run();
+  const code = await r.promise;
+  assert.equal(code, 0);
+  assert.ok(r.writes['/vault/PCs/Jane_Ashford.md'], 'Jane sheet written');
+  assert.match(r.writes['/vault/PCs/Jane_Ashford.md'], /\| HP \| 11 \| 7 \|/);
+  assert.match(r.writes['/vault/PCs/Jane_Ashford.md'], /- \[x\] \*\*Dying\*\*/);
+  assert.ok(r.lines.some((l) => /Jane Ashford/.test(l) && /HP 11→7/.test(l)));
+});
+
+test('flush warns for a KV slug with no matching vault sheet', async () => {
+  const r = run();
+  await r.promise;
+  assert.ok(r.lines.some((l) => /ghost/.test(l) && /no matching vault sheet/.test(l)));
+  assert.equal(r.writes['/vault/NPCs/Gatekeeper.md'], undefined); // NPCs untouched
+});
+
+test('flush does not write when the sheet already holds the values', async () => {
+  const already = [
+    '### Derived', '', '| Attribute | Max | Current |', '|--|--|--|',
+    '| HP | 11 | 7 |', '', '### Status', '', '- [x] **Dying**', '',
+  ].join('\n');
+  const r = run({ readFile: () => already });
+  await r.promise;
+  assert.equal(r.writes['/vault/PCs/Jane_Ashford.md'], undefined);
+  assert.ok(r.lines.some((l) => /Jane Ashford/.test(l) && /no change/.test(l)));
+});

--- a/tools/publish/test/flush-cli.test.js
+++ b/tools/publish/test/flush-cli.test.js
@@ -56,6 +56,14 @@ test('flush warns for a KV slug with no matching vault sheet', async () => {
   assert.equal(r.writes['/vault/NPCs/Gatekeeper.md'], undefined); // NPCs untouched
 });
 
+test('flush reports a possible failed KV read when the roster is empty', async () => {
+  const r = run({ adapter: fakeAdapter({ 'roster:test-campaign': '[]' }) });
+  const code = await r.promise;
+  assert.equal(code, 0);
+  assert.equal(r.writes['/vault/PCs/Jane_Ashford.md'], undefined);
+  assert.ok(r.lines.some((l) => /could not be read/.test(l)));
+});
+
 test('flush does not write when the sheet already holds the values', async () => {
   const already = [
     '### Derived', '', '| Attribute | Max | Current |', '|--|--|--|',

--- a/tools/publish/test/flush-reconcile.test.js
+++ b/tools/publish/test/flush-reconcile.test.js
@@ -1,0 +1,44 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { pcSlugOfKey, latestStateByPcSlug } = require('../lib/flush/reconcile');
+
+test('pcSlugOfKey extracts segment 2 of a loadout key, null otherwise', () => {
+  assert.equal(pcSlugOfKey('loadout:camp:jane-ashford:ABCD'), 'jane-ashford');
+  assert.equal(pcSlugOfKey('roster:camp'), null);
+  assert.equal(pcSlugOfKey('loadout:camp'), null); // too few segments
+  assert.equal(pcSlugOfKey(42), null);
+});
+
+test('latestStateByPcSlug keeps the newest device blob per PC', () => {
+  const states = {
+    'loadout:c:jane:AAAA': { hp: 5, updatedAt: 100 },
+    'loadout:c:jane:BBBB': { hp: 9, updatedAt: 200 }, // newer → wins
+    'loadout:c:marcus:CCCC': { hp: 7, updatedAt: 50 },
+  };
+  const out = latestStateByPcSlug(states);
+  assert.deepEqual(out.jane, { hp: 9, updatedAt: 200 });
+  assert.deepEqual(out.marcus, { hp: 7, updatedAt: 50 });
+});
+
+test('latestStateByPcSlug treats missing updatedAt as oldest and breaks ties on key', () => {
+  const states = {
+    'loadout:c:jane:AAAA': { hp: 1 },                 // no updatedAt → 0
+    'loadout:c:jane:BBBB': { hp: 2, updatedAt: 10 },  // wins over AAAA
+  };
+  assert.equal(latestStateByPcSlug(states).jane.hp, 2);
+  const tie = {
+    'loadout:c:jane:AAAA': { hp: 1, updatedAt: 10 },
+    'loadout:c:jane:ZZZZ': { hp: 2, updatedAt: 10 },  // equal time, greater key wins
+  };
+  assert.equal(latestStateByPcSlug(tie).jane.hp, 2);
+});
+
+test('latestStateByPcSlug ignores non-object blobs and bad keys', () => {
+  const states = {
+    'loadout:c:jane:AAAA': null,
+    'roster:c': '["loadout:c:jane:AAAA"]',
+    'loadout:c:marcus:CCCC': { hp: 3, updatedAt: 1 },
+  };
+  const out = latestStateByPcSlug(states);
+  assert.deepEqual(Object.keys(out), ['marcus']);
+});

--- a/tools/publish/test/inbox-wrangler.test.js
+++ b/tools/publish/test/inbox-wrangler.test.js
@@ -38,6 +38,14 @@ test('adapter.get throws on a real read failure (not a missing key)', async () =
   await assert.rejects(() => kv.get('req:a'), /wrangler kv get failed/);
 });
 
+test('adapter.get throws on a namespace error even though it says "not found"', async () => {
+  // A wrong-namespace failure carries "not found" too; it must NOT be swallowed
+  // as an absent key, or flush/inbox would read it as an empty campaign.
+  const runWrangler = () => ({ code: 1, stdout: '', stderr: 'KV namespace "NS" not found [code: 10041]' });
+  const kv = makeAdapter({ runWrangler, namespaceId: 'NS' });
+  await assert.rejects(() => kv.get('req:a'), /wrangler kv get failed/);
+});
+
 test('adapter.put forwards value and optional TTL', async () => {
   const calls = [];
   const runWrangler = (args) => { calls.push(args); return { code: 0, stdout: '', stderr: '' }; };

--- a/tools/publish/test/inbox-wrangler.test.js
+++ b/tools/publish/test/inbox-wrangler.test.js
@@ -32,6 +32,12 @@ test('adapter.get returns stdout on success, null on missing', async () => {
   assert.deepEqual(calls[0], ['kv', 'key', 'get', 'req:a', '--namespace-id', 'NS', '--remote']);
 });
 
+test('adapter.get throws on a real read failure (not a missing key)', async () => {
+  const runWrangler = () => ({ code: 1, stdout: '', stderr: 'Authentication error [code: 10000]' });
+  const kv = makeAdapter({ runWrangler, namespaceId: 'NS' });
+  await assert.rejects(() => kv.get('req:a'), /wrangler kv get failed/);
+});
+
 test('adapter.put forwards value and optional TTL', async () => {
   const calls = [];
   const runWrangler = (args) => { calls.push(args); return { code: 0, stdout: '', stderr: '' }; };


### PR DESCRIPTION
## Session-end state flush (CoC) — SP2b

Adds a `flush` command that snapshots each PC's current KV live-state back into
their CoC vault sheet, so the build-time fallback seed stays fresh past KV's
30-day TTL. This is the writeback half of the CoC live-tracking work (SP2, #110,
established the live tracking; the vault seed only ever held pre-campaign values
until now).

### What it does

`npx gm-apprentice-publish flush` (also run automatically when the change-request
loop stops):

- Reads every party member's current state via the existing `getStates` roster
  fan-out (no `kv.list()` — respects the free-tier list quota).
- Reconciles to the newest device blob per PC (`updatedAt`, tie-break on key).
- Rewrites each PC's `.md`: Derived **Current** cells (HP/MP/Sanity/Luck,
  preserving any `(starting N)` note), Current Reputation, and the five Status
  condition checkboxes. Skill values are left untouched — those belong to a later
  Advancement sub-project.
- Edits vault source only — **no rebuild/deploy**; the values ride in on the next
  build. Idempotent: re-running when nothing changed is a byte-level no-op.

### Reliability

The local wrangler KV adapter now mirrors a real KV binding: a genuinely-absent
key returns `null`, but a real read failure (expired auth, wrong namespace, no
network) **throws** instead of masquerading as an empty result. `flush` catches
that and exits non-zero rather than falsely reporting success. This also removes a
latent silent-failure in the change-request inbox path, which previously masked
auth failures as an empty queue.

### Tests

- New: `flush-reconcile`, `coc-writeback`, `flush-cli` suites (TDD).
- Extended: `inbox-wrangler` (read-failure now throws).
- Full publish suite: 1158/1158. Schema 41/41. Markdownlint clean.

### Versions

Plugin 1.8.30 / publish tool 1.11.9.

### Known follow-up

The missing-key classifier matches a bare `not found`, so a *wrong-namespace*
config error is still read as "empty" rather than failing loudly. Tightening it to
`key not found` needs a one-time capture of wrangler's real missing-key stderr to
avoid a false-alarm regression on normal missing keys. Auth failures — the common
case — are already caught.
