### PR TITLE
Publish-site bug-sweep: inbox, ranged to-hit, manifest warning, Load-Outs, CoC sheet (#118 #119 #101 #106 #107)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.37",
+  "version": "1.8.38",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.8.37] — 2026-07-19
+## [1.8.38] — 2026-07-20
+
+Publish tool 1.11.13.
+
+### Fixed
+
+- Inbox CLI crashed the whole `inbox pull` on any absent/orphaned KV key: wrangler's missing-key 404 embeds the REST endpoint URL (`.../storage/kv/namespaces/<id>/values/<key>`), and the `namespaces` substring tripped the `namespace` operational signal, so every missing key threw instead of returning `null`. A single TTL-reaped or orphaned `config:req-index` id then took down the entire at-table request queue. The error is now classified on the human-readable prose only (URLs stripped first), and a regression test covers the missing-key-404 case (#118).
+- GURPS PC renderer: the Ranged Attacks table now surfaces the current skill level the way Melee does — the trailing to-hit number is wrapped in `<span class="wp-tohit">` and each row carries `data-weapon-key`, and `buildWeapons` feeds ranged weapons into the live to-hit map (parry stays `null` for them). Ranged to-hit was previously inert on every sheet; no client change was needed (#119).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.38] — 2026-07-20
 
-Publish tool 1.11.13.
+Publish tool 1.11.14. A publish-site bug-sweep.
 
 ### Fixed
 
 - Inbox CLI crashed the whole `inbox pull` on any absent/orphaned KV key: wrangler's missing-key 404 embeds the REST endpoint URL (`.../storage/kv/namespaces/<id>/values/<key>`), and the `namespaces` substring tripped the `namespace` operational signal, so every missing key threw instead of returning `null`. A single TTL-reaped or orphaned `config:req-index` id then took down the entire at-table request queue. The error is now classified on the human-readable prose only (URLs stripped first), and a regression test covers the missing-key-404 case (#118).
 - GURPS PC renderer: the Ranged Attacks table now surfaces the current skill level the way Melee does — the trailing to-hit number is wrapped in `<span class="wp-tohit">` and each row carries `data-weapon-key`, and `buildWeapons` feeds ranged weapons into the live to-hit map (parry stays `null` for them). Ranged to-hit was previously inert on every sheet; no client change was needed (#119).
+- A played session/chapter present in the vault but absent from `_meta/publish-manifest.md` silently never published (the manifest is an allowlist and session-wrapup never registers the files it writes), so the landing "Latest Session" block pointed at the previous session while showing the new date. The build now warns on a `session`/`session_wrap`/`chapter` file that is in neither the manifest's Publishing nor Excluded list — the manifest parser now also reads the Excluded section, so a deliberate exclusion is not mistaken for an oversight (#101).
+- GURPS Load-Outs: the `### Load-Outs` feature had no PC-template guidance and no migration, so legacy sheets used ad-hoc equipment sections that silently rendered nothing. Documented a worked `### Load-Outs` example in `pc-gurps-4e.md`, added a migration to detect and convert/flag legacy equipment sections, and hardened the load-out-name parser so bold inside a table cell can no longer be read as a load-out name (#106).
+- CoC investigator sheet: a legacy sheet whose body structure diverges from the documented contract parsed to a near-empty model and rendered mostly blank with no signal. The build now warns when a CoC PC parses no characteristics, and a migration detects divergent sheets to convert or flag (#107).
 
 ### Added
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -458,3 +458,52 @@ hidden until revealed in play, not permanently secret.
   differ, and renders old-format sheets unchanged. If
   `publish.site_dir` is set in vault-config, offer to run
   `npm update gm-apprentice-publish` in the site directory.
+
+## Migration: 1.8.12 → 1.8.38
+
+Two publish features shipped their renderers without a migration to
+teach existing sheets the structure they parse, so pre-existing PCs
+silently render incomplete. Both are opt-in per PC — the renderers are
+resilient and never crash, they just drop the unparsed content — so
+these are flags-and-conversions the GM confirms, not automatic rewrites.
+
+### Content
+
+- **GURPS Load-Outs section** — the GURPS PC renderer turns a
+  `### Load-Outs` (or `### Loadouts`) subsection under `## Equipment`
+  into toggleable, encumbrance-recomputing gear groups
+  (`defaultCarried: false`). Sheets authored before the feature use
+  ad-hoc sections instead (`## Station-Issue Equipment (Returnable)`,
+  `### Optional Loadout`, a second `## Equipment` variant, etc.), and
+  the parser only matches the exact `Load-Outs`/`Loadouts` titles, so
+  that gear silently never appears as a toggle. Detect equipment-like
+  sections on a GURPS PC that are neither the main `## Equipment` table
+  nor a `### Load-Outs`/`### Loadouts` subsection, and offer to convert
+  each to a `### Load-Outs` subsection (a `**Name**` bold heading
+  immediately followed by an `Item`/`Weight`/`Cost` table, no bold
+  before the first heading or inside table cells) — or flag it for the
+  GM if the intent is ambiguous. The documented template now carries a
+  worked `### Load-Outs` example (`shared/templates/pc-gurps-4e.md`).
+  Opt-in per PC; no frontmatter change. (#106)
+- **CoC investigator-sheet body structure** — the CoC 7e renderer reads
+  the markdown body in the structure documented at
+  `docs/file-format-standards.md §8` (`## Stat Sheet` →
+  `### Characteristics`/`### Derived`/`### Reputation`/`### Combat`/
+  `### Status`, `## Skills`, `## Combat`, `## Equipment` + Record prose).
+  It normalizes skill-name variance and injects the canonical skill
+  list, so most drift renders fine, but a sheet whose section/subsection
+  titles diverge (or that stored characteristics/skills in frontmatter
+  for the old renderer) parses to a near-empty model and renders mostly
+  blank. The publish tool now warns at build time when a CoC PC parses
+  no characteristics; for each flagged sheet, offer to convert it to the
+  documented structure (the shipped `pc-coc-7e.md` / `pc-coc-7e-regency.md`
+  templates are the target) or flag it for the GM. Opt-in per PC. (#107)
+
+### Tooling
+
+- **Publish tool:** `gm-apprentice-publish` 1.11.14 hardens the GURPS
+  load-out-name parser (bold inside a load-out table cell can no longer
+  be mistaken for a load-out name) and emits a build-time warning for a
+  CoC PC that parses no characteristics. If `publish.site_dir` is set in
+  vault-config, offer to run `npm update gm-apprentice-publish` in the
+  site directory.

--- a/skills/shared/templates/pc-gurps-4e.md
+++ b/skills/shared/templates/pc-gurps-4e.md
@@ -185,6 +185,30 @@ Top 5 multi-step combat sequences for quick reference.
 |------|--------|------|----------|-------|
 | | | | | |
 
+### Load-Outs
+
+{Optional. Gear the character carries only sometimes — a returnable
+station kit, a heist loadout, a travel pack. On the published sheet
+each load-out becomes a toggle that recomputes encumbrance / Move /
+Dodge live when switched on; the main Equipment table above is always
+carried (`defaultCarried: true`), load-out items default off
+(`defaultCarried: false`). Delete this subsection if the PC has none.}
+
+{Contract the renderer parses (`tools/publish/lib/templates/gurps/parse.js`):
+this must be a `### Load-Outs` (or `### Loadouts`) subsection **under
+`## Equipment`, after the main table** — main items are read only from
+above the first `###`. Each load-out is a **bold `**Name**` heading
+immediately followed by a table** with `Item`/`Name`, `Weight`, and
+`Cost` columns. Gotchas: put no bold text before the first load-out
+heading, and no bold inside load-out table cells — either can be
+mistaken for a load-out name.}
+
+**Station-Issue Kit**
+
+| Item | Weight | Cost |
+|------|--------|------|
+| | | |
+
 ### Encumbrance
 
 | Level | Max Weight | Move | Dodge |

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -195,16 +195,20 @@ function build(options = {}) {
     // the file, and the allowlist then drops it with no signal. The landing "Latest Session"
     // block falls back to the previous session while showing the new date, which reads as a
     // broken link. Warn on registrable types that are in neither the Publishing nor the
-    // Excluded list (a deliberate exclusion is a decision, not an oversight).
-    const registered = new Set([...manifest.publishing, ...(manifest.excluded || [])]);
-    const REGISTRABLE_TYPES = new Set(['session', 'session_wrap', 'chapter']);
-    for (const page of corpus) {
-      const type = page.frontmatter && page.frontmatter.type;
-      if (!REGISTRABLE_TYPES.has(type)) continue;
-      const rel = vaultRelPathOf(page);
-      if (!registered.has(rel)) {
-        const kind = type === 'chapter' ? 'chapter' : 'session';
-        console.warn(`  WARNING: "${rel}" (type: ${type}) is present in the vault but not in the publish manifest — this ${kind} will NOT publish. Add it to _meta/publish-manifest.md.`);
+    // Excluded list (a deliberate exclusion is a decision, not an oversight). Only meaningful in
+    // player mode — that is the only mode where the manifest is enforced as an allowlist (the
+    // filter below); in full/GM mode unregistered pages still publish, so the warning would lie.
+    if (publishConfig.mode === 'player') {
+      const registered = new Set([...manifest.publishing, ...(manifest.excluded || [])]);
+      const REGISTRABLE_TYPES = new Set(['session', 'session_wrap', 'chapter']);
+      for (const page of corpus) {
+        const type = page.frontmatter && page.frontmatter.type;
+        if (!REGISTRABLE_TYPES.has(type)) continue;
+        const rel = vaultRelPathOf(page);
+        if (!registered.has(rel)) {
+          const kind = type === 'chapter' ? 'chapter' : 'session';
+          console.warn(`  WARNING: "${rel}" (type: ${type}) is present in the vault but not in the publish manifest — this ${kind} will NOT publish. Add it to _meta/publish-manifest.md.`);
+        }
       }
     }
   }

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -189,6 +189,24 @@ function build(options = {}) {
         console.warn(`  WARNING: manifest lists "${entry}" but no such page was scanned`);
       }
     }
+
+    // Reverse direction (#101): a played session/chapter present in the vault but absent from
+    // the manifest silently never publishes — session-wrapup writes canon but never registers
+    // the file, and the allowlist then drops it with no signal. The landing "Latest Session"
+    // block falls back to the previous session while showing the new date, which reads as a
+    // broken link. Warn on registrable types that are in neither the Publishing nor the
+    // Excluded list (a deliberate exclusion is a decision, not an oversight).
+    const registered = new Set([...manifest.publishing, ...(manifest.excluded || [])]);
+    const REGISTRABLE_TYPES = new Set(['session', 'session_wrap', 'chapter']);
+    for (const page of corpus) {
+      const type = page.frontmatter && page.frontmatter.type;
+      if (!REGISTRABLE_TYPES.has(type)) continue;
+      const rel = vaultRelPathOf(page);
+      if (!registered.has(rel)) {
+        const kind = type === 'chapter' ? 'chapter' : 'session';
+        console.warn(`  WARNING: "${rel}" (type: ${type}) is present in the vault but not in the publish manifest — this ${kind} will NOT publish. Add it to _meta/publish-manifest.md.`);
+      }
+    }
   }
 
   pairStoryFiles(pages, config.vaultPath);

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -517,6 +517,12 @@ function build(options = {}) {
           const systemOut = (rendered && typeof rendered === 'object')
             ? rendered
             : { sheetHtml: rendered || null };
+          // A system renderer may report structural warnings (e.g. a CoC sheet whose body
+          // diverges from the contract and parses near-empty, #107). Surface them like other
+          // page warnings instead of shipping a silently-broken sheet.
+          if (systemOut.warnings && systemOut.warnings.length) {
+            logWarnings(page.outputPath, systemOut.warnings);
+          }
           if (systemOut.liveData) {
             // Root-relative output path of the PC portrait, for the party-board
             // thumbnail. Resolved the same way portraitImg does (imageMap keyed

--- a/tools/publish/lib/inbox-wrangler.js
+++ b/tools/publish/lib/inbox-wrangler.js
@@ -35,7 +35,11 @@ function makeAdapter({ runWrangler, namespaceId }) {
       // namespace: "KV namespace ... not found [code: 10041]"), so those signals
       // are checked first and always throw — only a key-scoped not-found with no
       // operational signal is treated as an absent key.
-      const err = (res.stderr || '').toLowerCase();
+      // Strip any URL first: wrangler's missing-key 404 embeds the REST endpoint
+      // (".../namespaces/<id>/values/<key>"), whose "namespaces" would otherwise
+      // trip the `namespace` operational signal below and make every absent key
+      // throw instead of returning null. Classify on the human-readable prose only.
+      const err = (res.stderr || '').toLowerCase().replace(/https?:\/\/\S+/g, '');
       const operational = /namespace|authenticat|authoriz|unauthor|permission|credential|not logged in|network|fetch failed|timeout|econn|enotfound|10041|10000/.test(err);
       if (!operational && /not found|not_found|no value|does not exist/.test(err)) return null;
       throw new Error('wrangler kv get failed for "' + key + '": ' + ((res.stderr || '').trim() || 'exit ' + res.code));

--- a/tools/publish/lib/manifest.js
+++ b/tools/publish/lib/manifest.js
@@ -54,13 +54,19 @@ function parseManifest(markdown) {
       if (checked) resolved.push(stripInlineComment(checked[1]));
     }
 
-    // The Excluded section lists a `- Reason: …` category bullet followed by indented
-    // `  - path.md` file bullets. Collect the file paths (skip the Reason categories) so the
-    // build can tell a *deliberately* excluded file from one that is simply absent from the
-    // manifest — only the latter is a forgotten-to-register warning (#101).
+    // Collect the Excluded file paths so the build can tell a *deliberately* excluded file
+    // from one that is simply absent from the manifest — only the latter is a forgot-to-register
+    // warning (#101). Two shapes appear: the documented `- [x] path — reason` checkbox lines
+    // (same as Publishing, see publish-site/references/content-filtering.md) and a grouped
+    // `- Reason: …` category with indented `  - path` bullets. Handle both; skip Reason bullets.
     if (currentSection === 'excluded') {
-      const m = line.match(/^\s*-\s+(.+)$/);
-      if (m && !/^reason:/i.test(m[1].trim())) excluded.push(stripInlineComment(m[1]));
+      const checkboxed = line.match(checkedPattern);
+      if (checkboxed) {
+        excluded.push(stripInlineComment(checkboxed[1]));
+      } else {
+        const bullet = line.match(/^\s+-\s+(.+)$/);
+        if (bullet && !/^reason:/i.test(bullet[1].trim())) excluded.push(stripInlineComment(bullet[1]));
+      }
     }
   }
 

--- a/tools/publish/lib/manifest.js
+++ b/tools/publish/lib/manifest.js
@@ -25,6 +25,7 @@ function parseManifest(markdown) {
   const publishing = [];
   const needsDecision = [];
   const resolved = [];
+  const excluded = [];
 
   const checkedPattern = /^- \[[xX]\]\s+(.+)$/;
   const uncheckedPattern = /^- \[ \]\s+(.+)$/;
@@ -52,6 +53,15 @@ function parseManifest(markdown) {
       const checked = line.match(checkedPattern);
       if (checked) resolved.push(stripInlineComment(checked[1]));
     }
+
+    // The Excluded section lists a `- Reason: …` category bullet followed by indented
+    // `  - path.md` file bullets. Collect the file paths (skip the Reason categories) so the
+    // build can tell a *deliberately* excluded file from one that is simply absent from the
+    // manifest — only the latter is a forgotten-to-register warning (#101).
+    if (currentSection === 'excluded') {
+      const m = line.match(/^\s*-\s+(.+)$/);
+      if (m && !/^reason:/i.test(m[1].trim())) excluded.push(stripInlineComment(m[1]));
+    }
   }
 
   return {
@@ -59,6 +69,7 @@ function parseManifest(markdown) {
     publishing,
     needsDecision,
     resolved,
+    excluded,
   };
 }
 

--- a/tools/publish/lib/templates/coc/index.js
+++ b/tools/publish/lib/templates/coc/index.js
@@ -6,6 +6,16 @@ function renderCoCSheet(frontmatter, sections, meta) {
   const system = (meta && meta.system) || (frontmatter && frontmatter.system) || 'coc-7e';
   const model = parseCoC(frontmatter, sections || [], system);
   const statusBarHtml = buildStatusBar(model);
+
+  // A legacy investigator sheet whose body diverges from the documented contract
+  // (docs/file-format-standards.md §8) parses to a near-empty model — most tellingly no
+  // characteristics from `## Stat Sheet → ### Characteristics`. The renderer is resilient
+  // enough not to crash, so without this the sheet would ship mostly empty, silently. (#107)
+  const warnings = [];
+  if (!model.chars || Object.keys(model.chars).length === 0) {
+    warnings.push('CoC investigator sheet parsed no characteristics — the body structure likely diverges from the documented contract (`## Stat Sheet` → `### Characteristics`; see docs/file-format-standards.md §8). The sheet will render mostly empty; convert it to the documented structure or run the CoC-sheet migration.');
+  }
+
   return {
     sheetHtml: buildSheet(model),
     recordHtml: buildRecord(model, sections || []),
@@ -13,6 +23,7 @@ function renderCoCSheet(frontmatter, sections, meta) {
     statusBarHtml,
     // No status bar → no mutable vitals → nothing to wire.
     liveData: statusBarHtml ? buildCoCLiveData(model, meta) : null,
+    warnings,
   };
 }
 

--- a/tools/publish/lib/templates/gurps/blocks/ranged.js
+++ b/tools/publish/lib/templates/gurps/blocks/ranged.js
@@ -4,18 +4,24 @@ const { wide } = require('../render');
 function renderRanged(model) {
   const attacks = model.ranged || [];
   if (attacks.length === 0) return null;
-  const rows = attacks.map(a =>
-    `<tr><td class="nm">${escapeHtml(a.weapon || '')}</td>` +
-    `<td class="num">${escapeHtml(a.skill || '')}</td>` +
-    `<td class="num dmg">${escapeHtml(a.damage || '')}</td>` +
-    `<td class="num">${escapeHtml(a.acc || '')}</td>` +
-    `<td class="num">${escapeHtml(a.range || '')}</td>` +
-    `<td class="num">${escapeHtml(a.rof || '')}</td>` +
-    `<td class="num">${escapeHtml(a.shots || '')}</td>` +
-    `<td class="num">${escapeHtml(a.st || '')}</td>` +
-    `<td class="num">${escapeHtml(a.bulk || '')}</td>` +
-    `<td class="num">${escapeHtml(a.rcl || '')}</td>` +
-    `<td>${escapeHtml(a.notes || '')}</td></tr>`).join('\n');
+  const rows = attacks.map(a => {
+    const skill = String(a.skill || '');
+    const sm = skill.match(/^(.*?)(\d+)(\s*)$/);   // wrap the TRAILING number (current skill level / default)
+    const skillHtml = sm
+      ? `${escapeHtml(sm[1])}<span class="wp-tohit">${escapeHtml(sm[2])}</span>${escapeHtml(sm[3])}`
+      : escapeHtml(skill);
+    return `<tr data-weapon-key="${escapeHtml(a.weapon || '')}"><td class="nm">${escapeHtml(a.weapon || '')}</td>` +
+      `<td class="num">${skillHtml}</td>` +
+      `<td class="num dmg">${escapeHtml(a.damage || '')}</td>` +
+      `<td class="num">${escapeHtml(a.acc || '')}</td>` +
+      `<td class="num">${escapeHtml(a.range || '')}</td>` +
+      `<td class="num">${escapeHtml(a.rof || '')}</td>` +
+      `<td class="num">${escapeHtml(a.shots || '')}</td>` +
+      `<td class="num">${escapeHtml(a.st || '')}</td>` +
+      `<td class="num">${escapeHtml(a.bulk || '')}</td>` +
+      `<td class="num">${escapeHtml(a.rcl || '')}</td>` +
+      `<td>${escapeHtml(a.notes || '')}</td></tr>`;
+  }).join('\n');
   const inner = `<table><thead><tr><th>Weapon</th><th class="num">Skill</th><th class="num dmg">Damage</th><th class="num">Acc</th><th class="num">Range</th><th class="num">RoF</th><th class="num">Shots</th><th class="num">ST</th><th class="num">Bulk</th><th class="num">Rcl</th><th>Notes</th></tr></thead><tbody>${rows}</tbody></table>`;
   return wide('table', 'Ranged Attacks', inner);
 }

--- a/tools/publish/lib/templates/gurps/live-data.js
+++ b/tools/publish/lib/templates/gurps/live-data.js
@@ -73,7 +73,10 @@ function weaponSeries(weapon, skillsByName, model, authoredLevel) {
 
 function buildWeapons(model, skillsByName, authoredLevel) {
   const out = {};
-  const rows = model.melee || [];
+  // Melee + ranged both feed the live to-hit map so their `.wp-tohit` cells
+  // (keyed by data-weapon-key) update in step with encumbrance. Ranged rows
+  // carry no parry, so parry stays null for them.
+  const rows = [...(model.melee || []), ...(model.ranged || [])];
   for (const w of rows) {
     if (!w.weapon) continue;
     const authoredToHit = weaponToHit(w.skill);

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -704,11 +704,16 @@ function parseEquipment(model, sections, fm) {
         // Each load-out is a sub-sub-table or bold heading + table
         // Simple approach: parse bold headings as load-out names, then the following table
         const loText = loHtml;
+        // Load-out names are standalone headings/bold that sit BETWEEN tables. Bold inside a
+        // table CELL must not be read as a name — with multiple load-outs it shifts the
+        // name->table index alignment and mislabels later groups. Scan for names in the
+        // table-stripped text so only real headings survive. (#106)
+        const loNamesText = loText.replace(/<table[\s\S]*?<\/table>/gi, '\n');
         const loNameRegex = /<(?:h4|strong|b)[^>]*>([\s\S]*?)<\/(?:h4|strong|b)>/gi;
         const loTableRegex = /<table[\s\S]*?<\/table>/gi;
         const loNames = [];
         let nm;
-        while ((nm = loNameRegex.exec(loText)) !== null) {
+        while ((nm = loNameRegex.exec(loNamesText)) !== null) {
           loNames.push(nm[1].replace(/<[^>]+>/g, '').trim());
         }
         const loTables = [];

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.12",
+  "version": "1.11.13",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.13",
+  "version": "1.11.14",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/inbox-wrangler.test.js
+++ b/tools/publish/test/inbox-wrangler.test.js
@@ -46,6 +46,19 @@ test('adapter.get throws on a namespace error even though it says "not found"', 
   await assert.rejects(() => kv.get('req:a'), /wrangler kv get failed/);
 });
 
+test('adapter.get returns null on a missing-key 404 whose URL embeds "namespaces"', async () => {
+  // Regression (#118): wrangler's missing-key 404 embeds the REST endpoint
+  // (.../storage/kv/namespaces/<id>/values/<key>). The "namespaces" substring
+  // must NOT trip the `namespace` operational signal — the key is simply absent,
+  // so the whole inbox pull must not crash on one orphaned index id.
+  const runWrangler = () => ({
+    code: 1, stdout: '',
+    stderr: '✘ [ERROR] Failed to fetch https://api.cloudflare.com/client/v4/accounts/acct/storage/kv/namespaces/ns/values/req%3Aa - 404: Not Found',
+  });
+  const kv = makeAdapter({ runWrangler, namespaceId: 'NS' });
+  assert.equal(await kv.get('req:a'), null);
+});
+
 test('adapter.put forwards value and optional TTL', async () => {
   const calls = [];
   const runWrangler = (args) => { calls.push(args); return { code: 0, stdout: '', stderr: '' }; };

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -772,6 +772,43 @@ describe('build integration', () => {
       assert.ok(!warnings.some(w => w.includes('Planned Session.md') && w.includes('not in the publish manifest')),
         'a deliberately excluded session must not warn');
     });
+
+    it('does NOT warn about an unregistered session in full/GM mode (manifest not enforced)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-full-'));
+      const vault = path.join(tmp, 'vault');
+      fs.cpSync(path.join(fixturesDir, 'with-manifest'), vault, { recursive: true });
+      // Flip the vault to full mode, where the manifest is loaded but NOT enforced as an allowlist,
+      // so an unregistered session still publishes — the "will NOT publish" warning would lie.
+      const vcPath = path.join(vault, '_meta', 'vault-config.md');
+      fs.writeFileSync(vcPath, fs.readFileSync(vcPath, 'utf-8').replace('mode: player', 'mode: full'));
+      fs.writeFileSync(path.join(vault, 'Sessions', 'Unregistered Session.md'),
+        '---\ntype: session_wrap\nsession_number: 6\ncanon_status: AUTHORITATIVE\naliases: []\ntags: []\n---\n\n## Recap\n\nStill played.\n');
+
+      const configPath = path.join(tmp, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath: vault,
+        outputDir: path.join(tmp, 'docs'),
+        attachmentsDir: '_attachments',
+        siteTitle: 'Full',
+        siteUrl: 'https://example.github.io/t',
+        excludeDirs: ['_meta', '_Templates'],
+        excludeSections: ['GM Notes'],
+        folderMap: { 'Characters/NPCs': 'characters/npcs', Locations: 'locations', Sessions: 'sessions' },
+      }, null, 2));
+
+      const warnings = [];
+      const realWarn = console.warn;
+      console.warn = (...args) => warnings.push(args.join(' '));
+      try {
+        build({ configPath });
+      } finally {
+        console.warn = realWarn;
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+
+      assert.ok(!warnings.some(w => w.includes('not in the publish manifest')),
+        `full mode must not emit the unregistered-session warning, got: ${JSON.stringify(warnings)}`);
+    });
   });
 
   describe('with-manifest fixture', () => {

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -735,6 +735,43 @@ describe('build integration', () => {
       assert.ok(!warnings.some(w => w.includes('Locations/Tavern.md')),
         'an annotated but valid entry must not warn');
     });
+
+    it('warns when a played session is in the vault but absent from the manifest (#101)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-unreg-'));
+      const vault = path.join(tmp, 'vault');
+      fs.cpSync(path.join(fixturesDir, 'with-manifest'), vault, { recursive: true });
+      // A played session written by wrap-up but never registered (neither Publishing nor Excluded).
+      fs.writeFileSync(path.join(vault, 'Sessions', 'Unregistered Session.md'),
+        '---\ntype: session_wrap\nsession_number: 6\ncanon_status: AUTHORITATIVE\naliases: []\ntags: []\n---\n\n## Recap\n\nThe job went sideways.\n');
+
+      const configPath = path.join(tmp, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath: vault,
+        outputDir: path.join(tmp, 'docs'),
+        attachmentsDir: '_attachments',
+        siteTitle: 'Unreg',
+        siteUrl: 'https://example.github.io/t',
+        excludeDirs: ['_meta', '_Templates'],
+        excludeSections: ['GM Notes'],
+        folderMap: { 'Characters/NPCs': 'characters/npcs', Locations: 'locations', Sessions: 'sessions' },
+      }, null, 2));
+
+      const warnings = [];
+      const realWarn = console.warn;
+      console.warn = (...args) => warnings.push(args.join(' '));
+      try {
+        build({ configPath });
+      } finally {
+        console.warn = realWarn;
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+
+      assert.ok(warnings.some(w => w.includes('Sessions/Unregistered Session.md') && w.includes('not in the publish manifest')),
+        `expected an unregistered-session warning, got: ${JSON.stringify(warnings)}`);
+      // The deliberately-excluded prep session (Reason: prep) is a decision, not an oversight — no warning.
+      assert.ok(!warnings.some(w => w.includes('Planned Session.md') && w.includes('not in the publish manifest')),
+        'a deliberately excluded session must not warn');
+    });
   });
 
   describe('with-manifest fixture', () => {

--- a/tools/publish/test/live-data.test.js
+++ b/tools/publish/test/live-data.test.js
@@ -18,12 +18,15 @@ function sixModel() {
     skills: [
       { name: 'Climbing', level: '12', base: '13' },   // affected: -1 at Light
       { name: 'Judo', level: '14', base: '14' },        // Armor Familiarity: flat
+      { name: 'Beam Weapons (Pistol)', level: '15', base: '15' }, // ranged: flat
     ],
     melee: [
       { weapon: 'Vibro-axe', skill: 'Axe/Mace-17', parry: '12 (0U)' }, // Axe/Mace not affected
       { weapon: 'Judo throw', skill: 'Judo-14', parry: '11' },         // linked to flat Judo
     ],
-    ranged: [],
+    ranged: [
+      { weapon: 'Blaster pistol', skill: 'Beam Weapons (Pistol)-15' }, // no parry field
+    ],
     equipment: {
       items: [{ name: 'Vibro-axe', weight: '4 lbs' }, { name: 'Space Armor', weight: '56 lbs' }],
       loadouts: [{ name: 'Transit', items: [{ name: 'Hand thruster', weight: '4 lbs' }] }],
@@ -54,6 +57,12 @@ test('weapon parry/to-hit follow their linked skill', () => {
   // Judo throw linked to flat Judo -> flat
   assert.deepEqual(d.weapons['Judo throw'].parry, [11, 11, 11, 11, 11]);
   assert.deepEqual(d.weapons['Judo throw'].toHit, [14, 14, 14, 14, 14]);
+});
+
+test('ranged weapons join the live to-hit map (no parry)', () => {
+  const d = buildLiveData(sixModel(), { campaignId: 'c', pcSlug: 'p', buildVersion: 'v' });
+  assert.deepEqual(d.weapons['Blaster pistol'].toHit, [15, 15, 15, 15, 15]);
+  assert.equal(d.weapons['Blaster pistol'].parry, null);
 });
 
 test('items carry weight + default carried (main on, loadout off)', () => {

--- a/tools/publish/test/unit/coc-parse.test.js
+++ b/tools/publish/test/unit/coc-parse.test.js
@@ -106,3 +106,18 @@ describe('parseCoC backstory', () => {
     assert.deepEqual(plain.backstory, []);
   });
 });
+
+const { renderCoCSheet } = require('../../lib/templates/coc/index');
+
+describe('renderCoCSheet — legacy body-structure warning (#107)', () => {
+  it('warns when a sheet parses no characteristics (divergent legacy body)', () => {
+    const out = renderCoCSheet({ occupation: 'Antiquarian' }, [], 'coc-7e');
+    assert.ok(out.warnings.some(w => /no characteristics/i.test(w)),
+      `expected a no-characteristics warning, got: ${JSON.stringify(out.warnings)}`);
+  });
+
+  it('does not warn when the documented Stat Sheet structure parses', () => {
+    const out = renderCoCSheet(fm, [statSheet, skillsSection, weaponsSection], 'regency-cthulhu');
+    assert.deepStrictEqual(out.warnings, []);
+  });
+});

--- a/tools/publish/test/unit/gurps/blocks.ranged.test.js
+++ b/tools/publish/test/unit/gurps/blocks.ranged.test.js
@@ -13,6 +13,16 @@ describe('renderRanged', () => {
     assert.ok(html.includes('1d+1 imp'));
     assert.ok(html.includes('140/210'));
   });
+  it('shows the to-hit level and a live weapon-key hook, like melee', () => {
+    const model = { ranged: [
+      { weapon: 'Blaster pistol', skill: 'Beam Weapons (Pistol)-15', damage: '3d (5) burn', acc: '6', range: '300/900', rof: '3', shots: '200(3)', st: '', bulk: '-2', rcl: '', notes: '' },
+    ] };
+    const html = renderRanged(model);
+    // Trailing number wrapped as the current skill level (default surfaces the same way).
+    assert.ok(html.includes('Beam Weapons (Pistol)-<span class="wp-tohit">15</span>'));
+    // Row carries the key the live script updates.
+    assert.ok(html.includes('data-weapon-key="Blaster pistol"'));
+  });
   it('returns null when ranged is empty', () => {
     assert.strictEqual(renderRanged({ ranged: [] }), null);
   });

--- a/tools/publish/test/unit/gurps/parse.test.js
+++ b/tools/publish/test/unit/gurps/parse.test.js
@@ -249,6 +249,28 @@ describe('parseGurps — Equipment section', () => {
   });
 });
 
+describe('parseGurps — Load-Outs bold-in-cell hardening (issue #106)', () => {
+  const html =
+    '<table><tr><th>Item</th><th>Weight</th><th>Cost</th></tr>' +
+    '<tr><td>Backpack</td><td>3 lb</td><td>$60</td></tr></table>' +
+    '<h3>Load-Outs</h3>' +
+    '<p><strong>Field Kit</strong></p>' +
+    '<table><tr><th>Item</th><th>Weight</th><th>Cost</th></tr>' +
+    '<tr><td><strong>Rope</strong></td><td>5 lb</td><td>$10</td></tr></table>' +
+    '<p><strong>Dress Kit</strong></p>' +
+    '<table><tr><th>Item</th><th>Weight</th><th>Cost</th></tr>' +
+    '<tr><td>Cravat</td><td>0 lb</td><td>$5</td></tr></table>';
+  const section = { title: 'Equipment', id: 'equipment', html };
+
+  it('bold inside a load-out table cell is not read as a load-out name', () => {
+    const model = parseGurps({}, [section]);
+    const names = model.equipment.loadouts.map(l => l.name);
+    // Pre-fix, the in-cell <strong>Rope</strong> was captured as a name and shifted the
+    // name->table alignment, mislabeling the second load-out.
+    assert.deepStrictEqual(names, ['Field Kit', 'Dress Kit']);
+  });
+});
+
 // parseChains: list-form parser (rendered markdown strips ** to plain text)
 describe('parseGurps — parseChains list form', () => {
   const { extractSections } = require('../../../lib/processor');

--- a/tools/publish/test/unit/manifest.test.js
+++ b/tools/publish/test/unit/manifest.test.js
@@ -104,6 +104,24 @@ describe('parseManifest', () => {
       'Characters/NPCs/Secret Villain.md',
     ]);
   });
+
+  it('parses excluded paths in the documented `- [x] path — reason` checkbox format', () => {
+    // This is the format publish-site/references/content-filtering.md actually generates —
+    // the leading `- [x]` and trailing `— reason` must both be stripped to a clean path.
+    const md = [
+      '---',
+      'excluded: 2',
+      '---',
+      '',
+      '## Excluded (2 files)',
+      '',
+      '- [x] Sessions/Session 7.md — prep',
+      '- [x] Sessions/Session 8.md — prep',
+    ].join('\n');
+
+    const result = parseManifest(md);
+    assert.deepStrictEqual(result.excluded, ['Sessions/Session 7.md', 'Sessions/Session 8.md']);
+  });
 });
 
 describe('loadManifest', () => {

--- a/tools/publish/test/unit/manifest.test.js
+++ b/tools/publish/test/unit/manifest.test.js
@@ -80,6 +80,29 @@ describe('parseManifest', () => {
     assert.deepStrictEqual(result.publishing, []);
     assert.deepStrictEqual(result.needsDecision, []);
     assert.deepStrictEqual(result.resolved, []);
+    assert.deepStrictEqual(result.excluded, []);
+  });
+
+  it('parses excluded file paths, skipping the Reason category bullets', () => {
+    const md = [
+      '---',
+      'generated: 2026-04-18T14:30:00Z',
+      'excluded: 2',
+      '---',
+      '',
+      '## Excluded (2 files)',
+      '',
+      '- Reason: prep',
+      '  - Sessions/Planned Session.md',
+      '- Reason: GM override',
+      '  - Characters/NPCs/Secret Villain.md — kept off-site',
+    ].join('\n');
+
+    const result = parseManifest(md);
+    assert.deepStrictEqual(result.excluded, [
+      'Sessions/Planned Session.md',
+      'Characters/NPCs/Secret Villain.md',
+    ]);
   });
 });
 


### PR DESCRIPTION
A publish-site bug-sweep closing five open issues. Plugin 1.8.38, publish tool 1.11.14. **1199/1199 publish tests pass**; every fix has tests, and two code-review passes were run (the second surfaced three real findings in the #101 work, all fixed — see below).

## Fixes

**#118 — inbox `pull` crashed on any missing/orphaned KV key.** wrangler's missing-key 404 embeds the REST endpoint URL (`.../namespaces/<id>/values/<key>`), and the `namespaces` substring tripped the `namespace` operational signal, so every absent key threw instead of returning `null` — one orphaned `config:req-index` id took down the whole at-table queue. Classify on the human-readable prose only (URLs stripped first). + regression test.

**#119 — GURPS ranged to-hit was inert.** The Ranged Attacks table now wraps the trailing skill number in `<span class="wp-tohit">` and adds `data-weapon-key` per row (mirroring melee), and `buildWeapons` feeds ranged weapons into the live to-hit map (parry `null`). No client change needed.

**#101 — a played session absent from the manifest silently didn't publish.** The manifest is an allowlist and session-wrapup never registers the files it writes, so the landing "Latest Session" pointed at the previous session while showing the new date. The build now warns (player mode only — the one mode the allowlist is enforced) on a `session`/`session_wrap`/`chapter` file in neither the manifest's Publishing nor Excluded list. The manifest parser now reads the Excluded section (both the documented `- [x] path — reason` checkbox format and the grouped `- Reason:` form).

**#106 — GURPS Load-Outs had no template guidance or migration.** Legacy sheets used ad-hoc equipment sections that silently rendered nothing. Documented a worked `### Load-Outs` example in `pc-gurps-4e.md`, added a migration to detect/convert legacy sections, and hardened the load-out-name parser so bold inside a table cell can no longer be read as a load-out name (name scan runs on table-stripped HTML).

**#107 — CoC sheets that diverge from the documented body structure rendered mostly blank silently.** `renderCoCSheet` now reports a warning when no characteristics parse (`## Stat Sheet` → `### Characteristics` didn't match), surfaced at build time; a migration detects divergent sheets to convert or flag.

## Review findings addressed

The #101 fix went through a second review that caught: (1) the Excluded parser only handled the grouped format and would have false-warned on every deliberately-excluded session in the documented checkbox format; (2) the warning wasn't mode-gated and would have lied in full/GM mode; (3) a test that used the non-generated Excluded format. All three fixed, with tests in the documented format and a full-mode silence test.

## Verification

- Publish suite: 1199/1199 (added 9 tests)
- `validate_schema.py`: 41 files pass · markdownlint clean

Closes #118
Closes #119
Closes #101
Closes #106
Closes #107