### PR TITLE
Relationship-ontology cluster: land the ontology, enforce it, author against it (#124 #123 #120)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.38",
+  "version": "1.8.39",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Validate content filtering rules
         run: python scripts/validate_schema.py filtering tests/benchmark-campaign
 
+      - name: Validate relationship-ontology copies agree
+        run: python scripts/validate_ontology.py
+
       - name: PC entity-sheet freshness regression
         run: python tests/test_pc_freshness.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Validate relationship-ontology copies agree
         run: python scripts/validate_ontology.py
 
+      - name: Plan leads_to field validation
+        run: python tests/test_plan_leads_to.py
+
       - name: PC entity-sheet freshness regression
         run: python tests/test_pc_freshness.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.39] — 2026-07-20
+
+The relationship-ontology cluster: land the ontology, enforce it, author against it.
+
+### Added
+
+- `skills/shared/gm-apprentice-ontology.json` — the reconciled relationship-ontology export (77 predicates + the mobRPG projection: `mobrpg_event_type` and `mobrpg_relation_type`), landed on main from the previously-gitignored prototype directory. `entity-schema.md` is the authoritative vocabulary; this export is generated from it (#124).
+- `scripts/validate_ontology.py`, wired into CI — fails the build if the predicate set in `entity-schema.md` and the ontology export ever diverge, or if a predicate's mobRPG mapping falls outside the declared enums. This is the drift check the three-copies problem needed (#123).
+- `skills/shared/relationship-normalization.md` — one narrative-verb → sanctioned-predicate and inverse-normalization table (`owned_by A→B` ⇒ `owns B→A`), shared by the skills that write relationship edges and the QA pass that repairs them.
+
+### Changed
+
+- Relationship-writing skills now author `type:` from the controlled vocabulary instead of freeform-inventing predicates (which left ~a third of a real vault's edges off-ontology and pushed junk Generic nodes to mobRPG): session-wrapup, session-play, the-midwife handoff, and campaign-organizer's repair path all point at `_meta/relationship-types.md` + the normalization map (#120).
+- campaign-qa graph-health gains a strict **vocabulary-conformance** check — off-vocabulary, inverse-stored (wrong-direction), blank/malformed, and non-entity-target edges — separate from the existing vagueness/duplication checks (#120, #123).
+- `entity-schema.md` now documents the authority relationship (schema is the source of truth; the JSON export is generated) and resolves the Sequencing question: `leads_to`/`precedes`/`alternative_to` are clue frontmatter / narrative flow, not relationship predicates.
+
+---
+
 ## [1.8.38] — 2026-07-20
 
 Publish tool 1.11.14. A publish-site bug-sweep.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,9 @@ The relationship-ontology cluster: land the ontology, enforce it, author against
 - `scripts/validate_ontology.py`, wired into CI — fails the build if the predicate set in `entity-schema.md` and the ontology export ever diverge, or if a predicate's mobRPG mapping falls outside the declared enums. This is the drift check the three-copies problem needed (#123).
 - `skills/shared/relationship-normalization.md` — one narrative-verb → sanctioned-predicate and inverse-normalization table (`owned_by A→B` ⇒ `owns B→A`), shared by the skills that write relationship edges and the QA pass that repairs them.
 
-### Changed
-
 - Relationship-writing skills now author `type:` from the controlled vocabulary instead of freeform-inventing predicates (which left ~a third of a real vault's edges off-ontology and pushed junk Generic nodes to mobRPG): session-wrapup, session-play, the-midwife handoff, and campaign-organizer's repair path all point at `_meta/relationship-types.md` + the normalization map (#120).
 - campaign-qa graph-health gains a strict **vocabulary-conformance** check — off-vocabulary, inverse-stored (wrong-direction), blank/malformed, and non-entity-target edges — separate from the existing vagueness/duplication checks (#120, #123).
-- `entity-schema.md` now documents the authority relationship (schema is the source of truth; the JSON export is generated) and resolves the Sequencing question: `leads_to`/`precedes`/`alternative_to` are clue frontmatter / narrative flow, not relationship predicates.
+- `entity-schema.md` now documents the authority relationship (schema is the source of truth; the JSON export is generated) and resolves the Sequencing question. Narrative sequencing is not a relationship predicate — it is **node-based flow** (Alexandrian node design / Twine's passage graph), modelled as a **`leads_to` frontmatter field** (an array of wiki-links; two or more targets is a branch). The Clue type already carried `leads_to`; this adds the same field to the **Plan** type (schema, `plan.md` template, `validate_schema.py`, and a migration converting legacy `precedes`/`alternative_to`/`leads_to` sequencing edges onto it). session-prep reads it to find the next plan node(s)/branches. `precedes` folds into `leads_to`; `alternative_to` is emergent from multiple targets — neither is a predicate or a field.
 
 ---
 

--- a/scripts/validate_ontology.py
+++ b/scripts/validate_ontology.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Validate that the relationship-ontology copies agree (issue #123).
+
+The relationship vocabulary is the contract between gm-apprentice and mobRPG,
+and it exists in more than one place. `skills/shared/entity-schema.md` is the
+authoritative, human-authored source of truth; `skills/shared/gm-apprentice-ontology.json`
+is the machine-readable export that adds the mobRPG projection on top. Nothing
+used to check that the two agree, so vocabulary drift was only ever caught by a
+human noticing.
+
+This check fails when:
+  * the predicate set in entity-schema.md differs from the ontology export in
+    either direction;
+  * a predicate's `mobrpg_event_type` / `mobrpg_relation_type` is not a member
+    of the corresponding enum in the export.
+
+It warns (without failing) when an enum value is unreachable from any predicate
+— a mobRPG-projection observation that is deliberately not a hard error, since
+the enum documents mobRPG's own fixed event types.
+
+Scope: this validates the two in-repo copies. A vault's per-campaign
+`_meta/relationship-types.md` is a genre-filtered subset checked at vault time by
+campaign-qa's graph-health step (issue #120), not here. The mobRPG CLI's derived
+tables live on the (unmerged, gitignored) mobrpg-cli branch and are out of scope.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCHEMA = REPO / "skills" / "shared" / "entity-schema.md"
+ONTOLOGY = REPO / "skills" / "shared" / "gm-apprentice-ontology.json"
+
+
+def schema_predicates(text: str) -> set[str]:
+    """Parse the predicate vocabulary from entity-schema.md's category table.
+
+    The table is `| Category | Types |` rows where the Types cell is a
+    comma-separated predicate list, ending before the 'Each type has an inverse'
+    paragraph.
+    """
+    block = re.search(r"\| Category \| Types \|(.*?)Each type has an", text, re.S)
+    if not block:
+        raise SystemExit("ERROR: could not locate the predicate category table in entity-schema.md")
+    preds: set[str] = set()
+    for line in block.group(1).splitlines():
+        if "|" not in line or "---" in line or "Types" in line:
+            continue
+        cells = [c.strip() for c in line.split("|") if c.strip()]
+        if len(cells) != 2:
+            continue
+        for t in cells[1].split(","):
+            t = t.strip()
+            if t:
+                preds.add(t)
+    return preds
+
+
+def main() -> int:
+    if not SCHEMA.exists():
+        raise SystemExit(f"ERROR: missing {SCHEMA}")
+    if not ONTOLOGY.exists():
+        raise SystemExit(f"ERROR: missing {ONTOLOGY}")
+
+    schema_preds = schema_predicates(SCHEMA.read_text())
+    ontology = json.loads(ONTOLOGY.read_text())
+    ont_preds = {p["type"] for p in ontology["predicates"]}
+
+    errors: list[str] = []
+
+    missing_from_ontology = sorted(schema_preds - ont_preds)
+    if missing_from_ontology:
+        errors.append(
+            "predicates in entity-schema.md but missing from the ontology export: "
+            + ", ".join(missing_from_ontology)
+        )
+    missing_from_schema = sorted(ont_preds - schema_preds)
+    if missing_from_schema:
+        errors.append(
+            "predicates in the ontology export but missing from entity-schema.md: "
+            + ", ".join(missing_from_schema)
+        )
+
+    event_enum = set(ontology.get("mobrpg_event_type_enum", []))
+    relation_enum = set(ontology.get("mobrpg_relation_type_enum", [])) | {None}
+    used_events = set()
+    for p in ontology["predicates"]:
+        ev = p.get("mobrpg_event_type")
+        rel = p.get("mobrpg_relation_type")
+        if ev is not None:
+            used_events.add(ev)
+            if ev not in event_enum:
+                errors.append(f"predicate {p['type']!r} has mobrpg_event_type {ev!r} not in mobrpg_event_type_enum")
+        if rel not in relation_enum:
+            errors.append(f"predicate {p['type']!r} has mobrpg_relation_type {rel!r} not in mobrpg_relation_type_enum")
+
+    unreachable = sorted(event_enum - used_events - {"Generic"})
+    for value in unreachable:
+        print(f"  WARN  mobrpg_event_type {value!r} is in the enum but no predicate reifies to it")
+
+    print("=" * 50)
+    print(f"entity-schema.md predicates : {len(schema_preds)}")
+    print(f"ontology export predicates  : {len(ont_preds)}")
+    if errors:
+        for e in errors:
+            print(f"  ERROR {e}")
+        print(f"\nOntology validation FAILED with {len(errors)} error(s).")
+        return 1
+    print("Ontology copies agree. All checks passed!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_ontology.py
+++ b/scripts/validate_ontology.py
@@ -11,6 +11,7 @@ human noticing.
 This check fails when:
   * the predicate set in entity-schema.md differs from the ontology export in
     either direction;
+  * the set of predicates marked symmetric differs between the two copies;
   * a predicate's `mobrpg_event_type` / `mobrpg_relation_type` is not a member
     of the corresponding enum in the export.
 
@@ -58,6 +59,14 @@ def schema_predicates(text: str) -> set[str]:
     return preds
 
 
+def schema_symmetric(text: str) -> set[str]:
+    """Parse the '**Symmetric types** …:' comma/newline list from entity-schema.md."""
+    block = re.search(r"\*\*Symmetric types\*\*[^:]*:\n(.*?)\n\n", text, re.S)
+    if not block:
+        raise SystemExit("ERROR: could not locate the Symmetric types list in entity-schema.md")
+    return {t.strip() for t in re.split(r"[,\n]", block.group(1)) if t.strip()}
+
+
 def main() -> int:
     if not SCHEMA.exists():
         raise SystemExit(f"ERROR: missing {SCHEMA}")
@@ -82,6 +91,19 @@ def main() -> int:
             "predicates in the ontology export but missing from entity-schema.md: "
             + ", ".join(missing_from_schema)
         )
+
+    # Attribute agreement: the two copies must also agree on which predicates are
+    # symmetric (a consumer that stores a symmetric edge once must not disagree with one
+    # that stores an inverse). Catches the class of drift the set check alone would miss.
+    schema_sym = schema_symmetric(SCHEMA.read_text())
+    ont_sym = {p["type"] for p in ontology["predicates"] if p.get("symmetric")}
+    if schema_sym != ont_sym:
+        sym_only_schema = sorted(schema_sym - ont_sym)
+        sym_only_ont = sorted(ont_sym - schema_sym)
+        if sym_only_schema:
+            errors.append("symmetric in entity-schema.md but not in the ontology export: " + ", ".join(sym_only_schema))
+        if sym_only_ont:
+            errors.append("symmetric in the ontology export but not in entity-schema.md: " + ", ".join(sym_only_ont))
 
     event_enum = set(ontology.get("mobrpg_event_type_enum", []))
     relation_enum = set(ontology.get("mobrpg_relation_type_enum", [])) | {None}

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -206,6 +206,19 @@ def validate_file(filepath: Path) -> list[str]:
                     f"Invalid plan_type '{value}' — "
                     f"must be one of: {', '.join(sorted(PLAN_TYPES))}"
                 )
+        # leads_to: optional node-based sequencing — array of wiki-links to the
+        # plan node(s) this one leads to (2+ targets = a branch). Absent is fine.
+        if "leads_to" in frontmatter and frontmatter["leads_to"] is not None:
+            value = frontmatter["leads_to"]
+            if not isinstance(value, list):
+                errors.append("Field 'leads_to' must be an array of wiki-links")
+            else:
+                for item in value:
+                    if not isinstance(item, str) or "[[" not in item:
+                        errors.append(
+                            f"Field 'leads_to' entries must be wiki-links "
+                            f"(e.g. \"[[Plan Name]]\"), got {item!r}"
+                        )
 
     # Validate portrait field — only allowed for supported entity types
     portrait = frontmatter.get("portrait")

--- a/skills/campaign-organizer/references/graph-hygiene.md
+++ b/skills/campaign-organizer/references/graph-hygiene.md
@@ -12,6 +12,14 @@ that's discoverable by traversal — don't add `associated_with`.
 **Specificity.** `employs` > `associated_with`. Always use the
 most specific relationship type. Flag generic types.
 
+**Vocabulary.** Every `type:` must be a predicate in
+`_meta/relationship-types.md` (subset of `shared/entity-schema.md`).
+To place or repair an edge from a narrative verb, map it and
+normalize its direction with `shared/relationship-normalization.md`
+(`owned_by A→B` becomes `owns B→A`; store single-direction). An
+edge that isn't entity-to-entity (`appears_in <session>`) is a log
+reference — drop it, don't graph it.
+
 ## Anti-patterns
 
 - **Hub overload** — one entity connecting to everything.

--- a/skills/campaign-qa/references/checks/graph-health.md
+++ b/skills/campaign-qa/references/checks/graph-health.md
@@ -106,6 +106,35 @@ most recent `type: session_wrap` file).
 
 ### Step 5: Relationship Quality
 
+**Vocabulary conformance (strict):** Every `relationships[].type`
+in the vault must be a predicate listed in
+`_meta/relationship-types.md` (the genre-filtered projection of
+`shared/entity-schema.md`'s vocabulary). This is separate from,
+and more fundamental than, the vagueness check below — an
+invented predicate is worse than a vague one because no query,
+inverse-inference, or publish step knows about it. Flag:
+
+- **Off-vocabulary** — a `type:` not in the vocabulary at all
+  (`hosts`, `contains`, `adjacent_to`, `carved_by`, `patrols`,
+  …). Map it to the nearest sanctioned predicate via
+  `shared/relationship-normalization.md`, or drop it if it is not
+  an entity-to-entity edge.
+- **Wrong-direction / inverse stored** — an inverse form stored
+  as its own edge (`owned_by`, `employed_by`, `led_by`,
+  `works_for`). Storage is single-direction: rewrite to the base
+  predicate on the opposite endpoint (`owned_by A→B` becomes
+  `owns B→A`) and delete the duplicate.
+- **Blank or malformed** — an empty `type:`, or a mangled
+  compound like `created_owns`.
+- **Non-entity target** — an edge whose target resolves to a
+  `session_*` note or other non-entity (e.g. `appears_in`); this
+  is a log reference, not a graph edge — drop it.
+
+Report, don't auto-fix. This is the off-ontology check that a
+real vault needed (a third of one vault's edges were off-vocabulary).
+The in-repo schema↔export agreement is checked separately by
+`scripts/validate_ontology.py`.
+
 **Generic types:** Flag uses of `associated_with` or similar
 vague relationship types where a more specific type exists
 in `_meta/relationship-types.md`.

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -52,7 +52,11 @@ Table-ready — usable immediately without editing.
 After generating: **"Want me to save this to the vault?"**
 GM may defer (e.g., 3 options where players haven't chosen).
 Unsaved content flagged for wrap-up. If GM confirms, create
-vault file with `canon_status: DRAFT`.
+vault file with `canon_status: DRAFT`. Any `relationships:` edge
+takes its `type:` from the vocabulary in `_meta/relationship-types.md`
+— never an invented predicate (normalize via
+`shared/relationship-normalization.md`; deep authoring waits for
+wrap-up).
 
 If saved during play, also note the entity in the Play Notes
 file so session-wrapup picks it up.

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -113,6 +113,12 @@ already exists for the upcoming session, read it and determine
 what's already covered. Flag what needs updating vs what can
 stand. Skip gathering for sections already present unless
 Reconcile invalidated them.
+
+To find what the upcoming session should *cover*, follow the
+node graph: from the narrative-plan entity (`type: plan`) the
+last session resolved, read its `leads_to` field for the next
+plan node(s). Two or more targets are branches — surface them as
+the GM's choice, don't pick one silently.
 → Write `## Prior Prep Review` to Plan file.
 
 **7. Recap** — Present the "Previously on..." narrative recap from last

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -246,6 +246,19 @@ locations, and NPC relationships.
   it, so the marker only does its job there. Table shorthand is a hallucination
   surface — do not re-verify it forever, verify it once, here.
 
+- **Relationship edges**: when an entity's `relationships:` block
+  gains an edge, every `type:` must come from the controlled
+  vocabulary in `_meta/relationship-types.md` (the genre-filtered
+  subset of `shared/entity-schema.md`). Play notes give narrative
+  verbs; map each to the nearest sanctioned predicate, normalize
+  inverses to the base direction (`owned_by A→B` becomes `owns
+  B→A` — store single-direction), and **drop** facts that aren't
+  entity-to-entity edges (an `appears_in <session>` is a log
+  reference, not an edge). One table drives both this and the QA
+  repair: `shared/relationship-normalization.md`. Never invent a
+  `type:` — an off-vocabulary predicate is invisible to every
+  query and pushes to mobRPG as a junk Generic node.
+
 - **Timeline**: Linked events:
   `- **{in_game_date}** — [[Event_Name]] — {summary}`.
   Inline events: `- **{in_game_date}** — {description}`.

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -521,6 +521,21 @@ suggestions to match the campaign's genre.
 For domain/range constraints and the full inverse name list,
 consult `relationship-patterns.md` in the ttrpg-expert skill.
 
+**This table is the authoritative vocabulary.** The machine-readable
+export `shared/gm-apprentice-ontology.json` restates these predicates
+and adds the mobRPG projection (`mobrpg_event_type` /
+`mobrpg_relation_type`) on top; it is generated *from* this table, not
+the other way round. `scripts/validate_ontology.py` fails CI if the two
+ever disagree. A vault's `_meta/relationship-types.md` is a
+genre-filtered **subset** of this table — never a superset. Predicates
+that appear only in a vault copy are drift, not vocabulary.
+
+**Not relationship predicates:** narrative-flow / sequencing concepts —
+`leads_to`, `precedes`, `alternative_to` — are **not** edges in this
+graph. `leads_to` is a Clue *frontmatter field* (see the Clue schema),
+and clue-to-clue flow belongs there, not in a `relationships:` block. A
+vault vocabulary that lists a `Sequencing` category invented it.
+
 ## Required Relationships
 
 | Entity Type | Required Relationship |

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -512,7 +512,8 @@ If you record `A --[employs]--> B`, the inverse
 
 **Symmetric types** (stored once, no direction):
 knows, sibling_of, spouse_of, betrothed_to, enemy_of, allied_with,
-rival_of, friend_of, borders, trades_with, alter_ego_of, nemesis_of
+at_war_with, rival_of, friend_of, borders, trades_with, alter_ego_of,
+nemesis_of, negotiated_with
 
 **Genre tags:** Each type carries tags: `universal`, `fantasy`,
 `horror`, `scifi`, `superhero`, `historical`, `romance`. Filter

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -215,7 +215,7 @@ Extraction defaults:
 | clueType | string | Physical, testimonial, etc. |
 | foundAt | string | Location discovered |
 | foundBy | string | Who found it |
-| leadsTo | array | What it reveals |
+| leads_to | array | Wiki-links to the node(s) this clue reveals (node-based sequencing; shared with Plan) |
 | reliability | string | Trustworthiness |
 | discoveryState | object | Per-PC: `{"PC": "Unknown/Rumoured/Observed/Investigated/Understood"}` |
 
@@ -527,10 +527,14 @@ consult `relationship-patterns.md` in the ttrpg-expert skill.
 export `shared/gm-apprentice-ontology.json` restates these predicates
 and adds the mobRPG projection (`mobrpg_event_type` /
 `mobrpg_relation_type`) on top; it is generated *from* this table, not
-the other way round. `scripts/validate_ontology.py` fails CI if the two
-ever disagree. A vault's `_meta/relationship-types.md` is a
-genre-filtered **subset** of this table — never a superset. Predicates
-that appear only in a vault copy are drift, not vocabulary.
+the other way round. `scripts/validate_ontology.py` fails CI when the
+two disagree on the **predicate set or the symmetric set**, and checks
+the mobRPG projection for internal enum-consistency — it does **not**
+cross-check the per-predicate mobRPG mapping values against this table,
+because the table does not carry them (that layer is authored in the
+export). A vault's `_meta/relationship-types.md` is a genre-filtered
+**subset** of this table — never a superset. Predicates that appear
+only in a vault copy are drift, not vocabulary.
 
 **Not relationship predicates:** narrative-flow / sequencing is **not**
 an edge in this relationship graph and never a `relationships:` block

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -276,6 +276,7 @@ Extraction defaults:
 | chapter | string | Wiki-link to chapter overview (`"[[Chapter_N_Overview]]"`) |
 | participants | array | Wiki-link array to NPCs, factions, creatures involved |
 | locations | array | Wiki-link array to location entities |
+| leads_to | array | Wiki-link array to the plan node(s) this one leads to (node-based sequencing; see below) |
 
 ### Document
 
@@ -458,7 +459,7 @@ listing.
 
 **Plan:** `plan_type` (arc/scene/investigation/timeline),
 `chapter` (wiki-link), `participants` (wiki-links),
-`locations` (wiki-links)
+`locations` (wiki-links), `leads_to` (wiki-links)
 
 **Adventure Brief:** `scope` (campaign/one-shot/few-shot),
 `sessions_estimated`, `continuation_type` (new/new-chapter/new-arc/time-jump/prequel/parallel/new-pcs),
@@ -531,11 +532,17 @@ ever disagree. A vault's `_meta/relationship-types.md` is a
 genre-filtered **subset** of this table — never a superset. Predicates
 that appear only in a vault copy are drift, not vocabulary.
 
-**Not relationship predicates:** narrative-flow / sequencing concepts —
-`leads_to`, `precedes`, `alternative_to` — are **not** edges in this
-graph. `leads_to` is a Clue *frontmatter field* (see the Clue schema),
-and clue-to-clue flow belongs there, not in a `relationships:` block. A
-vault vocabulary that lists a `Sequencing` category invented it.
+**Not relationship predicates:** narrative-flow / sequencing is **not**
+an edge in this relationship graph and never a `relationships:` block
+entry. It is modelled the node-based way (Alexandrian node-based
+scenario design; Twine's passage graph): a **`leads_to` frontmatter
+field** — an array of wiki-links to the node(s) this one leads to — on
+both **Clue** and **Plan** entities. A node with two or more `leads_to`
+targets *is* a branch; the branching is the graph structure, so there
+is no separate `precedes` (redundant with `leads_to`) or
+`alternative_to` (emergent from multiple targets) predicate or field. A
+vault vocabulary that lists a `Sequencing` relationship category
+invented it — convert those edges to `leads_to` fields.
 
 ## Required Relationships
 

--- a/skills/shared/gm-apprentice-ontology.json
+++ b/skills/shared/gm-apprentice-ontology.json
@@ -1,0 +1,175 @@
+{
+  "$comment": "gm-apprentice knowledge-graph ontology export for the mobRPG team. Reconciled from skills/shared/entity-schema.md (authoritative) and skills/ttrpg-expert/relationship-patterns.md. mobRPG stores relationships two ways and this export describes both. mobrpg_relation_type maps a predicate onto WorldElementRelationType (Parent|Child|Link|Spouse) — a backend enum, stable across worlds. Parent/Child/Spouse are GENEALOGY between people (their only consumer is PersonService.getSiblings: find a person's parents, then their other children) and the backend auto-creates the reciprocal row for them; (S,Parent,T) reads 'S is the parent of T'. Place containment is NOT modelled with them — it is a Link, which is a single row with no reciprocal. mobrpg_event_type maps onto a reified event, whose eventTypes are per-world created classifiers. A predicate with a non-null mobrpg_relation_type is stored as a direct relation and its mobrpg_event_type does not apply; null means reify as an event. null/Generic predicates preserve their name on event.title.",
+  "version": "1.2",
+  "source_of_truth": "skills/shared/entity-schema.md",
+  "entity_types": {
+    "abstract": ["person", "character", "agent", "place", "artifact", "narrative", "world"],
+    "hierarchy": {
+      "person": ["player", "game_master", "character"],
+      "character": ["pc", "npc"],
+      "agent": ["character", "creature", "faction", "organization"],
+      "creature": ["beast", "undead", "construct", "spirit", "deity", "aberration"],
+      "organization": ["government", "corporation", "cult", "guild", "military", "criminal"],
+      "place": ["location"],
+      "artifact": ["item", "document"],
+      "item": ["weapon", "armor", "vehicle", "treasure", "relic", "tool", "consumable"],
+      "document": ["spell", "map", "letter", "prophecy", "contract", "journal"],
+      "narrative": ["event", "clue", "plan", "adventure-brief", "campaign_overview"],
+      "event": ["battle", "ritual", "disaster", "discovery", "betrayal_event", "celebration"],
+      "world": ["heritage", "world_domain", "world_flags"]
+    }
+  },
+  "edge_fields": {
+    "source": {"type": "entity_ref", "required": true},
+    "target": {"type": "entity_ref", "required": true},
+    "type": {"type": "predicate_enum", "required": true},
+    "tone": {"type": "tone_enum", "required": false},
+    "strength": {"type": "integer", "range": [1, 10], "required": false},
+    "bidirectional": {"type": "boolean", "required": false},
+    "description": {"type": "string", "required": false}
+  },
+  "tones": {
+    "positive": ["friendly", "romantic", "respectful", "professional"],
+    "negative": ["hostile", "fearful", "distrustful", "contemptuous"],
+    "neutral": ["neutral", "unknown", "complicated"]
+  },
+  "strength_scale": {"1-2": "weak", "3-4": "moderate", "5-6": "significant", "7-8": "strong", "9-10": "defining"},
+  "storage_rule": "Single-direction only; inverse is implied, not stored. Symmetric predicates stored once with bidirectional=true.",
+  "mobrpg_event_type_enum": ["Employ", "Membership", "Leadership", "Reign", "War", "Score", "Generic"],
+  "mobrpg_relation_type_enum": ["Parent", "Child", "Link", "Spouse"],
+  "required_relationships": {
+    "npc": "located_at",
+    "pc": "located_at",
+    "creature": "located_at",
+    "faction": "headquartered_at",
+    "organization": "headquartered_at"
+  },
+  "mobrpg_element_kind": {
+    "$comment": "gm-apprentice vault entity kind -> mobRPG element kind (endpoint family). `location` maps to political only as a DEFAULT: a location whose location_type is natural on the location_nature axis below routes to landfeature instead.",
+    "npc": "person",
+    "pc": "person",
+    "location": "political",
+    "faction": "organization",
+    "organization": "organization",
+    "item": "item",
+    "creature": "creature"
+  },
+  "location_nature": {
+    "$comment": "location_type is an OPEN vocabulary (free text authored per vault), so this cannot be exhaustive. It classifies the recurring, genre-general concepts onto the natural/built axis that decides mobRPG LandFeature vs Political -- the axis is ontology, the specific LandFeatureType/PoliticalType classifier is per-world and resolved in the map. Matching is exact on the normalised type, else on its head noun (last word), so 'icy planet' resolves via 'planet'. Values under natural are a suggested classifier name, not a closed enum: mobRPG's LandFeatureSubType enum is terrestrial and contains none of the celestial types, which exist as per-world classifiers. Unlisted types fall through to client heuristics and land in the map as review.",
+    "natural": {
+      "planet": "Planet",
+      "gas giant": "Planet",
+      "ice giant": "Planet",
+      "moon": "Moon",
+      "star": "Star",
+      "system": "System",
+      "star system": "System",
+      "asteroid": "Asteroid",
+      "asteroid belt": "Asteroid",
+      "anomaly": "Anomaly",
+      "nebula": "Nebula",
+      "comet": "Comet"
+    },
+    "built": [
+      "space station", "station", "spaceship", "ship", "city", "town", "village",
+      "settlement", "colony", "district", "sector", "outpost", "venue", "territory",
+      "polity", "dock", "port", "facility", "installation", "fortress", "base",
+      "gate", "starport", "trade route"
+    ]
+  },
+  "predicates": [
+    {"type": "parent_of", "inverse": "child_of", "category": "kinship", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": "Parent", "mobrpg_event_type": "Generic"},
+    {"type": "ancestor_of", "inverse": "descendant_of", "category": "kinship", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "sibling_of", "inverse": "sibling_of", "category": "kinship", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "spouse_of", "inverse": "spouse_of", "category": "kinship", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": "Spouse", "mobrpg_event_type": "Generic"},
+    {"type": "betrothed_to", "inverse": "betrothed_to", "category": "kinship", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "knows", "inverse": "knows", "category": "social", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "friend_of", "inverse": "friend_of", "category": "social", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "rival_of", "inverse": "rival_of", "category": "social", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "mentors", "inverse": "mentored_by", "category": "social", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "trusts", "inverse": "trusted_by", "category": "social", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "betrayed", "inverse": "betrayed_by", "category": "social", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "rules", "inverse": "ruled_by", "category": "power", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Reign"},
+    {"type": "employs", "inverse": "employed_by", "category": "power", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Employ"},
+    {"type": "commands", "inverse": "commanded_by", "category": "power", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Employ"},
+    {"type": "serves", "inverse": "served_by", "category": "power", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Employ"},
+    {"type": "vassal_of", "inverse": "liege_of", "category": "power", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Employ"},
+    {"type": "imprisons", "inverse": "imprisoned_by", "category": "power", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "located_at", "inverse": "location_of", "category": "spatial", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": "Link", "mobrpg_event_type": "Generic"},
+    {"type": "headquartered_at", "inverse": "headquarters_of", "category": "spatial", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": "Link", "mobrpg_event_type": "Generic"},
+    {"type": "part_of", "inverse": "has_part", "category": "spatial", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": "Link", "mobrpg_event_type": "Generic"},
+    {"type": "borders", "inverse": "borders", "category": "spatial", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": "Link", "mobrpg_event_type": "Generic"},
+    {"type": "haunts", "inverse": "haunted_by", "category": "spatial", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "owns", "inverse": "owned_by", "category": "possession", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Reign"},
+    {"type": "created", "inverse": "created_by", "category": "possession", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "wields", "inverse": "wielded_by", "category": "possession", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "seeks", "inverse": "sought_by", "category": "possession", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "discovered", "inverse": "discovered_by", "category": "knowledge", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "conceals", "inverse": "concealed_by", "category": "knowledge", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "recorded_in", "inverse": "records", "category": "knowledge", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "studies", "inverse": "studied_by", "category": "knowledge", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "enemy_of", "inverse": "enemy_of", "category": "conflict", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "War"},
+    {"type": "at_war_with", "inverse": "at_war_with", "category": "conflict", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "War"},
+    {"type": "conspires_against", "inverse": "conspired_against_by", "category": "conflict", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "War"},
+    {"type": "allied_with", "inverse": "allied_with", "category": "conflict", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "member_of", "inverse": "has_member", "category": "affiliation", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Membership"},
+    {"type": "founded", "inverse": "founded_by", "category": "affiliation", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Membership"},
+    {"type": "leads", "inverse": "led_by", "category": "affiliation", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Leadership"},
+    {"type": "defected_from", "inverse": "lost_member", "category": "affiliation", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Membership"},
+    {"type": "infiltrates", "inverse": "infiltrated_by", "category": "affiliation", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Membership"},
+
+    {"type": "bound_to", "inverse": "binds", "category": "supernatural", "symmetric": false, "genre": ["fantasy", "horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "cursed_by", "inverse": "cursed", "category": "supernatural", "symmetric": false, "genre": ["fantasy", "horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "summoned", "inverse": "summoned_by", "category": "supernatural", "symmetric": false, "genre": ["fantasy", "horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "worships", "inverse": "worshipped_by", "category": "supernatural", "symmetric": false, "genre": ["fantasy", "horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "corrupted_by", "inverse": "corrupted", "category": "supernatural", "symmetric": false, "genre": ["fantasy", "horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "caused", "inverse": "caused_by", "category": "temporal", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "triggered", "inverse": "triggered_by", "category": "temporal", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "participated_in", "inverse": "had_participant", "category": "temporal", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "witnessed", "inverse": "witnessed_by", "category": "temporal", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "trades_with", "inverse": "trades_with", "category": "economic", "symmetric": true, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "supplies", "inverse": "supplied_by", "category": "economic", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Employ"},
+    {"type": "finances", "inverse": "financed_by", "category": "economic", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "indebted_to", "inverse": "creditor_of", "category": "economic", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "murdered", "inverse": "murdered_by", "category": "event", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "poisoned", "inverse": "poisoned_by", "category": "event", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "wounded", "inverse": "wounded_by", "category": "event", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "rescued", "inverse": "rescued_by", "category": "event", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "captured", "inverse": "captured_by", "category": "event", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "deceived", "inverse": "deceived_by", "category": "event", "symmetric": false, "genre": ["universal"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "possessed_by", "inverse": "possesses", "category": "horror", "symmetric": false, "genre": ["horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "infected_by", "inverse": "infected", "category": "horror", "symmetric": false, "genre": ["horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "fears", "inverse": "feared_by", "category": "horror", "symmetric": false, "genre": ["horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "feeds_on", "inverse": "fed_upon_by", "category": "horror", "symmetric": false, "genre": ["horror"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "courts", "inverse": "courted_by", "category": "romance", "symmetric": false, "genre": ["romance"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "rejected", "inverse": "rejected_by", "category": "romance", "symmetric": false, "genre": ["romance"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "disguised_as", "inverse": "disguise_of", "category": "romance", "symmetric": false, "genre": ["romance"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "blackmails", "inverse": "blackmailed_by", "category": "romance", "symmetric": false, "genre": ["romance"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "conquered", "inverse": "conquered_by", "category": "historical", "symmetric": false, "genre": ["historical"], "mobrpg_relation_type": null, "mobrpg_event_type": "War"},
+    {"type": "exiled_from", "inverse": "exiled", "category": "historical", "symmetric": false, "genre": ["historical"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "succeeded", "inverse": "preceded", "category": "historical", "symmetric": false, "genre": ["historical"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "negotiated_with", "inverse": "negotiated_with", "category": "historical", "symmetric": true, "genre": ["historical"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "uploaded_to", "inverse": "upload_source_of", "category": "scifi", "symmetric": false, "genre": ["scifi"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "augmented_by", "inverse": "augments", "category": "scifi", "symmetric": false, "genre": ["scifi"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "cloned_from", "inverse": "clone_source_of", "category": "scifi", "symmetric": false, "genre": ["scifi"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "hacked", "inverse": "hacked_by", "category": "scifi", "symmetric": false, "genre": ["scifi"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+
+    {"type": "alter_ego_of", "inverse": "alter_ego_of", "category": "superhero", "symmetric": true, "genre": ["superhero"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "empowered_by", "inverse": "empowers", "category": "superhero", "symmetric": false, "genre": ["superhero"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"},
+    {"type": "nemesis_of", "inverse": "nemesis_of", "category": "superhero", "symmetric": true, "genre": ["superhero"], "mobrpg_relation_type": null, "mobrpg_event_type": "Generic"}
+  ]
+}

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -513,10 +513,21 @@ these are flags-and-conversions the GM confirms, not automatic rewrites.
 ## Migration: 1.8.38 → 1.8.39
 
 Resolves the long-open Sequencing question. `leads_to`, `precedes`, and
-`alternative_to` were added as relationship predicates in 1.7.0, but they
-are **not** graph edges — they are narrative flow. This reverses that
-addition so the relationship vocabulary is single-sourced from
-`shared/entity-schema.md` and enforced by `scripts/validate_ontology.py`.
+`alternative_to` were added as relationship *predicates* in 1.7.0, but
+narrative flow is not a relationship edge — it is node-based sequencing
+(Alexandrian node design; Twine's passage graph). This reverses the
+predicate addition so the relationship vocabulary is single-sourced from
+`shared/entity-schema.md` and enforced by `scripts/validate_ontology.py`,
+and re-homes sequencing onto a **`leads_to` frontmatter field** on Plan
+entities (the Clue type already carries `leads_to`).
+
+### Structural
+
+- **New Plan field `leads_to`** — an array of wiki-links to the plan
+  node(s) a plan leads to (two or more targets = a branch). Optional;
+  absent means a terminal/unlinked node. Added to `shared/templates/plan.md`
+  and the schema; existing plans work unmigrated (absent field). session-prep
+  reads it to find the next plan(s)/branches when preparing.
 
 ### Content
 
@@ -524,12 +535,14 @@ addition so the relationship vocabulary is single-sourced from
   the `Sequencing` category (`leads_to`, `precedes`, `alternative_to`)
   from `_meta/relationship-types.md`; it is not in the authoritative
   schema, so a vault carrying it is a superset, not a subset. Then
-  convert any existing edges that used them:
+  convert any existing edges that used them to node fields:
   - `leads_to` on a **clue** → the clue's `leads_to` *frontmatter field*
     (clue-to-clue flow lives there, per the Clue schema).
-  - `precedes` / `alternative_to` between **plans** → express in the
-    plan's narrative body (which plan follows or forks from which); do
-    not store as a `relationships:` edge.
+  - `leads_to` / `precedes` between **plans** → the plan's new `leads_to`
+    frontmatter field (`precedes A→B` becomes `B` in A's `leads_to`).
+  - `alternative_to` between **plans** → the two plans are alternative
+    targets of the *upstream* node: add both to that node's `leads_to`.
+    No dedicated field — branching is the graph structure.
   - Report each converted edge; never silently drop graph data.
-  Opt-in per vault. `campaign-qa` graph-health now flags these as
-  off-vocabulary until converted.
+  Opt-in per vault. `campaign-qa` graph-health now flags the off-vocabulary
+  predicates until converted.

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -244,7 +244,9 @@ Standardizes date field names across session and event entities.
 - **New relationship types:** `leads_to`, `precedes`,
   `alternative_to` added to relationship ontology for
   expressing sequencing, causation, and branching between
-  plan entities.
+  plan entities. **(Superseded by the 1.8.38 → 1.8.39
+  migration below — these are narrative flow, not graph
+  predicates, and are removed from the relationship vocabulary.)**
 
 ### Content
 
@@ -507,3 +509,27 @@ these are flags-and-conversions the GM confirms, not automatic rewrites.
   CoC PC that parses no characteristics. If `publish.site_dir` is set in
   vault-config, offer to run `npm update gm-apprentice-publish` in the
   site directory.
+
+## Migration: 1.8.38 → 1.8.39
+
+Resolves the long-open Sequencing question. `leads_to`, `precedes`, and
+`alternative_to` were added as relationship predicates in 1.7.0, but they
+are **not** graph edges — they are narrative flow. This reverses that
+addition so the relationship vocabulary is single-sourced from
+`shared/entity-schema.md` and enforced by `scripts/validate_ontology.py`.
+
+### Content
+
+- **Remove the Sequencing predicates from the vault vocabulary** — drop
+  the `Sequencing` category (`leads_to`, `precedes`, `alternative_to`)
+  from `_meta/relationship-types.md`; it is not in the authoritative
+  schema, so a vault carrying it is a superset, not a subset. Then
+  convert any existing edges that used them:
+  - `leads_to` on a **clue** → the clue's `leads_to` *frontmatter field*
+    (clue-to-clue flow lives there, per the Clue schema).
+  - `precedes` / `alternative_to` between **plans** → express in the
+    plan's narrative body (which plan follows or forks from which); do
+    not store as a `relationships:` edge.
+  - Report each converted edge; never silently drop graph data.
+  Opt-in per vault. `campaign-qa` graph-health now flags these as
+  off-vocabulary until converted.

--- a/skills/shared/relationship-normalization.md
+++ b/skills/shared/relationship-normalization.md
@@ -1,0 +1,76 @@
+# Relationship Normalization
+
+The single narrative-verb → sanctioned-predicate map, shared by the
+skills that **write** `relationships:` blocks (session-wrapup,
+session-play, the-midwife, vault-ingest) and by the skills that **audit**
+them (campaign-qa graph-health). Prevention and repair read the same
+table, so drift can't reopen.
+
+The authoritative vocabulary is the predicate table in
+`shared/entity-schema.md`; a vault's `_meta/relationship-types.md` is its
+genre-filtered subset. **Only ever write a `type:` that is in that
+vocabulary.** When a play note gives you a narrative verb, do one of three
+things, in order:
+
+1. **Map it** to the nearest sanctioned predicate (below).
+2. **Normalize its direction** if it is an inverse (below) — storage is
+   single-direction.
+3. **Drop it** if it is not an entity-to-entity edge (below).
+
+## Normalize inverses to the base direction
+
+Storage is single-direction: record the base predicate on the opposite
+endpoint, never the inverse as its own edge.
+
+| Written as (inverse/synonym) | Store as |
+|------------------------------|----------|
+| `owned_by A → B` | `owns B → A` |
+| `employed_by` / `works_for A → B` | `employs B → A` |
+| `led_by A → B` | `leads B → A` |
+| `ruled_by A → B` | `rules B → A` |
+| `commanded_by A → B` | `commands B → A` |
+| `located_in` / `hosted_by A → B` | `located_at A → B` |
+| `member A → B` (of a group) | `member_of A → B` |
+
+For symmetric predicates (`knows`, `allied_with`, `borders`, `enemy_of`,
+`rival_of`, `trades_with`, `sibling_of`, `spouse_of`, …) store once with
+`bidirectional: true`, either direction.
+
+## Map narrative verbs to sanctioned predicates
+
+Non-exhaustive — extend by category, never by inventing a new `type:`.
+
+| Narrative verb(s) | Sanctioned predicate |
+|-------------------|----------------------|
+| hosts, contains, part of, inside, within | `part_of` (child → parent) |
+| adjacent to, next to, connects to | `borders` |
+| stationed at, lives at, based at, appears at *(a place)* | `located_at` |
+| HQ'd at, operates from | `headquartered_at` |
+| carved by, forged by, built by, wrote, authored | `created` |
+| carries, holds, bears, piloted by *(→ owner)* | `owns` / `wields` |
+| serves under, reports to, assigned by | `serves` / `commands` (base direction) |
+| raided, assaulted, attacked, besieged | `at_war_with` / `conquered` |
+| deceives, misled, tricked, lied to | `deceived` |
+| investigated by, questioned, interrogated | *usually not an edge — see below* |
+| has intelligence on, spies on, watches | `infiltrates` / `studies` |
+
+If no predicate is close, prefer the most general in the right category
+over inventing one, and leave a `description:` that keeps the specific
+verb for a human reader.
+
+## Not graph edges — drop them
+
+Some play-note facts are narrative, not entity-to-entity relationships.
+Do not force them into the graph:
+
+- **`appears_in <session_*>`** and any edge whose target is a session /
+  scene / play-notes file — that is a log reference, not an entity edge.
+- **One-off actions** with no lasting structural meaning (`threatened`,
+  `marked`, `released_in`, `encountered_by`) — capture them in the
+  entity's prose or a timeline event, not as an edge.
+- **Sequencing** (`leads_to`, `precedes`, `alternative_to`) — clue-to-clue
+  flow lives in the Clue's `leads_to` **frontmatter field**, never a
+  `relationships:` block (see `entity-schema.md`).
+
+When in doubt, a fact is an edge only if a graph query would want to
+traverse it. Otherwise it is prose.

--- a/skills/shared/relationship-normalization.md
+++ b/skills/shared/relationship-normalization.md
@@ -68,9 +68,11 @@ Do not force them into the graph:
 - **One-off actions** with no lasting structural meaning (`threatened`,
   `marked`, `released_in`, `encountered_by`) — capture them in the
   entity's prose or a timeline event, not as an edge.
-- **Sequencing** (`leads_to`, `precedes`, `alternative_to`) — clue-to-clue
-  flow lives in the Clue's `leads_to` **frontmatter field**, never a
-  `relationships:` block (see `entity-schema.md`).
+- **Sequencing / branching** (`leads_to`, `precedes`, `alternative_to`) —
+  node-based narrative flow lives in the **`leads_to` frontmatter field** on
+  Clue and Plan entities (an array of wiki-links; two or more targets is a
+  branch), never a `relationships:` block. `precedes` folds into `leads_to`;
+  `alternative_to` is emergent from multiple targets (see `entity-schema.md`).
 
 When in doubt, a fact is an edge only if a graph query would want to
 traverse it. Otherwise it is prose.

--- a/skills/shared/templates/plan.md
+++ b/skills/shared/templates/plan.md
@@ -13,6 +13,8 @@ chapter: "[[]]"
 campaign: "[[Campaign_Overview_Updated]]"
 participants: []
 locations: []
+leads_to: []                # wiki-links to the plan node(s) this leads to
+                            # (node-based sequencing; 2+ targets = a branch)
 relationships:
   - target: "[[]]"
     type: ""

--- a/skills/the-midwife/references/scaffold-handoff.md
+++ b/skills/the-midwife/references/scaffold-handoff.md
@@ -80,9 +80,13 @@ For each approved plan:
      factions, and creatures mentioned in the plan
    - Populate `locations` with wiki-links to locations
      mentioned in the plan
-   - Add `relationships` between plans where sequencing
-     or branching exists (e.g., `leads_to`, `precedes`,
-     `alternative_to`)
+   - Express any sequencing or branching between plans (which
+     plan follows or forks from which) in the plan's narrative
+     body — **not** as `relationships:` edges.
+     `leads_to`/`precedes`/`alternative_to` are narrative flow,
+     not graph predicates (see `shared/entity-schema.md`). A
+     genuine `relationships:` edge on a plan takes its `type:`
+     from the controlled vocabulary in `_meta/relationship-types.md`.
    - **Preserve the body prose verbatim.** Carry the full
      narrative content across unchanged; only adapt section
      headers to the plan type and add `[[wiki-links]]`. Do not

--- a/skills/the-midwife/references/scaffold-handoff.md
+++ b/skills/the-midwife/references/scaffold-handoff.md
@@ -80,13 +80,14 @@ For each approved plan:
      factions, and creatures mentioned in the plan
    - Populate `locations` with wiki-links to locations
      mentioned in the plan
-   - Express any sequencing or branching between plans (which
-     plan follows or forks from which) in the plan's narrative
-     body — **not** as `relationships:` edges.
-     `leads_to`/`precedes`/`alternative_to` are narrative flow,
-     not graph predicates (see `shared/entity-schema.md`). A
-     genuine `relationships:` edge on a plan takes its `type:`
-     from the controlled vocabulary in `_meta/relationship-types.md`.
+   - Record sequencing/branching between plans in the plan's
+     `leads_to` frontmatter field (wiki-links to the plan node(s)
+     this one leads to; two or more targets is a branch) —
+     **not** as `relationships:` edges. Node-based flow is a
+     `leads_to` field, not a graph predicate (see
+     `shared/entity-schema.md`). A genuine `relationships:` edge
+     on a plan takes its `type:` from the controlled vocabulary
+     in `_meta/relationship-types.md`.
    - **Preserve the body prose verbatim.** Carry the full
      narrative content across unchanged; only adapt section
      headers to the plan type and add `[[wiki-links]]`. Do not

--- a/skills/the-midwife/references/scaffold-handoff.md
+++ b/skills/the-midwife/references/scaffold-handoff.md
@@ -37,7 +37,11 @@ Which should I create as vault entities?"
 
 Approved entities are filed by campaign-organizer to the
 correct vault folders with proper frontmatter. Do not
-auto-promote — the GM chooses.
+auto-promote — the GM chooses. Any `relationships:` edge on a
+promoted entity takes its `type:` from the vocabulary in
+`_meta/relationship-types.md` (subset of `shared/entity-schema.md`);
+map narrative verbs and normalize inverses via
+`shared/relationship-normalization.md` — never invent a predicate.
 
 **2b. Plan promotion** — List all topic files from
 `_midwife/{adventure}/` that contain narrative planning

--- a/tests/test_plan_leads_to.py
+++ b/tests/test_plan_leads_to.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regression test for the Plan `leads_to` field validation (node-based sequencing).
+
+`leads_to` is optional on plan entities; when present it must be an array of
+wiki-links to the plan node(s) this one leads to. Verifies validate_schema.py
+accepts valid/absent forms and rejects malformed ones.
+"""
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+
+SPEC = importlib.util.spec_from_file_location(
+    "validate_schema",
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "validate_schema.py",
+)
+vs = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(vs)
+
+FAILURES = []
+
+
+def leads_to_errors(fragment: str) -> list[str]:
+    """Validate a plan file with the given leads_to fragment; return only leads_to errors."""
+    fm = "type: plan\nplan_type: scene\ncanon_status: DRAFT\nchapter: \"[[Chapter 1]]\""
+    if fragment:
+        fm += "\n" + fragment
+    path = pathlib.Path(tempfile.mktemp(suffix=".md"))
+    path.write_text(f"---\n{fm}\n---\n\nbody\n")
+    try:
+        return [e for e in vs.validate_file(path) if "leads_to" in e]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def check(name: str, errors: list[str], want_error: bool):
+    got_error = len(errors) > 0
+    if got_error != want_error:
+        FAILURES.append(f"{name}: expected {'an error' if want_error else 'no error'}, got {errors!r}")
+
+
+check("valid array of wiki-links", leads_to_errors('leads_to:\n  - "[[Plan B]]"\n  - "[[Plan C]]"'), False)
+check("single-target array", leads_to_errors('leads_to:\n  - "[[Plan B]]"'), False)
+check("absent field", leads_to_errors(""), False)
+check("empty array", leads_to_errors("leads_to: []"), False)
+check("non-wiki-link entry rejected", leads_to_errors("leads_to:\n  - Plan B"), True)
+check("scalar (non-array) rejected", leads_to_errors("leads_to: 7"), True)
+
+if FAILURES:
+    print(f"{len(FAILURES)} FAILURE(S):", file=sys.stderr)
+    for f in FAILURES:
+        print(f"  {f}", file=sys.stderr)
+    sys.exit(1)
+print("All plan leads_to validation tests passed.")

--- a/tests/test_plan_leads_to.py
+++ b/tests/test_plan_leads_to.py
@@ -7,6 +7,7 @@ accepts valid/absent forms and rejects malformed ones.
 """
 
 import importlib.util
+import os
 import pathlib
 import sys
 import tempfile
@@ -26,7 +27,9 @@ def leads_to_errors(fragment: str) -> list[str]:
     fm = "type: plan\nplan_type: scene\ncanon_status: DRAFT\nchapter: \"[[Chapter 1]]\""
     if fragment:
         fm += "\n" + fragment
-    path = pathlib.Path(tempfile.mktemp(suffix=".md"))
+    fd, name = tempfile.mkstemp(suffix=".md")
+    os.close(fd)
+    path = pathlib.Path(name)
     path.write_text(f"---\n{fm}\n---\n\nbody\n")
     try:
         return [e for e in vs.validate_file(path) if "leads_to" in e]


### PR DESCRIPTION
Lands the relationship ontology on main, adds drift enforcement, and makes the authoring skills adhere to it. Plugin 1.8.39.

## Background

main's `skills/shared/entity-schema.md` already carries the authoritative 77-predicate relationship vocabulary — it was verified to exactly equal the ontology export the mobRPG prototype branch had evolved to (v1.2). So the source of truth already existed and was current; what was missing was a published machine-readable artifact, any check that the copies agree, and any pointer from the skills that actually write relationship edges.

## #124 — land the ontology

- `skills/shared/gm-apprentice-ontology.json` (v1.2, 77 predicates, carrying both the `mobrpg_event_type` and `mobrpg_relation_type` projections) moved out of the gitignored `docs/prototypes/mobrpg/` prototype dir onto main, beside its source of truth.
- `entity-schema.md` now documents the authority relationship: the schema table is authoritative; the JSON export is generated from it; a vault's `_meta/relationship-types.md` is a genre-filtered **subset**.
- Resolves the Sequencing question: `leads_to`/`precedes`/`alternative_to` are clue frontmatter / narrative flow, **not** relationship predicates.

## #123 — enforcement

- `scripts/validate_ontology.py`, wired into `lint.yml`, fails CI when the predicate set **or the symmetric set** diverges between `entity-schema.md` and the ontology export, or when a predicate's mobRPG mapping falls outside the declared enums. (The symmetric-set check was added in review, after it caught `at_war_with`/`negotiated_with` drifting.)
- campaign-qa graph-health gains a strict **vocabulary-conformance** check — off-vocabulary, inverse-stored (wrong-direction), blank/malformed, and non-entity-target edges — separate from the existing vagueness/duplication checks.

**Scope note (why this closes #123):** #123's checklist splits by where the files live. Everything on `main` is done — one authoritative vocabulary, the schema↔export CI check, the QA membership check. The remaining items — deriving the mobRPG **CLI**'s lookup tables from the export and CI-checking them — require the mobRPG CLI, which lives on the unmerged `mobrpg-cli` branch (gitignored here) and is parked. Those items move with the mobRPG work when it un-parks; they are not achievable on main without reviving it.

## #120 — author against it

- Every relationship-writing skill (session-wrapup, session-play, the-midwife handoff, campaign-organizer repair) now takes `type:` from the vocabulary in `_meta/relationship-types.md` instead of freeform-inventing predicates (which had left ~a third of a real vault's edges off-ontology and pushed junk Generic nodes to mobRPG).
- `skills/shared/relationship-normalization.md` — one narrative-verb → sanctioned-predicate and inverse-normalization table (`owned_by A→B` ⇒ `owns B→A`), shared by the write side and the QA repair so prevention and repair can't reopen.

## Verification

- `validate_ontology.py`: 77 ⇔ 77 agree (verified it fails exit 1 on both an injected off-vocabulary predicate and injected symmetric drift)
- `validate_schema.py`: 41 files pass · `skill-creator quick_validate` valid on all 5 touched skills · markdownlint clean
- Code review (opus): one attribute-drift finding fixed (symmetric reconciled + the check extended to catch that class); confirmed no parked mobRPG CLI code was pulled in — only the JSON data file.

The parked mobRPG CLI stayed parked.

Closes #124
Closes #123
Closes #120