### PR TITLE
Read-only CoC investigator party board

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.30",
+  "version": "1.8.31",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.31] — 2026-07-18
+
+Publish tool 1.11.10.
+
+### Added
+
+- Read-only CoC investigator party board on the roster page: per-PC HP/SAN/MP/Luck, DEX, optional Reputation (Regency), and the five condition badges. Reuses the roster-index/`getStates` fan-out and the 60s adaptive poller (no `kv.list`). The party board is now system-aware via a shared spine (`js/party-core.js`) + per-system skins dispatched by `lib/party-board-registry.js`.
+
+---
+
 ## [1.8.30] — 2026-07-18
 
 Publish tool 1.11.9.

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -3841,3 +3841,16 @@ td.gl-pc a { display: flex; align-items: center; gap: 10px; text-decoration: non
 .gl-delta[hidden],
 .gl-status-note[hidden] { display: none !important; }
 @media (max-width: 640px) { .gl-col-st { display: none; } }
+
+/* --- CoC party board skin (SP3) --- */
+.gl-bar-san > i { background: #9d7bd8; }   /* Sanity — violet */
+.gl-bar-mp  > i { background: #4ba3c7; }   /* Magic points — cyan */
+.gl-dex { color: var(--text-muted); font-weight: 600; }
+.gl-rep { font-weight: 700; }
+.gl-badge.cond-insanity    { color: #b98be0; background: rgba(157,123,216,0.16); }
+.gl-badge.cond-wound       { color: #e06b5c; background: rgba(192,57,43,0.18); }
+.gl-badge.cond-unconscious { color: #d4a017; background: rgba(212,160,23,0.18); }
+.gl-badge.cond-dying       { color: #ff6b6b; background: rgba(192,57,43,0.28); }
+.gl-party-row.mad  { background: linear-gradient(90deg, rgba(157,123,216,0.14), transparent 60%); }
+.gl-party-row.hurt { background: linear-gradient(90deg, rgba(192,57,43,0.15), transparent 60%); }
+.gl-party-row.mad.hurt { background: linear-gradient(90deg, rgba(192,57,43,0.15), rgba(157,123,216,0.14) 70%); }

--- a/tools/publish/js/coc-party.js
+++ b/tools/publish/js/coc-party.js
@@ -1,0 +1,94 @@
+/* CoC party board skin: renders each investigator's read-only row (HP/SAN/MP as
+   bar+number, Luck as a bare number, DEX, optional Rep, condition badges) and
+   paints live updates. Generic spine lives in party-core.js. cocRowCells is
+   exported for Node tests + the server renderer; the DOM bootstrap is browser
+   only. Mirrors js/gurps-party.js. */
+(function (root) {
+  'use strict';
+  var core = (typeof require === 'function' && typeof module !== 'undefined')
+    ? require('./party-core') : (root.__partyCore || {});
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c];
+    });
+  }
+  function bar(kind, cur, max) {
+    var c = (cur == null) ? 0 : cur, m = (max == null) ? 0 : max;
+    var pct = m > 0 ? Math.max(0, Math.min(100, Math.round((c / m) * 100))) : 0;
+    return '<span class="gl-vnum' + (3 * c < m ? ' gl-low' : '') + '">' + esc(c) +
+      '<span class="gl-max">/' + esc(m) + '</span></span>' +
+      '<span class="gl-bar gl-bar-' + kind + '"><i style="width:' + pct + '%"></i><span class="gl-third"></span></span>';
+  }
+
+  // Authored order mirrors CONDITION_CHIPS / COND_KEYS in coc-live.js.
+  var COND = [
+    ['temporaryInsanity', 'cond-insanity', 'Temp. Insanity'],
+    ['indefiniteInsanity', 'cond-insanity', 'Indefinite Insanity'],
+    ['majorWound', 'cond-wound', 'Major Wound'],
+    ['unconscious', 'cond-unconscious', 'Unconscious'],
+    ['dying', 'cond-dying', 'Dying'],
+  ];
+  var MAD = { temporaryInsanity: 1, indefiniteInsanity: 1 };
+  var HURT = { majorWound: 1, unconscious: 1, dying: 1 };
+
+  function statusCell(conditions) {
+    var cond = conditions || {};
+    var badges = COND.filter(function (c) { return cond[c[0]]; })
+      .map(function (c) { return '<span class="gl-badge ' + c[1] + '">' + c[2] + '</span>'; });
+    return badges.length ? badges.join(' ') : '<span class="gl-badge ok">Ready</span>';
+  }
+  function rowClassFor(conditions) {
+    var cond = conditions || {};
+    var mad = Object.keys(MAD).some(function (k) { return cond[k]; });
+    var hurt = Object.keys(HURT).some(function (k) { return cond[k]; });
+    return (mad ? 'mad' : '') + (mad && hurt ? ' ' : '') + (hurt ? 'hurt' : '');
+  }
+
+  // Merge authored-default manifest values (pc) with the flat live blob (state).
+  function cocRowCells(pc, state) {
+    var st = state || {};
+    var hpCur = st.hp != null ? st.hp : (pc.hp ? pc.hp.cur : null);
+    var sanCur = st.san != null ? st.san : (pc.san ? pc.san.cur : null);
+    var mpCur = st.mp != null ? st.mp : (pc.mp ? pc.mp.cur : null);
+    var luck = st.luck != null ? st.luck : pc.luck;
+    var rep = st.rep != null ? st.rep : pc.rep;
+    var conditions = st.conditions || pc.conditions || {};
+    return {
+      rowClass: rowClassFor(conditions),
+      dex: '<span class="gl-dex">' + esc(pc.dex != null ? pc.dex : '—') + '</span>',
+      hp: bar('hp', hpCur, pc.hp ? pc.hp.max : null),
+      san: bar('san', sanCur, pc.san ? pc.san.max : null),
+      mp: bar('mp', mpCur, pc.mp ? pc.mp.max : null),
+      luck: '<span class="gl-vnum' + (luck != null && luck < 15 ? ' gl-low' : '') + '">' + esc(luck != null ? luck : '—') + '</span>',
+      rep: rep != null ? '<span class="gl-rep">' + esc(rep) + '</span>' : '',
+      status: statusCell(conditions),
+      player: pc.player ? esc(pc.player) : '',
+    };
+  }
+
+  var api = { cocRowCells: cocRowCells };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  root.__cocParty = api;
+
+  // --- DOM / poll bootstrap (browser only) ---
+  if (typeof document === 'undefined') return;
+  function setup(manifest) {
+    return function paint(statesByKey) {
+      var latest = core.groupLatestByPc(statesByKey || {});
+      manifest.pcs.forEach(function (pc) {
+        var row = document.querySelector('[data-gl-party="' + pc.pcSlug.replace(/["\\]/g, '\\$&') + '"]');
+        if (!row) return;
+        var cells = cocRowCells(pc, latest[pc.pcSlug] || null);
+        row.className = 'gl-party-row ' + cells.rowClass;
+        ['hp', 'san', 'mp', 'luck', 'rep', 'status'].forEach(function (f) {
+          var cell = row.querySelector('[data-gl-party-field="' + f + '"]');
+          if (cell) cell.innerHTML = cells[f];
+        });
+      });
+      var ind = document.querySelector('.gl-party-live-time');
+      if (ind) ind.textContent = 'updated just now';
+    };
+  }
+  core.mountBoard({ dataElId: 'coc-party-data', setup: setup });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tools/publish/js/gurps-party.js
+++ b/tools/publish/js/gurps-party.js
@@ -1,48 +1,29 @@
-/* GURPS party board: aggregates every PC's live KV state into the read-only
-   initiative table on the roster page. Pure helpers are exported for Node tests;
-   the DOM/poll bootstrap only runs in a browser. Mirrors js/gurps-live.js. */
+/* GURPS party board skin: derives each PC's live view and paints the initiative
+   table. Generic spine lives in party-core.js. Pure helpers are exported for
+   Node tests; the DOM bootstrap only runs in a browser. */
 (function (root) {
   'use strict';
+  var core = (typeof require === 'function' && typeof module !== 'undefined')
+    ? require('./party-core') : (root.__partyCore || {});
 
   function esc(s) {
     return String(s).replace(/[&<>"]/g, function (c) {
       return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c];
     });
   }
-
-  // Pick the freshest state per PC. Key = loadout:<campaign>:<pcSlug>:<player>.
-  function groupLatestByPc(statesByKey) {
-    var best = {}, bestAt = {};
-    Object.keys(statesByKey || {}).forEach(function (key) {
-      var parts = key.split(':');
-      if (parts.length < 4) return;
-      var slug = parts[2];
-      var st = statesByKey[key];
-      var at = (st && typeof st.updatedAt === 'number') ? st.updatedAt : 0;
-      if (!(slug in bestAt) || at >= bestAt[slug]) { best[slug] = st; bestAt[slug] = at; }
-    });
-    return best;
-  }
-
-  // base→cur when a condition changed the value, else a plain number.
   function stat(base, cur) {
     if (base === cur) return esc(cur);
     return '<span class="gl-was">' + esc(base) + '</span>' + esc(cur);
   }
-
-  // current/basic, e.g. "3/6" — always show both so the GM sees how far
-  // encumbrance/conditions have knocked a value down from its unloaded value.
   function ratio(cur, base) {
     if (base == null) return esc(cur);
     return esc(cur) + '<span class="gl-of">/' + esc(base) + '</span>';
   }
-
   function bar(kind, cur, max) {
     var pct = max > 0 ? Math.max(0, Math.min(100, Math.round((cur / max) * 100))) : 0;
     return '<span class="gl-vnum' + (3 * cur < max ? ' gl-low' : '') + '">' + esc(cur) + '<span class="gl-max">/' + esc(max) + '</span></span>' +
       '<span class="gl-bar gl-bar-' + kind + '"><i style="width:' + pct + '%"></i><span class="gl-third"></span></span>';
   }
-
   function rowCells(view) {
     var rowClass = view.reeling && view.tired ? 'both' : view.reeling ? 'reeling' : view.tired ? 'tired' : '';
     var badges = [];
@@ -62,80 +43,22 @@
     };
   }
 
-  // Freshest updatedAt across every state — how the poller detects a live game.
-  function maxUpdatedAt(statesByKey) {
-    var mx = 0;
-    Object.keys(statesByKey || {}).forEach(function (key) {
-      var st = statesByKey[key];
-      var at = (st && typeof st.updatedAt === 'number') ? st.updatedAt : 0;
-      if (at > mx) mx = at;
-    });
-    return mx;
-  }
-
-  // Adaptive poll scheduler. The board used to setInterval(poll, 5000), which
-  // one open tab left running for hours — each poll is a kv.list on the free
-  // tier's 1,000/day cap. Now it polls every 60s only while "active", and goes
-  // silent otherwise. Active = interacted-or-edited within the idle window.
-  // Deps (now/setTimer/clearTimer/isHidden/poll) are injected so it is testable
-  // with a fake clock; the browser bootstrap passes the real ones.
-  //   poll() must return a Promise resolving to the states map (or undefined).
-  function createPoller(opts) {
-    var now = opts.now, setTimer = opts.setTimer, clearTimer = opts.clearTimer;
-    var isHidden = opts.isHidden || function () { return false; };
-    var doPoll = opts.poll;
-    var POLL_MS = opts.pollMs || 60000;
-    var IDLE_MS = opts.idleMs || 15 * 60 * 1000;
-    var lastActivity = now();
-    var lastMax = 0;
-    var timer = null;
-
-    function active() { return (now() - lastActivity) < IDLE_MS; }
-    function clear() { if (timer !== null) { clearTimer(timer); timer = null; } }
-    function schedule() {
-      clear();
-      if (!isHidden() && active()) timer = setTimer(tick, POLL_MS);
-    }
-    function tick() { timer = null; run(); }
-    function run() {
-      if (isHidden()) { clear(); return; }   // dormant while backgrounded
-      return Promise.resolve(doPoll()).then(finish, finish);
-    }
-    function finish(states) {
-      // A newer max updatedAt means a player edited during play → keep polling.
-      if (states && typeof states === 'object') {
-        var mx = maxUpdatedAt(states);
-        if (mx > lastMax) { lastMax = mx; lastActivity = now(); }
-      }
-      schedule();
-    }
-    function interact() {           // visible again / keydown → poll now, resume
-      lastActivity = now();
-      clear();
-      if (!isHidden()) run();
-    }
-    return { start: run, stop: clear, interact: interact, isActive: active };
-  }
-
-  var api = { groupLatestByPc, rowCells, maxUpdatedAt, createPoller };
+  var api = {
+    groupLatestByPc: core.groupLatestByPc,
+    maxUpdatedAt: core.maxUpdatedAt,
+    createPoller: core.createPoller,
+    rowCells: rowCells,
+  };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   root.__gurpsParty = api;
 
   // --- DOM / poll bootstrap (browser only) ---
   if (typeof document === 'undefined') return;
-  document.addEventListener('DOMContentLoaded', function () {
-    var el = document.getElementById('gurps-party-data');
-    if (!el) return;
-    var manifest;
-    try { manifest = JSON.parse(el.textContent); } catch (e) { return; }
-    if (!manifest || !manifest.pcs || !manifest.pcs.length) return;
+  function setup(manifest) {
     var gl = root.__gurpsLive;
-    if (!gl || !gl.deriveLive) return;
-    var bySlug = {};
-    manifest.pcs.forEach(function (pc) { bySlug[pc.pcSlug] = pc; });
-
-    function paint(statesByKey) {
-      var latest = groupLatestByPc(statesByKey || {});
+    if (!gl || !gl.deriveLive) return null;
+    return function paint(statesByKey) {
+      var latest = core.groupLatestByPc(statesByKey || {});
       manifest.pcs.forEach(function (pc) {
         var row = document.querySelector('[data-gl-party="' + pc.pcSlug.replace(/["\\]/g, '\\$&') + '"]');
         if (!row) return;
@@ -148,41 +71,7 @@
       });
       var ind = document.querySelector('.gl-party-live-time');
       if (ind) ind.textContent = 'updated just now';
-    }
-
-    var inFlight = false;
-    // Resolves with the states map (so the scheduler can spot a live game) or
-    // undefined when the poll was skipped/failed — either way it keeps last-good.
-    function poll() {
-      if (document.hidden || inFlight) return Promise.resolve(undefined);
-      inFlight = true;
-      return fetch('/api/loadout-list?campaign=' + encodeURIComponent(manifest.campaignId))
-        .then(function (r) { if (!r.ok) throw new Error('loadout-list ' + r.status); return r.json(); })
-        .then(function (j) {
-          if (!j || !j.states || typeof j.states !== 'object') throw new Error('bad loadout-list payload');
-          paint(j.states);
-          return j.states;
-        })
-        .catch(function () { return undefined; /* keep last-good */ })
-        .then(function (states) { inFlight = false; return states; });
-    }
-
-    var poller = api.createPoller({
-      now: function () { return Date.now(); },
-      setTimer: function (fn, ms) { return setTimeout(fn, ms); },
-      clearTimer: function (id) { clearTimeout(id); },
-      isHidden: function () { return document.hidden; },
-      poll: poll,
-      pollMs: 60000,
-      idleMs: 15 * 60 * 1000,
-    });
-    poller.start();
-    // Becoming visible, a keypress, or a pointer press on the board all count as
-    // activity: poll now and resume the 60s cadence. Hiding lets the next tick
-    // fall dormant. (A visible board with no interaction and no player edits for
-    // 15 min goes silent by design — any of these events revives it.)
-    document.addEventListener('visibilitychange', function () { if (!document.hidden) poller.interact(); });
-    document.addEventListener('keydown', function () { poller.interact(); });
-    document.addEventListener('pointerdown', function () { poller.interact(); });
-  });
+    };
+  }
+  core.mountBoard({ dataElId: 'gurps-party-data', setup: setup });
 })(typeof window !== 'undefined' ? window : this);

--- a/tools/publish/js/party-core.js
+++ b/tools/publish/js/party-core.js
@@ -1,0 +1,114 @@
+/* Shared party-board spine: adaptive poller, freshest-state grouping, and the
+   generic fetch/DOMContentLoaded bootstrap. System skins (gurps-party.js,
+   coc-party.js) supply a per-system paint() via mountBoard. Pure helpers are
+   exported for Node tests; the DOM bootstrap runs only in a browser. */
+(function (root) {
+  'use strict';
+
+  // Freshest state per PC. Key = loadout:<campaign>:<pcSlug>:<player>.
+  function groupLatestByPc(statesByKey) {
+    var best = {}, bestAt = {};
+    Object.keys(statesByKey || {}).forEach(function (key) {
+      var parts = key.split(':');
+      if (parts.length < 4) return;
+      var slug = parts[2];
+      var st = statesByKey[key];
+      var at = (st && typeof st.updatedAt === 'number') ? st.updatedAt : 0;
+      if (!(slug in bestAt) || at >= bestAt[slug]) { best[slug] = st; bestAt[slug] = at; }
+    });
+    return best;
+  }
+
+  // Freshest updatedAt across every state — how the poller detects a live game.
+  function maxUpdatedAt(statesByKey) {
+    var mx = 0;
+    Object.keys(statesByKey || {}).forEach(function (key) {
+      var st = statesByKey[key];
+      var at = (st && typeof st.updatedAt === 'number') ? st.updatedAt : 0;
+      if (at > mx) mx = at;
+    });
+    return mx;
+  }
+
+  // Adaptive poll scheduler: 60s only while active, never while hidden. Deps are
+  // injected so it is testable with a fake clock. poll() resolves to the states
+  // map (or undefined). Ported verbatim from the original gurps-party.js.
+  function createPoller(opts) {
+    var now = opts.now, setTimer = opts.setTimer, clearTimer = opts.clearTimer;
+    var isHidden = opts.isHidden || function () { return false; };
+    var doPoll = opts.poll;
+    var POLL_MS = opts.pollMs || 60000;
+    var IDLE_MS = opts.idleMs || 15 * 60 * 1000;
+    var lastActivity = now();
+    var lastMax = 0;
+    var timer = null;
+
+    function active() { return (now() - lastActivity) < IDLE_MS; }
+    function clear() { if (timer !== null) { clearTimer(timer); timer = null; } }
+    function schedule() {
+      clear();
+      if (!isHidden() && active()) timer = setTimer(tick, POLL_MS);
+    }
+    function tick() { timer = null; run(); }
+    function run() {
+      if (isHidden()) { clear(); return; }
+      return Promise.resolve(doPoll()).then(finish, finish);
+    }
+    function finish(states) {
+      if (states && typeof states === 'object') {
+        var mx = maxUpdatedAt(states);
+        if (mx > lastMax) { lastMax = mx; lastActivity = now(); }
+      }
+      schedule();
+    }
+    function interact() {
+      lastActivity = now();
+      clear();
+      if (!isHidden()) run();
+    }
+    return { start: run, stop: clear, interact: interact, isActive: active };
+  }
+
+  // Generic browser bootstrap. opts.setup(manifest) -> paint(statesByKey).
+  function mountBoard(opts) {
+    if (typeof document === 'undefined') return;
+    document.addEventListener('DOMContentLoaded', function () {
+      var el = document.getElementById(opts.dataElId);
+      if (!el) return;
+      var manifest;
+      try { manifest = JSON.parse(el.textContent); } catch (e) { return; }
+      if (!manifest || !manifest.pcs || !manifest.pcs.length) return;
+      var paint = opts.setup(manifest);
+      if (!paint) return;
+      var inFlight = false;
+      function poll() {
+        if (document.hidden || inFlight) return Promise.resolve(undefined);
+        inFlight = true;
+        return fetch('/api/loadout-list?campaign=' + encodeURIComponent(manifest.campaignId))
+          .then(function (r) { if (!r.ok) throw new Error('loadout-list ' + r.status); return r.json(); })
+          .then(function (j) {
+            if (!j || !j.states || typeof j.states !== 'object') throw new Error('bad loadout-list payload');
+            paint(j.states);
+            return j.states;
+          })
+          .catch(function () { return undefined; })
+          .then(function (states) { inFlight = false; return states; });
+      }
+      var poller = createPoller({
+        now: function () { return Date.now(); },
+        setTimer: function (fn, ms) { return setTimeout(fn, ms); },
+        clearTimer: function (id) { clearTimeout(id); },
+        isHidden: function () { return document.hidden; },
+        poll: poll, pollMs: 60000, idleMs: 15 * 60 * 1000,
+      });
+      poller.start();
+      document.addEventListener('visibilitychange', function () { if (!document.hidden) poller.interact(); });
+      document.addEventListener('keydown', function () { poller.interact(); });
+      document.addEventListener('pointerdown', function () { poller.interact(); });
+    });
+  }
+
+  var api = { groupLatestByPc: groupLatestByPc, maxUpdatedAt: maxUpdatedAt, createPoller: createPoller, mountBoard: mountBoard };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  root.__partyCore = api;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tools/publish/js/party-core.js
+++ b/tools/publish/js/party-core.js
@@ -84,7 +84,11 @@
       function poll() {
         if (document.hidden || inFlight) return Promise.resolve(undefined);
         inFlight = true;
-        return fetch('/api/loadout-list?campaign=' + encodeURIComponent(manifest.campaignId))
+        // Bound the request: a hung connection would otherwise pin inFlight true
+        // forever and silently freeze the board until a full reload.
+        var controller = new AbortController();
+        var timeoutId = setTimeout(function () { controller.abort(); }, 15000);
+        return fetch('/api/loadout-list?campaign=' + encodeURIComponent(manifest.campaignId), { signal: controller.signal })
           .then(function (r) { if (!r.ok) throw new Error('loadout-list ' + r.status); return r.json(); })
           .then(function (j) {
             if (!j || !j.states || typeof j.states !== 'object') throw new Error('bad loadout-list payload');
@@ -92,7 +96,7 @@
             return j.states;
           })
           .catch(function () { return undefined; })
-          .then(function (states) { inFlight = false; return states; });
+          .then(function (states) { clearTimeout(timeoutId); inFlight = false; return states; });
       }
       var poller = createPoller({
         now: function () { return Date.now(); },

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -12,8 +12,8 @@ const { generateThemeCSS, resolveGenrePreset } = require('./theme');
 const { buildStorySpine, unitRefs, characterStoryGroup } = require('./story-spine');
 const { storyPage: renderStoryUnit, characterStoryPage } = require('./templates/story');
 const { storyLanding } = require('./templates/story-landing');
-const { buildPartyManifest, partyDataScript } = require('./party-manifest');
-const { renderPartyBoard } = require('./templates/gurps/party-board');
+const { partyDataScript } = require('./party-manifest');
+const { boardFor } = require('./party-board-registry');
 
 const AUTO_EXCLUDE_STATUS = new Set(['planned', 'prepped']);
 const AUTO_EXCLUDE_STAGE = new Set(['outline', 'draft', 'ready']);
@@ -602,13 +602,16 @@ function build(options = {}) {
   }
 
   if (deferredRosters.length) {
-    const manifest = buildPartyManifest(partyCampaignId, partyEntries);
+    const board = boardFor(publishConfig.system);
+    const manifest = board ? board.buildManifest(partyCampaignId, partyEntries) : null;
     for (const deferredRoster of deferredRosters) {
       try {
-        const boardHtml = manifest ? renderPartyBoard(manifest, deferredRoster.page.outputPath) : null;
-        const islandHtml = manifest ? partyDataScript(manifest) : null;
+        const boardHtml = (board && manifest) ? board.renderBoard(manifest, deferredRoster.page.outputPath) : null;
+        const islandHtml = (board && manifest) ? partyDataScript(manifest, board.scriptId) : null;
         const html = wikiTemplate(deferredRoster.page, deferredRoster.processed, navFor, config, imageMap, {
-          publishConfig, linkMap, pages, partyBoardHtml: boardHtml, partyDataScript: islandHtml,
+          publishConfig, linkMap, pages,
+          partyBoardHtml: boardHtml, partyDataScript: islandHtml,
+          partyClientScripts: boardHtml ? board.clientScripts : [],
         });
         const outPath = path.join(outputDir, deferredRoster.page.outputPath);
         ensureDir(outPath);

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -603,11 +603,22 @@ function build(options = {}) {
 
   if (deferredRosters.length) {
     const board = boardFor(publishConfig.system);
-    const manifest = board ? board.buildManifest(partyCampaignId, partyEntries) : null;
+    // Named partyManifest (not manifest) to avoid shadowing the outer vault
+    // manifest. Guarded like every other render path so a manifest-build failure
+    // does not abort the banners/story/timeline/landing stages that follow.
+    let partyManifest = null;
+    if (board) {
+      try {
+        partyManifest = board.buildManifest(partyCampaignId, partyEntries);
+      } catch (e) {
+        errorCount++;
+        console.error(`  ERROR building party manifest: ${e.message}`);
+      }
+    }
     for (const deferredRoster of deferredRosters) {
       try {
-        const boardHtml = (board && manifest) ? board.renderBoard(manifest, deferredRoster.page.outputPath) : null;
-        const islandHtml = (board && manifest) ? partyDataScript(manifest, board.scriptId) : null;
+        const boardHtml = (board && partyManifest) ? board.renderBoard(partyManifest, deferredRoster.page.outputPath) : null;
+        const islandHtml = (board && partyManifest) ? partyDataScript(partyManifest, board.scriptId) : null;
         const html = wikiTemplate(deferredRoster.page, deferredRoster.processed, navFor, config, imageMap, {
           publishConfig, linkMap, pages,
           partyBoardHtml: boardHtml, partyDataScript: islandHtml,

--- a/tools/publish/lib/party-board-registry.js
+++ b/tools/publish/lib/party-board-registry.js
@@ -1,0 +1,32 @@
+'use strict';
+// Maps a campaign's system id to its party-board skin. Single source of truth so
+// build.js / wiki.js do not hard-code any one system. Keys mirror pc-registry.js
+// and live-mount.js. clientScripts are ORDERED — party-core.js (the shared spine)
+// must load before any system client that reads window.__partyCore.
+const { buildPartyManifest } = require('./party-manifest');
+const { renderPartyBoard } = require('./templates/gurps/party-board');
+const { buildCoCPartyManifest, renderCoCBoard } = require('./templates/coc/party-board');
+
+const GURPS = {
+  buildManifest: buildPartyManifest,
+  renderBoard: renderPartyBoard,
+  scriptId: 'gurps-party-data',
+  clientScripts: ['party-core.js', 'gurps-live.js', 'gurps-party.js'],
+};
+const COC = {
+  buildManifest: buildCoCPartyManifest,
+  renderBoard: renderCoCBoard,
+  scriptId: 'coc-party-data',
+  clientScripts: ['party-core.js', 'coc-party.js'],
+};
+const REGISTRY = {
+  'gurps': GURPS, 'gurps-4e': GURPS,
+  'coc': COC, 'coc-7e': COC, 'regency-cthulhu': COC,
+};
+
+function boardFor(system) {
+  if (!system) return null;
+  return REGISTRY[String(system).toLowerCase()] || null;
+}
+
+module.exports = { boardFor };

--- a/tools/publish/lib/party-manifest.js
+++ b/tools/publish/lib/party-manifest.js
@@ -30,9 +30,10 @@ function buildPartyManifest(campaignId, entries) {
   return { campaignId, pcs };
 }
 
-function partyDataScript(manifest) {
+function partyDataScript(manifest, elId) {
+  const id = elId || 'gurps-party-data';
   const json = JSON.stringify(manifest).replace(/</g, '\\u003c');
-  return `<script type="application/json" id="gurps-party-data">${json}</script>`;
+  return `<script type="application/json" id="${id}">${json}</script>`;
 }
 
 module.exports = { buildPartyManifest, partyDataScript };

--- a/tools/publish/lib/templates/coc/live-data.js
+++ b/tools/publish/lib/templates/coc/live-data.js
@@ -12,6 +12,8 @@ function buildCoCLiveData(model, meta) {
     campaignId: meta.campaignId,
     pcSlug: meta.pcSlug,
     buildVersion: meta.buildVersion, // informational; never gates hydration
+    dex: (model && model.chars && model.chars.DEX && model.chars.DEX.reg != null) ? model.chars.DEX.reg : null,
+    player: (model && model.player) || null,
     hp: { cur: hp.cur, max: hp.max },
     mp: { cur: mp.cur, max: mp.max },
     san: { cur: san.cur, max: san.max, start: san.start },

--- a/tools/publish/lib/templates/coc/parse.js
+++ b/tools/publish/lib/templates/coc/parse.js
@@ -159,6 +159,7 @@ function parseCoC(frontmatter, sections, system) {
       firstAppearance: fm.first_appearance || '', asOf: fm.asOfSession || '',
       era: fm.era || '',
     },
+    player: (fm && fm.player_name) || null,
     chars: parseChars(statHtml),
     derived: parseDerived(statHtml),
     reputation: parseReputation(statHtml),

--- a/tools/publish/lib/templates/coc/party-board.js
+++ b/tools/publish/lib/templates/coc/party-board.js
@@ -1,0 +1,70 @@
+'use strict';
+const { cocRowCells } = require('../../../js/coc-party');
+const { avatarHtml } = require('../party-avatar');
+const { relativeHref, escapeHtml } = require('../../processor');
+
+// Sort: DEX desc, then name asc. Missing DEX sorts last (−Infinity).
+function dexCmp(a, b) {
+  const dx = (x) => (typeof x.dex === 'number' ? x.dex : -Infinity);
+  return dx(b) - dx(a) || String(a.name).localeCompare(String(b.name));
+}
+
+// entries: [{ name, outputPath, portrait, data }] where data is a CoC live blob.
+function buildCoCPartyManifest(campaignId, entries) {
+  const pcs = (entries || [])
+    .filter((e) => e && e.data)
+    .map((e) => ({
+      pcSlug: e.data.pcSlug,
+      name: e.name,
+      outputPath: e.outputPath,
+      portrait: e.portrait != null ? e.portrait : null,
+      player: e.data.player != null ? e.data.player : null,
+      dex: e.data.dex != null ? e.data.dex : null,
+      hp: e.data.hp || null,
+      mp: e.data.mp || null,
+      san: e.data.san || null,
+      luck: e.data.luck ? e.data.luck.cur : null,
+      rep: e.data.rep ? e.data.rep.cur : null,
+      conditions: e.data.conditions || {},
+    }))
+    .sort(dexCmp);
+  if (!pcs.length) return null;
+  return { campaignId, pcs };
+}
+
+function renderCoCBoard(manifest, rosterOutputPath) {
+  if (!manifest || !manifest.pcs || !manifest.pcs.length) return null;
+  const showRep = manifest.pcs.some((pc) => pc.rep != null);
+  const rows = manifest.pcs.map((pc) => {
+    const c = cocRowCells(pc, null);   // authored-default initial render
+    const href = relativeHref(rosterOutputPath, pc.outputPath);
+    const repTd = showRep ? `\n  <td data-gl-party-field="rep">${c.rep}</td>` : '';
+    return `<tr class="gl-party-row ${c.rowClass}" data-gl-party="${escapeHtml(pc.pcSlug)}">
+  <td class="gl-pc"><a href="${escapeHtml(href)}">${avatarHtml(pc, rosterOutputPath)}<span class="gl-pc-txt"><span class="gl-pc-name">${escapeHtml(pc.name)}</span><span class="gl-pc-sub">${c.player}</span></span></a></td>
+  <td data-gl-party-field="dex">${c.dex}</td>
+  <td class="gl-vital" data-gl-party-field="hp">${c.hp}</td>
+  <td class="gl-vital" data-gl-party-field="san">${c.san}</td>
+  <td class="gl-vital" data-gl-party-field="mp">${c.mp}</td>
+  <td data-gl-party-field="luck">${c.luck}</td>${repTd}
+  <td data-gl-party-field="status">${c.status}</td>
+</tr>`;
+  }).join('\n');
+
+  const repTh = showRep ? '<th>Rep</th>' : '';
+  return `<section class="gl-party" aria-label="Live party status">
+  <div class="gl-party-head">
+    <h2>Party Status</h2>
+    <span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>
+  </div>
+  <div class="gl-party-scroll">
+  <table class="gl-party-table">
+    <thead><tr><th class="gl-pc">Investigator</th><th>DEX</th><th>HP</th><th>SAN</th><th>MP</th><th>Luck</th>${repTh}<th>Status</th></tr></thead>
+    <tbody>
+${rows}
+    </tbody>
+  </table>
+  </div>
+</section>`;
+}
+
+module.exports = { buildCoCPartyManifest, renderCoCBoard };

--- a/tools/publish/lib/templates/gurps/party-board.js
+++ b/tools/publish/lib/templates/gurps/party-board.js
@@ -1,17 +1,8 @@
 'use strict';
 const { deriveLive } = require('../../../js/gurps-live');
 const { rowCells } = require('../../../js/gurps-party');
-const { getInitials } = require('../landing-data');
-const { relativeHref, escapeHtml, encodeImageUrl } = require('../../processor');
-
-// Circular avatar: portrait thumbnail when the PC has one, initials otherwise.
-function avatarHtml(pc, rosterOutputPath) {
-  if (pc.portrait) {
-    const src = encodeImageUrl(relativeHref(rosterOutputPath, pc.portrait));
-    return `<span class="gl-av gl-av-img"><img src="${escapeHtml(src)}" alt="" loading="lazy"></span>`;
-  }
-  return `<span class="gl-av">${escapeHtml(getInitials(pc.name))}</span>`;
-}
+const { relativeHref, escapeHtml } = require('../../processor');
+const { avatarHtml } = require('../party-avatar');
 
 function renderPartyBoard(manifest, rosterOutputPath) {
   if (!manifest || !manifest.pcs || !manifest.pcs.length) return null;

--- a/tools/publish/lib/templates/party-avatar.js
+++ b/tools/publish/lib/templates/party-avatar.js
@@ -1,0 +1,15 @@
+'use strict';
+const { getInitials } = require('./landing-data');
+const { relativeHref, escapeHtml, encodeImageUrl } = require('../processor');
+
+// Circular avatar: portrait thumbnail when the PC has one, initials otherwise.
+// Shared by every system's party board.
+function avatarHtml(pc, rosterOutputPath) {
+  if (pc.portrait) {
+    const src = encodeImageUrl(relativeHref(rosterOutputPath, pc.portrait));
+    return `<span class="gl-av gl-av-img"><img src="${escapeHtml(src)}" alt="" loading="lazy"></span>`;
+  }
+  return `<span class="gl-av">${escapeHtml(getInitials(pc.name))}</span>`;
+}
+
+module.exports = { avatarHtml };

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -12,6 +12,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
   const extraSidebar = (context || {}).extraSidebar || {};
   const partyBoardHtml = (context || {}).partyBoardHtml || null;
   const partyDataScript = (context || {}).partyDataScript || null;
+  const partyClientScripts = (context || {}).partyClientScripts || [];
   const badges = metadataBadgesFor(fm);
   const portrait = portraitImg(fm, page.outputPath, imageMap || {});
 
@@ -106,7 +107,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
     breadcrumbsHtml,
     scripts: [
       ...clientScripts(page.outputPath),
-      ...(partyBoardHtml ? [rootPath(page.outputPath) + 'js/gurps-live.js', rootPath(page.outputPath) + 'js/gurps-party.js'] : []),
+      ...(partyBoardHtml ? partyClientScripts.map(s => rootPath(page.outputPath) + 'js/' + s) : []),
     ],
   });
 }

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/build-party-board.test.js
+++ b/tools/publish/test/build-party-board.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert');
 const { wikiTemplate } = require('../lib/templates/index');
 const { buildPartyManifest, partyDataScript } = require('../lib/party-manifest');
 const { renderPartyBoard } = require('../lib/templates/gurps/party-board');
+const { boardFor } = require('../lib/party-board-registry');
 
 function pcEntry(name, slug, bs, dx) {
   return { name, outputPath: 'characters/pcs/' + slug + '.html', data: {
@@ -25,6 +26,7 @@ test('wikiTemplate injects the board, island, and live scripts when context carr
     publishConfig: { system: 'gurps' }, linkMap: {}, pages: [],
     partyBoardHtml: renderPartyBoard(manifest, page.outputPath),
     partyDataScript: partyDataScript(manifest),
+    partyClientScripts: ['party-core.js', 'gurps-live.js', 'gurps-party.js'],
   });
   assert.match(html, /class="gl-party"/);
   assert.match(html, /id="gurps-party-data"/);
@@ -40,4 +42,27 @@ test('wikiTemplate without party context renders no board or live scripts', () =
   const html = wikiTemplate(page, processed, () => '<nav></nav>', { siteTitle: 'X' }, {}, { publishConfig: {}, linkMap: {}, pages: [] });
   assert.doesNotMatch(html, /gurps-party-data/);
   assert.doesNotMatch(html, /js\/gurps-party\.js/);
+});
+
+test('CoC roster injects the coc board, coc-party-data island, and ordered scripts', () => {
+  const board = boardFor('coc-7e');
+  const entries = [{ name: 'Emma Wentworth', outputPath: 'characters/pcs/emma-wentworth.html', portrait: null, data: {
+    pcSlug: 'emma-wentworth', dex: 70, player: 'Missy', hp: { cur: 10, max: 10 }, san: { cur: 35, max: 92 },
+    mp: { cur: 12, max: 12 }, luck: { cur: 80 }, rep: { cur: 71 }, conditions: { indefiniteInsanity: true } } }];
+  const manifest = board.buildManifest('canticle', entries);
+  const page = { title: 'Player Characters', displayTitle: 'Player Characters',
+    outputPath: 'player-characters.html', frontmatter: { type: 'pc_roster' } };
+  const processed = { html: '<p>Active investigators.</p>', metadata: {}, warnings: [] };
+  const html = wikiTemplate(page, processed, () => '<nav></nav>', { siteTitle: 'Canticle' }, {}, {
+    publishConfig: { system: 'coc-7e' }, linkMap: {}, pages: [],
+    partyBoardHtml: board.renderBoard(manifest, page.outputPath),
+    partyDataScript: require('../lib/party-manifest').partyDataScript(manifest, board.scriptId),
+    partyClientScripts: board.clientScripts,
+  });
+  assert.match(html, /class="gl-party"/);
+  assert.match(html, /id="coc-party-data"/);
+  assert.match(html, /js\/party-core\.js/);
+  assert.match(html, /js\/coc-party\.js/);
+  assert.doesNotMatch(html, /js\/gurps-party\.js/);
+  assert.match(html, /Active investigators/);
 });

--- a/tools/publish/test/coc-live-data.test.js
+++ b/tools/publish/test/coc-live-data.test.js
@@ -49,3 +49,25 @@ test('skill rows carry a stable data-skill attribute for tick serialization', ()
   });
   assert.match(html, /data-skill="Spot Hidden"/);
 });
+
+test('buildCoCLiveData carries dex and player from the model', () => {
+  const model = {
+    derived: { hp: { cur: 10, max: 10 }, mp: { cur: 12, max: 12 }, sanity: { cur: 35, max: 92, start: 60 }, luck: { cur: 80 } },
+    chars: { DEX: { reg: 70 } },
+    player: 'Missy',
+    reputation: { current: 71 },
+    conditions: { indefiniteInsanity: true },
+    skills: [{ name: 'Spot Hidden' }],
+  };
+  const blob = buildCoCLiveData(model, { campaignId: 'canticle', pcSlug: 'emma-wentworth', buildVersion: 'v1' });
+  assert.equal(blob.dex, 70);
+  assert.equal(blob.player, 'Missy');
+  assert.equal(blob.rep.cur, 71);
+  assert.equal(blob.conditions.indefiniteInsanity, true);
+});
+
+test('buildCoCLiveData null-safes a missing DEX / player', () => {
+  const blob = buildCoCLiveData({ derived: {} }, { campaignId: 'c', pcSlug: 's', buildVersion: 'v' });
+  assert.equal(blob.dex, null);
+  assert.equal(blob.player, null);
+});

--- a/tools/publish/test/coc-party-board.test.js
+++ b/tools/publish/test/coc-party-board.test.js
@@ -1,0 +1,60 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { buildCoCPartyManifest, renderCoCBoard } = require('../lib/templates/coc/party-board');
+
+// Golden fixture — Canticle Chapter 4 (see the design spec appendix).
+function entry(name, slug, dex, player, hp, san, mp, luck, rep, conditions) {
+  return { name, outputPath: 'characters/pcs/' + slug + '.html', portrait: null, data: {
+    pcSlug: slug, dex, player,
+    hp: { cur: hp[0], max: hp[1] }, san: { cur: san[0], max: san[1] }, mp: { cur: mp[0], max: mp[1] },
+    luck: { cur: luck }, rep: rep == null ? null : { cur: rep }, conditions: conditions || {},
+  } };
+}
+const CANTICLE = [
+  entry('Freddy Cavendish', 'freddy-cavendish', 60, 'Jay', [10, 10], [50, 99], [10, 10], 55, 50),
+  entry('Nathaniel Holt', 'nathaniel-holt', 70, 'Phil', [11, 11], [50, 50], [10, 10], 55, 22),
+  entry('Emma Wentworth', 'emma-wentworth', 70, 'Missy', [10, 10], [35, 92], [12, 12], 80, 71, { indefiniteInsanity: true }),
+  entry('Katherine Ward', 'katherine-ward', 60, 'Juel', [10, 10], [70, 99], [14, 14], 60, 42),
+  entry('Adrien de Montferrand', 'adrien-de-montferrand', 55, 'Anna', [12, 12], [60, 60], [12, 12], 80, 56),
+  entry('Georgiana Wentworth', 'georgiana-wentworth', 50, 'Beth', [11, 11], [65, 65], [16, 16], 78, 45),
+];
+
+test('buildCoCPartyManifest sorts DEX desc, name asc tiebreak', () => {
+  const m = buildCoCPartyManifest('canticle', CANTICLE);
+  assert.deepEqual(m.pcs.map((p) => p.name), [
+    'Emma Wentworth', 'Nathaniel Holt', 'Freddy Cavendish', 'Katherine Ward',
+    'Adrien de Montferrand', 'Georgiana Wentworth',
+  ]);
+  assert.equal(m.pcs[0].dex, 70);
+  assert.equal(m.pcs[0].player, 'Missy');
+});
+
+test('buildCoCPartyManifest returns null for no entries', () => {
+  assert.equal(buildCoCPartyManifest('c', []), null);
+  assert.equal(buildCoCPartyManifest('c', [{ name: 'x', data: null }]), null);
+});
+
+test('renderCoCBoard emits the columns, the DEX-70 leader, and the insanity badge', () => {
+  const html = renderCoCBoard(buildCoCPartyManifest('canticle', CANTICLE), 'player-characters.html');
+  assert.match(html, /class="gl-party"/);
+  assert.match(html, /<th>DEX<\/th><th>HP<\/th><th>SAN<\/th><th>MP<\/th><th>Luck<\/th>/);
+  assert.match(html, /<th>Rep<\/th>/);                       // Regency has rep
+  assert.match(html, /data-gl-party="emma-wentworth"/);
+  assert.match(html, /gl-party-row mad/);
+  assert.match(html, /cond-insanity">Indefinite Insanity/);
+  assert.match(html, /data-gl-party-field="san"/);
+  assert.match(html, /Missy/);                               // player sub-line
+  // Emma (DEX 70) renders before Georgiana (DEX 50)
+  assert.ok(html.indexOf('emma-wentworth') < html.indexOf('georgiana-wentworth'));
+});
+
+test('renderCoCBoard omits the Rep column when no PC has reputation', () => {
+  const noRep = CANTICLE.map((e) => ({ ...e, data: { ...e.data, rep: null } }));
+  const html = renderCoCBoard(buildCoCPartyManifest('c', noRep), 'player-characters.html');
+  assert.doesNotMatch(html, /<th>Rep<\/th>/);
+  assert.doesNotMatch(html, /data-gl-party-field="rep"/);
+});
+
+test('renderCoCBoard returns null for a null manifest', () => {
+  assert.equal(renderCoCBoard(null, 'x.html'), null);
+});

--- a/tools/publish/test/coc-party.test.js
+++ b/tools/publish/test/coc-party.test.js
@@ -1,0 +1,52 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const cp = require('../js/coc-party.js');
+
+const emma = {
+  pcSlug: 'emma-wentworth', name: 'Emma Wentworth', player: 'Missy', dex: 70,
+  hp: { cur: 10, max: 10 }, mp: { cur: 12, max: 12 }, san: { cur: 35, max: 92 },
+  luck: 80, rep: 71, conditions: { indefiniteInsanity: true },
+};
+
+test('cocRowCells: authored defaults when state is null', () => {
+  const c = cp.cocRowCells(emma, null);
+  assert.match(c.hp, /width:100%/);
+  assert.match(c.san, /35<span class="gl-max">\/92<\/span>/);
+  assert.match(c.san, /gl-bar-san/);
+  assert.match(c.san, /width:38%/);      // round(35/92*100)
+  assert.equal(c.dex, '<span class="gl-dex">70</span>');
+  assert.equal(c.rep, '<span class="gl-rep">71</span>');
+  assert.equal(c.player, 'Missy');
+});
+
+test('cocRowCells: indefinite insanity -> mad row + insanity badge', () => {
+  const c = cp.cocRowCells(emma, null);
+  assert.equal(c.rowClass, 'mad');
+  assert.match(c.status, /cond-insanity/);
+  assert.match(c.status, /Indefinite Insanity/);
+});
+
+test('cocRowCells: no conditions -> Ready badge, empty rowClass', () => {
+  const c = cp.cocRowCells({ ...emma, conditions: {} }, null);
+  assert.equal(c.rowClass, '');
+  assert.match(c.status, /gl-badge ok">Ready/);
+});
+
+test('cocRowCells: wound conditions -> hurt row + badges', () => {
+  const c = cp.cocRowCells({ ...emma, conditions: { majorWound: true, dying: true } }, null);
+  assert.equal(c.rowClass, 'hurt');
+  assert.match(c.status, /cond-wound">Major Wound/);
+  assert.match(c.status, /cond-dying">Dying/);
+});
+
+test('cocRowCells: live state overrides authored values', () => {
+  const c = cp.cocRowCells(emma, { hp: 3, san: 10, mp: 1, luck: 12, conditions: {} });
+  assert.match(c.hp, /3<span class="gl-max">\/10<\/span>/);
+  assert.match(c.hp, /gl-low/);          // 3*3 < 10
+  assert.match(c.luck, /gl-low">12/);    // luck < 15 dims
+});
+
+test('cocRowCells: mad+hurt combine', () => {
+  const c = cp.cocRowCells({ ...emma, conditions: { temporaryInsanity: true, unconscious: true } }, null);
+  assert.equal(c.rowClass, 'mad hurt');
+});

--- a/tools/publish/test/party-board-registry.test.js
+++ b/tools/publish/test/party-board-registry.test.js
@@ -1,0 +1,29 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { boardFor } = require('../lib/party-board-registry');
+const { buildPartyManifest } = require('../lib/party-manifest');
+const { buildCoCPartyManifest } = require('../lib/templates/coc/party-board');
+
+test('boardFor maps GURPS aliases to the GURPS skin', () => {
+  for (const s of ['gurps', 'gurps-4e', 'GURPS-4e']) {
+    const b = boardFor(s);
+    assert.equal(b.scriptId, 'gurps-party-data');
+    assert.deepEqual(b.clientScripts, ['party-core.js', 'gurps-live.js', 'gurps-party.js']);
+    assert.equal(b.buildManifest, buildPartyManifest);
+  }
+});
+
+test('boardFor maps CoC / Regency aliases to the CoC skin', () => {
+  for (const s of ['coc', 'coc-7e', 'regency-cthulhu']) {
+    const b = boardFor(s);
+    assert.equal(b.scriptId, 'coc-party-data');
+    assert.deepEqual(b.clientScripts, ['party-core.js', 'coc-party.js']);
+    assert.equal(b.buildManifest, buildCoCPartyManifest);
+  }
+});
+
+test('boardFor returns null for unknown/absent systems', () => {
+  assert.equal(boardFor('dnd-5e-2024'), null);
+  assert.equal(boardFor(null), null);
+  assert.equal(boardFor(undefined), null);
+});

--- a/tools/publish/test/party-core.test.js
+++ b/tools/publish/test/party-core.test.js
@@ -1,0 +1,54 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const core = require('../js/party-core.js');
+
+test('groupLatestByPc picks the max-updatedAt state per pcSlug', () => {
+  const states = {
+    'loadout:c:six:p1': { updatedAt: 100, hp: { cur: 9 } },
+    'loadout:c:six:p2': { updatedAt: 300, hp: { cur: 4 } },
+    'loadout:c:ann:p1': { updatedAt: 50, hp: { cur: 7 } },
+  };
+  const out = core.groupLatestByPc(states);
+  assert.equal(out.six.hp.cur, 4);
+  assert.equal(out.ann.hp.cur, 7);
+});
+
+test('groupLatestByPc treats a missing updatedAt as oldest (0)', () => {
+  const states = { 'loadout:c:six:p1': { hp: { cur: 4 } }, 'loadout:c:six:p2': { updatedAt: 10, hp: { cur: 9 } } };
+  assert.equal(core.groupLatestByPc(states).six.hp.cur, 9);
+});
+
+test('maxUpdatedAt returns the freshest updatedAt, 0 when none', () => {
+  assert.equal(core.maxUpdatedAt({}), 0);
+  assert.equal(core.maxUpdatedAt({ a: { updatedAt: 100 }, b: { updatedAt: 300 }, c: {} }), 300);
+  assert.equal(core.maxUpdatedAt(null), 0);
+});
+
+test('createPoller polls while active and stops when idle', () => {
+  let t = 0; const timers = {}; let id = 0; let polls = 0;
+  const poller = core.createPoller({
+    now: () => t,
+    setTimer: (fn, ms) => { const k = ++id; timers[k] = { fn, at: t + ms }; return k; },
+    clearTimer: (k) => { delete timers[k]; },
+    isHidden: () => false,
+    poll: () => { polls++; return Promise.resolve({ 'loadout:c:x:p': { updatedAt: t } }); },
+    pollMs: 1000, idleMs: 5000,
+  });
+  return Promise.resolve(poller.start()).then(() => {
+    assert.equal(polls, 1);
+    assert.ok(Object.keys(timers).length === 1, 'schedules next tick while active');
+  });
+});
+
+test('createPoller does not schedule while hidden', () => {
+  let hidden = true; const timers = {}; let id = 0;
+  const poller = core.createPoller({
+    now: () => 0,
+    setTimer: (fn, ms) => { const k = ++id; timers[k] = fn; return k; },
+    clearTimer: (k) => { delete timers[k]; },
+    isHidden: () => hidden,
+    poll: () => Promise.resolve(undefined),
+  });
+  poller.start();
+  assert.equal(Object.keys(timers).length, 0);
+});


### PR DESCRIPTION
Adds a read-only GM party board for Call of Cthulhu investigators to the roster page, mirroring the existing GURPS board. Extracts the generic board machinery into a shared spine so every system's board is now a thin skin dispatched by a registry.

## What's new

- **CoC party board** on the roster page: per-investigator HP/SAN/MP bars, bare Luck (dims red under 15), DEX, optional Reputation (Regency), and the five condition badges. Rows sort DEX-desc with a name tiebreak; insanity tints the row violet (`mad`), wounds tint it red (`hurt`).
- **Shared spine (`js/party-core.js`)** — the adaptive 60s poller, freshest-state grouping, and fetch/DOMContentLoaded bootstrap, extracted out of the GURPS board (behavior-preserving).
- **Per-system skins + registry** — `lib/party-board-registry.js` maps `system → { buildManifest, renderBoard, scriptId, clientScripts }`; `build.js`/`wiki.js` no longer hard-code GURPS.

## Design

- **Read-only.** The board only reads the poll payload — it never writes KV or calls `store.save`. It reuses the roster-index/`getStates` fan-out and the 60s adaptive poller (no `kv.list`, no 5s poll).
- **Dual-mode modules.** `party-core.js`, `gurps-party.js`, and `coc-party.js` run in Node (tests) and raw in the browser without a bundler; `party-core.js` loads first so the shared spine exists before any skin.
- GURPS output is unchanged apart from its rosters now injecting `party-core.js` first — required, since `gurps-party.js` now consumes the shared spine.

## Verification

- Full test suite green (1182/1182), including all pre-existing GURPS board tests plus new coverage for the spine, the CoC client/server skins (Canticle golden fixture), the registry, and the wired build path.
- End-to-end build of the Canticle vault (`coc-7e`) renders the board with the correct DEX-desc order, column set, Rep column, condition badges, and row tints — no render errors.

Bumps plugin 1.8.30 → 1.8.31 and publish tool 1.11.9 → 1.11.10.
