### PR TITLE
Carry sheet_crest through the config loader (fixes #112)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.31",
+  "version": "1.8.32",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.32] — 2026-07-19
+
+Publish tool 1.11.11.
+
+### Fixed
+
+- CoC investigator-sheet crest/seal (`publish.sheet_crest`) never rendered: the config loader's field-by-field allow-list silently dropped the key, so it never reached the renderer. `loadPublishConfig` now carries `sheet_crest` (publish block first, then the `vault.config.json` fallback), and it is documented in the publish-site configuration reference (#112).
+
+---
+
 ## [1.8.31] — 2026-07-18
 
 Publish tool 1.11.10.

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -26,6 +26,7 @@ any equivalent in `vault.config.json`.
 | Image optimization | `publish.images` | Opt-in WebP re-encoding of copied images (default: off) |
 | Section banners | `publish.banners` | Hero image or clickable map at the top of a section index |
 | Locations grouping | `publish.locations` | Pivot the Locations index on a `location_type` (default: genre-derived) |
+| CoC sheet crest | `publish.sheet_crest` | Vault-relative image for the Order crest / wax seal in the CoC investigator-sheet masthead. Renders only when set and the image exists; a per-PC `crest` frontmatter value overrides it |
 | Setting year | `setting_year` | Fallback in-game date on the landing page (used only when the campaign overview has no `current_game_date`) |
 
 > **Landing page state.** The landing hero (in-game date, session count) and the

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -81,6 +81,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
   const merged = {
     mode: publish.mode || PUBLISH_DEFAULTS.mode,
     system: publish.system || null,
+    // CoC sheet masthead crest/seal. Not part of any list-union — a bare passthrough,
+    // publish block first then the vault.config.json fallback (see #112).
+    sheet_crest: publish.sheet_crest || jsonConfigFallback.sheet_crest || null,
     exclude_drafts: publish.exclude_drafts ?? PUBLISH_DEFAULTS.exclude_drafts,
     exclude_sections: unionExcludeList(
       publish.exclude_sections,

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.10",
+  "version": "1.11.11",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -242,3 +242,45 @@ describe('exclude_fields union merge', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe('sheet_crest', () => {
+  // Regression for #112: the field-by-field allow-list in loadPublishConfig
+  // silently dropped sheet_crest, so the CoC sheet crest/seal never rendered.
+  it('preserves sheet_crest from the vault-config.md publish block', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(
+      path.join(metaDir, 'vault-config.md'),
+      '---\npublish:\n  sheet_crest: "_attachments/factions/order.webp"\n---\n',
+    );
+    const result = loadPublishConfig(tmpDir);
+    assert.strictEqual(result.sheet_crest, '_attachments/factions/order.webp');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('falls back to vault.config.json sheet_crest when the publish block has none', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const result = loadPublishConfig(tmpDir, { sheet_crest: 'images/crest.png' });
+    assert.strictEqual(result.sheet_crest, 'images/crest.png');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('lets the publish block win over the vault.config.json fallback', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(
+      path.join(metaDir, 'vault-config.md'),
+      '---\npublish:\n  sheet_crest: "block.webp"\n---\n',
+    );
+    const result = loadPublishConfig(tmpDir, { sheet_crest: 'fallback.webp' });
+    assert.strictEqual(result.sheet_crest, 'block.webp');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('defaults sheet_crest to null when unset', () => {
+    const result = loadPublishConfig('/nonexistent/path');
+    assert.strictEqual(result.sheet_crest, null);
+  });
+});


### PR DESCRIPTION
Fixes #112.

The CoC investigator-sheet Order crest / wax seal (`publish.sheet_crest`) never rendered: `loadPublishConfig()` assembles its result field-by-field, and `sheet_crest` wasn't among the enumerated keys, so it was silently dropped before reaching the renderer. The renderer (`pc.js`), the image-manifest guard (`build.js`), and the CSS all already supported the feature — the value just never arrived.

## Fix

- **`lib/config.js`** — carry `sheet_crest` through the merged config: `publish.sheet_crest || jsonConfigFallback.sheet_crest || null` (publish block wins, then the `vault.config.json` fallback).
- **`test/unit/config.test.js`** — regression coverage (4 tests): preserved from the publish block, JSON-fallback path, publish-block-wins precedence, and null-when-unset. Written test-first (RED before the fix, GREEN after).
- **`references/configuration.md`** — documented `publish.sheet_crest` in the publish-key table, so the next top-level key added to the allow-list is less likely to be dropped unnoticed.

## Verification

- Full suite green (1186/1186, +4 new).
- Schema validation 41/41; markdownlint clean on both changed docs.

Bumps plugin 1.8.31 → 1.8.32, publish tool 1.11.10 → 1.11.11.
