### PR TITLE
publish: group Documents index by character (about/practitioner pivot) (#96)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.39",
+  "version": "1.8.40",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.8.39] — 2026-07-20
+## [1.8.40] — 2026-07-21
+
+Publish tool 1.11.15. Documents index grouped by character (#96).
+
+### Added
+
+- The **Documents** section index now groups handouts into headed sections, one per character the document concerns — mirroring the Factions/Locations grouped-listing pattern instead of falling through to a flat A–Z card grid. The grouping key is frontmatter `about` (narrative handouts) or `practitioner` (mechanical/reference cards), resolved from a `[[wiki-link]]` to a plain name; documents with neither land in a trailing **Other Documents** group. Character groups sort alphabetically, "Other" always last, cards alphabetical within a group. Reuses the existing `intel-section`/`card-grid` styling, so no CSS changes (#96).
+- `documents` section-title key for the genre presets — scifi "Files & Dossiers", military "Dossiers & Records", horror "Documents & Evidence", fantasy "Records & Correspondence" — with an explicit `section_titles.documents` override winning over the genre default (#96).
+
+### Fixed
+
+- Grouped index filtering: when the name filter hides every card in a group, the group's heading now collapses too instead of lingering over an empty grid (#96).
 
 The relationship-ontology cluster: land the ontology, enforce it, author against it.
 

--- a/tools/publish/js/filters.js
+++ b/tools/publish/js/filters.js
@@ -4,6 +4,13 @@
   var cards = document.querySelectorAll('[data-entity-type]');
   var countEl = document.querySelector('.index-count');
   var totalCount = cards.length;
+  // The unfiltered header label, restored verbatim once a filter clears — so a page that
+  // opens with "15 documents" reverts to it instead of freezing on "Showing 15 of 15".
+  var initialCountText = countEl ? countEl.textContent : '';
+  // Grouped indexes (e.g. Documents pivoted by character) wrap cards in headed sections. When
+  // a filter hides every card in a section, its heading would otherwise linger over an empty
+  // grid, so collapse the whole section too.
+  var groupSections = document.querySelectorAll('.intel-section');
 
   var activeType = 'all';
 
@@ -26,8 +33,20 @@
       }
     });
 
+    groupSections.forEach(function(section) {
+      var sectionCards = section.querySelectorAll('[data-entity-type]');
+      if (sectionCards.length === 0) return;
+      var anyVisible = Array.prototype.some.call(sectionCards, function(card) {
+        return card.style.display !== 'none';
+      });
+      section.style.display = anyVisible ? '' : 'none';
+    });
+
     if (countEl) {
-      countEl.textContent = 'Showing ' + visible + ' of ' + totalCount;
+      var filterActive = activeType !== 'all' || nameQuery !== '';
+      countEl.textContent = filterActive
+        ? 'Showing ' + visible + ' of ' + totalCount
+        : initialCountText;
     }
   }
 

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -11,14 +11,16 @@ const GENRE_SECTION_TITLES = {
     factions: 'Intelligence Briefing',
     items: 'Armory & Acquisitions',
     creatures: 'Bestiary',
+    documents: 'Dossiers & Records',
   },
-  fantasy: { creatures: 'Bestiary' },
-  horror: { creatures: 'Bestiary' },
+  fantasy: { creatures: 'Bestiary', documents: 'Records & Correspondence' },
+  horror: { creatures: 'Bestiary', documents: 'Documents & Evidence' },
   scifi: {
     locations: 'Star Charts',
     factions: 'Powers & Interests',
     items: 'Hardware & Equipment',
     creatures: 'Xenofauna',
+    documents: 'Files & Dossiers',
   },
 };
 
@@ -27,6 +29,7 @@ const DEFAULT_SECTION_TITLES = {
   factions: 'Factions & Organizations',
   items: 'Items & Artifacts',
   creatures: 'Creatures',
+  documents: 'Documents',
 };
 
 function sectionTitle(key, publishConfig) {
@@ -583,6 +586,61 @@ function renderFactions(pages, indexDir, imageMap = {}) {
   return `<div class="intel-briefing">${sections}</div>`;
 }
 
+// Every document in a handout-heavy vault is a per-character prop, so a flat A–Z grid buries
+// the one thing a reader wants: whose file is this? Pivot on `about` (narrative handouts) or
+// `practitioner` (mechanical/reference cards), resolving a [[wiki-link]] to a plain name.
+// Documents with neither land in a trailing "Other Documents" group. Character groups sort
+// alphabetically; "Other" is always last. Reuses the faction section + generic card classes,
+// so no CSS changes are needed.
+function renderDocuments(pages, indexDir, imageMap = {}) {
+  if (pages.length === 0) return '<p class="text-muted">No documents or handouts yet.</p>';
+  const OTHER = 'Other Documents';
+
+  function groupKey(fm) {
+    let raw = fm.about || fm.practitioner || '';
+    // A handout authored with a YAML list (about: [[[A]], [[B]]]) files under its first
+    // subject rather than a single garbled "A,B" group.
+    if (Array.isArray(raw)) raw = raw[0] || '';
+    const s = String(raw).replace(/\[\[|\]\]/g, '').trim();
+    if (!s) return OTHER;
+    const parts = s.split('|');            // [[Name|Display]] -> Display
+    return (parts[1] || parts[0]).trim() || OTHER;
+  }
+
+  const byChar = {};
+  for (const p of pages) {
+    const key = groupKey(p.frontmatter);
+    (byChar[key] = byChar[key] || []).push(p);
+  }
+  const names = Object.keys(byChar).filter(n => n !== OTHER).sort((a, b) => a.localeCompare(b));
+  if (byChar[OTHER]) names.push(OTHER);
+
+  function renderCard(p) {
+    const fm = p.frontmatter;
+    const subtitle = plainMetaValue(fm.doc_kind || fm.document_type || (fm.type === 'reference' ? 'reference' : '') || '');
+    return `<a class="entity-card" href="${escapeHtml(relHref(p, indexDir))}"
+  data-entity-type="${escapeHtml(fm.doc_kind || fm.type || '')}"
+  data-entity-name="${escapeHtml(p.displayTitle)}"
+  data-entity-status="${escapeHtml(getCanonStatus(fm) || '')}">
+  <h4>${escapeHtml(p.displayTitle)}</h4>
+  ${subtitle ? `<div class="card-subtitle">${escapeHtml(subtitle)}</div>` : ''}
+</a>`;
+  }
+
+  const sections = names.map(name => {
+    const cards = byChar[name]
+      .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle))
+      .map(renderCard)
+      .join('\n');
+    return `<section class="intel-section">
+  <h2 class="intel-section-title">${escapeHtml(name)}</h2>
+  <div class="card-grid">${cards}</div>
+</section>`;
+  }).join('\n');
+
+  return `<div class="documents-page">${sections}</div>`;
+}
+
 function extractMdSections(markdown) {
   const sections = {};
   const lines = markdown.split('\n');
@@ -868,6 +926,7 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
   const isCreatures = dir === 'creatures';
   const isFactions = dir === 'factions';
   const isItems = dir === 'items';
+  const isDocuments = dir === 'documents';
   const isCampaign = dir === 'campaign';
 
   let bodyContent;
@@ -883,6 +942,8 @@ function indexTemplate(dir, label, pages, navFor, config, publishConfig, imageMa
     bodyContent = renderFactions(pages, dir, imageMap);
   } else if (isItems) {
     bodyContent = renderArmory(pages, dir);
+  } else if (isDocuments) {
+    bodyContent = renderDocuments(pages, dir, imageMap);
   } else if (isCampaign && pages.some(p => p.frontmatter.type === 'campaign_overview')) {
     // Only render the overview deep-dive (which surfaces the overview's prose) when the overview
     // is actually published. In player mode the overview is excluded as a spoiler doc, so fall
@@ -950,6 +1011,14 @@ ${bodyContent}`;
   <span class="index-count">${total} items catalogued</span>
 </div>
 ${bodyContent}`;
+  } else if (isDocuments) {
+    content = `
+<div class="index-header">
+  <h1 class="page-title">${escapeHtml(sectionTitle('documents', publishConfig))}</h1>
+  <span class="index-count">${total} document${total !== 1 ? 's' : ''}</span>
+</div>
+${nameFilterHtml}
+${bodyContent}`;
   } else if (isCampaign) {
     const overview = pages.find(p => p.frontmatter.type === 'campaign_overview');
     const campaignName = (overview && overview.frontmatter.campaign) || config.siteTitle || 'Campaign';
@@ -991,5 +1060,5 @@ ${bodyContent}`;
 
 module.exports = {
   indexTemplate, buildPillFilters, buildLocationTree, renderLocationsPage,
-  resolveLocationGrouping, partitionByPivot,
+  resolveLocationGrouping, partitionByPivot, renderDocuments,
 };

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.14",
+  "version": "1.11.15",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/documents-grouping.test.js
+++ b/tools/publish/test/unit/documents-grouping.test.js
@@ -1,0 +1,152 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { renderDocuments, indexTemplate } = require('../../lib/templates/index-page');
+
+function doc(title, fm = {}) {
+  return {
+    title,
+    displayTitle: title,
+    outputPath: `documents/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.html`,
+    frontmatter: { type: 'reference', ...fm },
+    markdown: '',
+  };
+}
+
+// The Dead End vault shape from the issue: every handout is a per-character prop, keyed on
+// `about` (narrative) or `practitioner` (mechanical/reference).
+const VAULT = [
+  doc('The Last Chart', { about: '[[Rock Lavey]]' }),
+  doc('Field Trauma Card', { practitioner: '[[Rock Lavey]]' }),
+  doc('Four-Arm Gunwork', { practitioner: '[[Ronin Sanchez]]' }),
+  doc('The Anomaly Log', { about: '[[Shackleton Magellan]]' }),
+  doc('Kumari\'s Note', { about: '[[Six]]' }),
+  doc('A Loose End', {}),
+];
+
+const render = (pages = VAULT, indexDir = 'documents') => renderDocuments(pages, indexDir);
+const idxOf = (html, needle) => html.indexOf(needle);
+
+describe('renderDocuments', () => {
+  it('shows an empty-state message when there are no documents', () => {
+    const html = render([]);
+    assert.ok(html.includes('No documents or handouts yet.'));
+  });
+
+  it('groups documents under a heading per character', () => {
+    const html = render();
+    for (const name of ['Rock Lavey', 'Ronin Sanchez', 'Shackleton Magellan', 'Six']) {
+      assert.ok(html.includes(`intel-section-title">${name}</h2>`), `heading for ${name}`);
+    }
+  });
+
+  it('pivots on practitioner when about is absent', () => {
+    const html = render([doc('Field Trauma Card', { practitioner: '[[Rock Lavey]]' })]);
+    assert.ok(html.includes('intel-section-title">Rock Lavey</h2>'));
+    assert.ok(html.includes('>Field Trauma Card</h4>'));
+  });
+
+  it('prefers about over practitioner when both are set', () => {
+    const html = render([doc('Dual', { about: '[[Six]]', practitioner: '[[Rock Lavey]]' })]);
+    assert.ok(html.includes('intel-section-title">Six</h2>'));
+    assert.ok(!html.includes('intel-section-title">Rock Lavey</h2>'));
+  });
+
+  it('resolves a [[Name|Display]] wiki-link to the display half', () => {
+    const html = render([doc('Aliased', { about: '[[rock-lavey|Rock Lavey]]' })]);
+    assert.ok(html.includes('intel-section-title">Rock Lavey</h2>'));
+    assert.ok(!html.includes('rock-lavey'));
+  });
+
+  it('sorts character groups alphabetically', () => {
+    const html = render();
+    assert.ok(idxOf(html, '>Rock Lavey<') < idxOf(html, '>Ronin Sanchez<'));
+    assert.ok(idxOf(html, '>Ronin Sanchez<') < idxOf(html, '>Shackleton Magellan<'));
+    assert.ok(idxOf(html, '>Shackleton Magellan<') < idxOf(html, '>Six<'));
+  });
+
+  it('collects documents with neither key under a trailing Other Documents group', () => {
+    const html = render();
+    assert.ok(html.includes('intel-section-title">Other Documents</h2>'));
+    // "Other Documents" always sorts last, after every named character.
+    assert.ok(idxOf(html, '>Other Documents<') > idxOf(html, '>Six<'));
+  });
+
+  it('files a list-valued about under its first subject, not a garbled combined group', () => {
+    const html = render([doc('Shared Order', { about: ['[[Six]]', '[[Rock Lavey]]'] })]);
+    assert.ok(html.includes('intel-section-title">Six</h2>'));
+    assert.ok(!html.includes('Six,'));
+    assert.ok(!html.includes('intel-section-title">Rock Lavey</h2>'));
+  });
+
+  it('treats a blank about/practitioner as Other, not an empty heading', () => {
+    const html = render([doc('Blank', { about: '   ' })]);
+    assert.ok(html.includes('intel-section-title">Other Documents</h2>'));
+    assert.ok(!html.includes('intel-section-title"></h2>'));
+  });
+
+  it('sorts cards alphabetically within a group', () => {
+    const html = render([
+      doc('Zulu File', { about: '[[Six]]' }),
+      doc('Alpha File', { about: '[[Six]]' }),
+    ]);
+    assert.ok(idxOf(html, '>Alpha File<') < idxOf(html, '>Zulu File<'));
+  });
+
+  it('renders a subtitle from doc_kind', () => {
+    const html = render([doc('Spec Sheet', { about: '[[Six]]', doc_kind: 'blueprint' })]);
+    assert.ok(html.includes('card-subtitle">blueprint</div>'));
+  });
+
+  it('reuses the already-styled section and card classes (no new CSS)', () => {
+    const html = render();
+    assert.ok(html.includes('class="documents-page"'));
+    assert.ok(html.includes('class="intel-section"'));
+    assert.ok(html.includes('class="card-grid"'));
+    assert.ok(html.includes('class="entity-card"'));
+  });
+});
+
+describe('indexTemplate — documents index wiring', () => {
+  const navFor = () => '<nav></nav>';
+  const config = { siteTitle: 'Test' };
+
+  it('routes the documents dir to the grouped renderer', () => {
+    const html = indexTemplate('documents', 'Documents', VAULT, navFor, config, { theme: {} });
+    assert.ok(html.includes('class="documents-page"'));
+    assert.ok(html.includes('intel-section-title">Six</h2>'));
+  });
+
+  it('keeps the name filter but drops pills and the sort control', () => {
+    const html = indexTemplate('documents', 'Documents', VAULT, navFor, config, { theme: {} });
+    assert.ok(html.includes('class="name-filter"'), 'name filter kept');
+    assert.ok(!html.includes('class="pill-filters"'), 'no pill filters');
+    assert.ok(!html.includes('class="sort-control"'), 'no sort control');
+  });
+
+  it('shows a document count in the header', () => {
+    const html = indexTemplate('documents', 'Documents', VAULT, navFor, config, { theme: {} });
+    assert.ok(html.includes(`${VAULT.length} documents`));
+  });
+
+  it('singularizes the count for one document', () => {
+    const html = indexTemplate('documents', 'Documents', [VAULT[0]], navFor, config, { theme: {} });
+    assert.ok(html.includes('>1 document<'));
+  });
+
+  it('uses the neutral section title with no genre preset', () => {
+    const html = indexTemplate('documents', 'Documents', VAULT, navFor, config, { theme: {} });
+    assert.ok(html.includes('<h1 class="page-title">Documents</h1>'));
+  });
+
+  it('flavors the section title under the scifi preset', () => {
+    const html = indexTemplate('documents', 'Documents', VAULT, navFor, config, { theme: {}, _genrePreset: 'scifi' });
+    assert.ok(html.includes('Files &amp; Dossiers'));
+  });
+
+  it('honors an explicit section_titles override above the genre', () => {
+    const html = indexTemplate('documents', 'Documents', VAULT, navFor, config,
+      { theme: {}, _genrePreset: 'scifi', section_titles: { documents: 'The Archive' } });
+    assert.ok(html.includes('The Archive'));
+    assert.ok(!html.includes('Files &amp; Dossiers'));
+  });
+});


### PR DESCRIPTION
Closes #96.

## Gap

The **Documents** section index had no dedicated renderer, so it fell through to the generic A–Z card grid. On a handout-heavy vault where every document is a per-character prop, that produced one flat, undifferentiated grid — no way to see which files belong to which character. Locations group by `parent_location`, Factions by `faction_type`; Documents had no equivalent pivot, and the pill filter was useless (handouts share one `type`).

## What changed

Group the Documents index into headed sections, one per character the document concerns — mirroring the Factions/Locations grouped-listing pattern.

- **Grouping key:** frontmatter `about` (narrative handouts) or `practitioner` (mechanical/reference cards), resolved from a `[[wiki-link]]` to a plain name. A `[[Name|Display]]` link resolves to the display half; a list-valued key files under its first subject.
- Documents with neither key land in a trailing **Other Documents** group.
- Character groups sort alphabetically, **Other** always last, cards alphabetical within a group.
- Reuses the already-styled `intel-section` / `card-grid` / `entity-card` classes — **no CSS changes**.

### Resolved open questions from the issue

- **Group ordering** — alphabetical (the safe deterministic default; there is no stable per-character sort source at the index layer).
- **Genre section title** — added a `documents` key to the genre presets (scifi "Files & Dossiers", military "Dossiers & Records", horror "Documents & Evidence", fantasy "Records & Correspondence"), with an explicit `section_titles.documents` override winning over the genre default.
- **Name filter with groups** — fixed: when the name filter hides every card in a group, the group's heading now collapses too instead of lingering over an empty grid. The header count also reverts to its unfiltered label ("15 documents") once the filter clears.

## Tests

- 19 new tests in `test/unit/documents-grouping.test.js` (renderer + `indexTemplate` wiring).
- Full publish suite: **1218 passing**, 0 failing.
- Empty-section hiding + count revert confirmed end-to-end.
- Verified `filters.js` change doesn't affect the Factions/Items indexes (their cards carry no `data-entity-type` / use a different section class, and neither page renders a name filter).

## Version

Plugin 1.8.39 → **1.8.40**; publish tool 1.11.14 → **1.11.15**.