### PR TITLE
session-prep: add Behaviours + Complications to the scene skeleton

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.36",
+  "version": "1.8.37",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.37] — 2026-07-19
+
+### Added
+
+- Scene skeleton gains a **Behaviours** field — what the situation and its NPCs do on their own, independent of the players, and how it escalates if the PCs do nothing ("what happens here if they never show up?"). This is the load-bearing element of situation-based design that our operational scene template had distilled away: the reference layer already taught it (Sly Flourish's situation checklist, the Alexandrian's proactive nodes, PbtA Fronts' clocks — all attributed), but the `## Planned Scenes` skeleton the GM fills in only captured how a scene opens (Slice A's situation objective + named initiator) and how players branch, never the engine that runs regardless of player choice. It is the durable form of the failure report's RC1 fix ("an engine that runs entirely on NPC behaviour and survives any player choice"). Added to the `## Planned Scenes` skeleton and the standalone scene-note template in `session-prep/references/session-templates.md`, and as a craft rule in session-prep step 14.
+- Scene skeleton also gains a **Complications** field — the 2–3 curveballs a GM holds ready to spike tension (a rival arrives, a PC is recognised, the timer is discovered), distinct from Behaviours (the situation's default motion) and Branching (the players' own choices). The standalone scene-note template already had a `## Complications` section; the operative `## Planned Scenes` skeleton did not, so it only half-carried Sly Flourish's five-field situation checklist (Location · Inhabitants · Behaviours · Goal · Complications). Together with Behaviours this completes that mapping in the skeleton the GM actually fills.
+- No new sources for either field — Sly Flourish, The Alexandrian, and Fronts (Apocalypse World) are all already in `ATTRIBUTION.md`.
+
+---
+
 ## [1.8.36] — 2026-07-19
 
 ### Changed

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -280,6 +280,13 @@ the **premise**, not the finished scene. For each scene:
      and what they want from *this* PC (ensemble scenes: the household
      schedule is a valid initiator). A scene that cannot answer this is not
      finished.
+   - **Behaviours** — what the situation and its NPCs do on their own,
+     independent of the players, and how it escalates if the PCs do nothing
+     ("what happens here if they never show up?"). The initiator opens the
+     door; the behaviours keep it moving. This is the engine that lets a scene
+     survive any player choice — the durable form of the "runs on NPC
+     behaviour, not a predicted PC response" fix. (Sly Flourish's situation
+     "Behaviours"; ref: `skills/ttrpg-expert/scene-encounter-patterns.md`.)
    - **Read-aloud** as a `> ` blockquote: objective sensory description,
      2–4 sentences, addressed to the table — never naming one PC or dictating
      a feeling ("you feel…").

--- a/skills/session-prep/references/session-templates.md
+++ b/skills/session-prep/references/session-templates.md
@@ -127,8 +127,21 @@ Name the NPC who initiates and what they want from *this* PC, or
 the errand/schedule that sends them. Ensemble scenes: the
 household schedule (a shared meal, a departure) is a valid
 initiator. A scene that cannot answer this is not finished.
+**Behaviours:** What the situation and its NPCs do on their own —
+independent of the players, and how it escalates if the PCs do
+nothing. Ask "what happens here if the characters never show up?"
+The initiator opens the door; the behaviours keep it moving. This
+is the engine that lets the scene survive any player choice — a
+scene that only moves when a PC acts is fragile. (Sly Flourish's
+"Behaviours"; a Front-style clock for anything on a timer.)
 **Branching:** What choices do players face? Where do different
 choices lead?
+**Complications:** 2–3 curveballs held ready to spike tension when
+the scene sags — a rival arrives, a PC is recognised, the contact
+is being watched, the timer is discovered. Distinct from Behaviours
+(the situation's default motion) and Branching (the players' own
+choices): these are the GM's escalation toolkit, dropped when
+needed, not scripted to a beat. (Sly Flourish's "Complications.")
 
 ### Scene 2: [Title]
 [Same structure]
@@ -328,9 +341,15 @@ scene begins. 2-4 sentences. Sensory details.]
 
 How does this scene begin? What brings the investigators here?
 
-## NPC Motivations
+## NPC Motivations & Behaviours
 
-For each NPC present, what do they want and what will they do?
+For each NPC present, what do they want and what will they do —
+including what they do on their own timeline, independent of the
+players? And the situation itself: what environmental or timed
+pressure advances if no NPC acts (a fire spreading, a ritual
+completing, a tide rising)? What happens here if the PCs never
+show up? The scene should run on this behaviour, not on a
+predicted PC response.
 
 ## Complications
 


### PR DESCRIPTION
## Why

Follow-up to the failure-report review. The operative `## Planned Scenes` skeleton the GM fills in captured how a scene *opens* (Slice A's situation objective + named initiator) and how players *branch* — but not the engine that runs **regardless of player choice**, which is the load-bearing element of situation-based scene design.

A research pass confirmed this is not our invention to make: it's the core of "prep situations, not plots," and it's already taught in our own reference layer (`ttrpg-expert/scene-encounter-patterns.md`). The gap was only between that research layer and the operative template. All frameworks involved are already credited in `ATTRIBUTION.md`:

- **Sly Flourish** situation checklist — the "Behaviours" field (*"how do the inhabitants act… independent of player actions — what would the pattern of their behaviour be if the characters never showed up?"*)
- **The Alexandrian** — proactive nodes (adversaries pursuing their own agendas independent of the PCs)
- **PbtA Fronts** — grim portents / countdown clocks (what happens on a timer if unopposed)

## Changes

Two new fields on the scene skeleton (`session-prep/references/session-templates.md`), plus Behaviours as a step-14 craft rule (`session-prep/SKILL.md`) and on the standalone scene-note template:

- **Behaviours** — what the situation and its NPCs do on their own, independent of the players, and how it escalates if the PCs do nothing. The durable form of the failure report's RC1 fix ("an engine that runs entirely on NPC behaviour and survives any player choice").
- **Complications** — the 2–3 curveballs held ready to spike tension (a rival arrives, a PC is recognised, the timer is discovered), distinct from Behaviours (default motion) and Branching (player choices). The standalone template already had a `## Complications` section; the operative skeleton did not.

Together these complete Sly Flourish's five-field situation mapping — Location · Inhabitants · **Behaviours** · Goal · **Complications** — in the skeleton the GM actually fills in.

No change to the `ttrpg-expert` reference layer (it already carried the full methodology) and no new sources.

## Verification

- `validate_schema.py`: 41 files pass
- skill-creator `quick_validate`: session-prep valid
- markdownlint clean
- Local code review run; 1 low-severity finding fixed (standalone template had scoped Behaviours to NPCs only, dropping the non-NPC clock)

Version 1.8.36 → 1.8.37.