### PR TITLE
Publish-site onboarding Slice 4A: Tier-1 scaffold cleanup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.44",
+  "version": "1.8.45",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.45] — 2026-07-22
+
+Publish tool 1.11.18. Tier-1 sites no longer ship the change-request inbox's
+KV binding or Cloudflare Functions.
+
+### Fixed
+
+- Tier-1 (static) sites no longer scaffold or deploy the change-request inbox's
+  KV binding or Cloudflare Functions: `gm-publish init` ships a minimal
+  `wrangler.toml` (keeping `pages_build_output_dir` for a clean bare
+  `wrangler pages deploy`) with no `[[kv_namespaces]]` block and no `functions/`,
+  and the build-time Function re-sync is gated on the site's backend flags. This
+  removes a placeholder KV binding that shipped to every site. `vault.config.json`
+  (which holds a local absolute path) is now gitignored by the scaffold.
+
 ## [1.8.44] — 2026-07-22
 
 Publish tool 1.11.17. Publish-site setup is now preflight-first and

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -229,13 +229,15 @@ working) but **no** `[[kv_namespaces]]` block — and **no** `functions/`
 directory. The KV binding and the `functions/` are added only when you opt
 into the inbox or the live status bar: either the streamlined
 `gm-publish setup-inbox` / `setup-status-bar` commands (coming in the next
-release) or the manual steps in this section, which add the `[[kv_namespaces]]`
-block and copy the Functions in for you. Already-deployed inbox sites are
-unaffected — this only changes what a brand-new site ships. Existing sites
-without the Functions yet: copy `wrangler.toml`'s `[[kv_namespaces]]` block
-and the `functions/` directory from a freshly `init`-ed site that has had the
-inbox set up (they are not build output — they live beside
-`vault.config.json`, not in `docs/`).
+release) or the manual steps in this section. Already-deployed inbox sites are
+unaffected — this only changes what a brand-new site ships.
+
+**You do not hand-copy the Functions.** Once a backend flag (`backend.inbox` or
+`backend.statusBar`) is `true` in `vault.config.json`, the next `npm run build`
+copies the plugin's Cloudflare Functions into the site's `functions/` for you (a
+Tier-1 site with both flags off gets none — they live beside `vault.config.json`,
+not in `docs/`). The manual steps below do exactly that: create the namespace,
+bind it in `wrangler.toml`, flip the flag, rebuild, deploy.
 
 The at-table **loadout** endpoint (`/api/loadout`) ships in the same
 `functions/api/` directory and **reuses this same `INBOX` KV namespace**
@@ -252,9 +254,10 @@ files, then redeploy.
 state (`{ "<key>": {v,items,hp,fp,updatedAt}, … }`) for the roster-page party
 board. It is **read-only** — it exposes only `onRequestGet`, never a write. Bound
 to the same `INBOX` KV namespace as `/api/loadout`; no new namespace or binding is
-needed. It ships alongside the other Functions once you set up the inbox or the
-live status bar; **existing sites must hand-copy** `functions/api/loadout-list.js`
-(and re-deploy) the same way they copied `functions/api/loadout.js` for SP1.
+needed. On the flag-based flow below it ships with the rebuild; a legacy site
+that hand-manages `functions/` must copy `functions/api/loadout-list.js` **and
+its `functions/api/loadout-core.mjs` dependency** (`loadout-list.js` imports it —
+skip it only if the loadout endpoint already put it there), then re-deploy.
 
 > **KV list-quota fix — existing sites must refresh the loadout + inbox Functions
 > and redeploy.** Early builds had the party board poll the list endpoint every 5
@@ -306,11 +309,33 @@ live status bar; **existing sites must hand-copy** `functions/api/loadout-list.j
    npx wrangler@4 kv namespace create INBOX
    ```
 
-   It prints an `id`. Paste that id into `wrangler.toml`, replacing
-   `PUT-YOUR-KV-NAMESPACE-ID-HERE`.
+   It prints an `id`.
 
-2. **Deploy** (with `wrangler.toml` present, the deploy bundles the Function
-   and binds KV automatically):
+2. **Bind it in `wrangler.toml`.** A minimal Tier-1 `wrangler.toml` has no KV
+   block yet — add one, pasting the id from step 1:
+
+   ```toml
+   [[kv_namespaces]]
+   binding = "INBOX"
+   id = "<paste the id from step 1>"
+   ```
+
+   (If yours is an older scaffold that still has an
+   `id = "PUT-YOUR-KV-NAMESPACE-ID-HERE"` line, replace that id instead of
+   adding a second block.)
+
+3. **Turn on the inbox flag.** In `vault.config.json`, set `inbox` to `true`:
+
+   ```json
+   "backend": { "statusBar": false, "inbox": true }
+   ```
+
+   (For the live status bar / party board, set `"statusBar": true` too — it
+   reuses the same namespace.) This is what makes the next build ship the inbox
+   chatbox **and** copy the inbox Functions into `functions/`.
+
+4. **Build and deploy.** The build copies the Functions in because a backend
+   flag is now on:
 
    ```bash
    npm run build
@@ -323,7 +348,7 @@ live status bar; **existing sites must hand-copy** `functions/api/loadout-list.j
    > is what makes the bare form required; there is nothing inbox-specific
    > about it.
 
-3. **Verify the endpoint** — with no session code set yet, a submit must be
+5. **Verify the endpoint** — with no session code set yet, a submit must be
    rejected:
 
    ```bash

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -223,17 +223,26 @@ wrangler only uploads files that changed, so repeat deploys are fast.
 The change-request inbox lets players submit sheet edits from their phones. It
 needs a KV namespace bound to your Pages project. Do this once per site.
 
-New sites scaffolded after this feature already have `wrangler.toml` and a
-`functions/` directory. Existing sites: copy `wrangler.toml` and the
-`functions/` directory from a freshly `init`-ed site into your site root
-(they are not build output — they live beside `vault.config.json`, not in
-`docs/`).
+A fresh Tier-1 site scaffolds a **minimal** `wrangler.toml` — it has
+`pages_build_output_dir` (so the bare `npx wrangler@4 pages deploy` keeps
+working) but **no** `[[kv_namespaces]]` block — and **no** `functions/`
+directory. The KV binding and the `functions/` are added only when you opt
+into the inbox or the live status bar: either the streamlined
+`gm-publish setup-inbox` / `setup-status-bar` commands (coming in the next
+release) or the manual steps in this section, which add the `[[kv_namespaces]]`
+block and copy the Functions in for you. Already-deployed inbox sites are
+unaffected — this only changes what a brand-new site ships. Existing sites
+without the Functions yet: copy `wrangler.toml`'s `[[kv_namespaces]]` block
+and the `functions/` directory from a freshly `init`-ed site that has had the
+inbox set up (they are not build output — they live beside
+`vault.config.json`, not in `docs/`).
 
 The at-table **loadout** endpoint (`/api/loadout`) ships in the same
 `functions/api/` directory and **reuses this same `INBOX` KV namespace**
 (under a `loadout:` key prefix) — no new namespace, binding, or
-`wrangler.toml` change. New sites scaffold it automatically. Existing sites
-that already set up the inbox above: copy `functions/api/loadout.js` and
+`wrangler.toml` change. Once the inbox is set up, the loadout endpoint is
+already alongside it. Existing sites that set up the inbox before the loadout
+existed: copy `functions/api/loadout.js` and
 `functions/api/loadout-core.mjs` from the scaffold alongside the inbox
 files, then redeploy.
 

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -252,9 +252,9 @@ files, then redeploy.
 state (`{ "<key>": {v,items,hp,fp,updatedAt}, … }`) for the roster-page party
 board. It is **read-only** — it exposes only `onRequestGet`, never a write. Bound
 to the same `INBOX` KV namespace as `/api/loadout`; no new namespace or binding is
-needed. Sites scaffolded with a newer `gm-publish init` get it automatically;
-**existing sites must hand-copy** `functions/api/loadout-list.js` (and re-deploy)
-the same way they copied `functions/api/loadout.js` for SP1.
+needed. It ships alongside the other Functions once you set up the inbox or the
+live status bar; **existing sites must hand-copy** `functions/api/loadout-list.js`
+(and re-deploy) the same way they copied `functions/api/loadout.js` for SP1.
 
 > **KV list-quota fix — existing sites must refresh the loadout + inbox Functions
 > and redeploy.** Early builds had the party board poll the list endpoint every 5

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -394,15 +394,17 @@ the following structure inside `<site_dir>`:
 <site_dir>/
 ├── package.json
 ├── vault.config.json
-├── wrangler.toml
-├── functions/
-│   └── api/            # inbox + loadout endpoints (used only if you enable them)
+├── wrangler.toml        # minimal: pages_build_output_dir, no KV binding
 ├── css/
 │   └── overrides.css
 ├── README.md
 ├── .gitignore
 └── .nojekyll
 ```
+
+The scaffold is intentionally minimal — no `functions/` directory and no KV
+binding in `wrangler.toml`. Those are added only if the GM opts into the
+at-table inbox or live status bar later (Phase G).
 
 If the command fails with "command not found", explain:
 
@@ -628,15 +630,13 @@ re-run. Then continue to Phase F.
 
 Initialise git, commit, and push, then enable Pages.
 
-First keep `vault.config.json` out of the public repository — it holds the
-absolute `vaultPath` on the GM's machine (which usually includes their
-username and campaign name), and it is only needed locally at build time,
-never by the served site. Add it to `.gitignore` before the first commit:
+The scaffold's `.gitignore` already keeps `vault.config.json` (which holds
+the absolute `vaultPath` on the GM's machine) out of the repo, so no manual
+edit is needed before committing:
 
 ```bash
 git init
 git branch -M main
-printf '\nvault.config.json\n' >> .gitignore
 git add .
 git commit -m "Initial site scaffold"
 ```

--- a/tools/publish/bin/gm-publish.js
+++ b/tools/publish/bin/gm-publish.js
@@ -134,15 +134,23 @@ if (command === 'build') {
   warnIfVersionDrift();
   assertRuntimeDeps();
 
-  // Bring plugin-owned Cloudflare Functions up to date on every build, so API routes
-  // added or fixed in a newer plugin version reach sites scaffolded before they existed
-  // (init only copies them once). The site root holds functions/ alongside the config.
+  // Bring plugin-owned Cloudflare Functions up to date on every build so API routes
+  // added or fixed in a newer plugin version reach flagged sites scaffolded before they
+  // existed. A Tier-1 (static) site has no backend, so it gets no Functions re-added.
   try {
-    const { syncScaffoldFunctions } = require('../lib/sync-functions');
+    const { syncScaffoldFunctions, shouldSyncFunctions } = require('../lib/sync-functions');
     const siteRoot = path.dirname(path.resolve(configPath));
-    const { created, updated } = syncScaffoldFunctions(siteRoot);
-    for (const f of created) console.log(`  synced (new) functions/${f}`);
-    for (const f of updated) console.log(`  synced (updated) functions/${f}`);
+    let backendExplicit;
+    try {
+      backendExplicit = JSON.parse(fs.readFileSync(configPath, 'utf8')).backend;
+    } catch {
+      // Unreadable/absent config → leave undefined so resolveBackendFlags falls back to detection.
+    }
+    if (shouldSyncFunctions(siteRoot, backendExplicit)) {
+      const { created, updated } = syncScaffoldFunctions(siteRoot);
+      for (const f of created) console.log(`  synced (new) functions/${f}`);
+      for (const f of updated) console.log(`  synced (updated) functions/${f}`);
+    }
   } catch (err) {
     console.warn(`⚠️  Could not sync scaffold Functions: ${err.message}`);
   }

--- a/tools/publish/lib/init.js
+++ b/tools/publish/lib/init.js
@@ -69,11 +69,6 @@ async function init(targetDir = '.', options = {}) {
     { dest: 'css/overrides.css',               tmpl: 'css/overrides.css',                    isTemplate: false },
     { dest: '.gitignore',                      tmpl: 'dot-gitignore',                         isTemplate: false },
     { dest: 'wrangler.toml',                   tmpl: 'wrangler.toml.tmpl',                    isTemplate: true  },
-    { dest: 'functions/api/inbox-core.mjs',    tmpl: 'functions/api/inbox-core.mjs',          isTemplate: false },
-    { dest: 'functions/api/request.js',        tmpl: 'functions/api/request.js',              isTemplate: false },
-    { dest: 'functions/api/loadout-core.mjs',  tmpl: 'functions/api/loadout-core.mjs',        isTemplate: false },
-    { dest: 'functions/api/loadout.js',        tmpl: 'functions/api/loadout.js',              isTemplate: false },
-    { dest: 'functions/api/loadout-list.js',   tmpl: 'functions/api/loadout-list.js',         isTemplate: false },
   ];
 
   // Check for pre-existing files before writing anything

--- a/tools/publish/lib/sync-functions.js
+++ b/tools/publish/lib/sync-functions.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { resolveBackendFlags } = require('./backend-flags');
 
 const SCAFFOLD_FUNCTIONS_DIR = path.join(__dirname, '..', 'templates-scaffold', 'functions');
 
@@ -84,4 +85,12 @@ function syncScaffoldFunctions(siteRoot, options = {}) {
   return { created, updated };
 }
 
-module.exports = { syncScaffoldFunctions, SCAFFOLD_FUNCTIONS_DIR };
+// The build re-syncs plugin-owned Functions so upgraded sites get new API routes.
+// A Tier-1 (static) site has no backend, so it must not have Functions re-added.
+// Gate the sync on the site's resolved backend flags.
+function shouldSyncFunctions(siteRoot, backendExplicit) {
+  const flags = resolveBackendFlags(backendExplicit, siteRoot);
+  return Boolean(flags.statusBar || flags.inbox);
+}
+
+module.exports = { syncScaffoldFunctions, shouldSyncFunctions, SCAFFOLD_FUNCTIONS_DIR };

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.17",
+  "version": "1.11.18",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/templates-scaffold/dot-gitignore
+++ b/tools/publish/templates-scaffold/dot-gitignore
@@ -4,3 +4,7 @@ site/
 Thumbs.db
 *.log
 npm-debug.log*
+
+# Local build config — holds an absolute vaultPath (username/campaign path);
+# used only at build time, never served. Keep it out of a public repo.
+vault.config.json

--- a/tools/publish/templates-scaffold/wrangler.toml.tmpl
+++ b/tools/publish/templates-scaffold/wrangler.toml.tmpl
@@ -1,11 +1,7 @@
-# Cloudflare Pages config. Lets `wrangler pages deploy` bundle the functions/
-# directory and bind the KV namespace the change-request inbox uses.
+# Cloudflare Pages config for a static (Tier-1) site. `pages_build_output_dir`
+# makes `wrangler pages deploy` publish the built docs/ folder. The change-request
+# inbox / live status bar add their KV namespace binding here on opt-in
+# (gm-publish setup-inbox / setup-status-bar).
 name = "{{PACKAGE_NAME}}"
 pages_build_output_dir = "docs"
 compatibility_date = "2024-11-01"
-
-# The inbox queue. After `wrangler kv namespace create INBOX`, paste the printed
-# id below (see the Cloudflare Pages setup guide, "Change-request inbox").
-[[kv_namespaces]]
-binding = "INBOX"
-id = "PUT-YOUR-KV-NAMESPACE-ID-HERE"

--- a/tools/publish/test/init-inbox.test.js
+++ b/tools/publish/test/init-inbox.test.js
@@ -5,28 +5,22 @@ const os = require('node:os');
 const path = require('node:path');
 const { init } = require('../lib/init.js');
 
-test('init scaffolds the inbox Function and wrangler.toml', async () => {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'inbox-init-'));
+test('init scaffolds a Tier-1 wrangler.toml with no KV binding and no Functions', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tier1-init-'));
   await init(dir, { siteTitle: 'Dead End', toolDep: 'file:../tool' });
 
-  const core = await fs.readFile(path.join(dir, 'functions/api/inbox-core.mjs'), 'utf8');
-  assert.match(core, /export const PREFIX = 'req:'/);
-
-  const request = await fs.readFile(path.join(dir, 'functions/api/request.js'), 'utf8');
-  assert.match(request, /onRequestPost/);
-
-  const loadoutCore = await fs.readFile(path.join(dir, 'functions/api/loadout-core.mjs'), 'utf8');
-  assert.match(loadoutCore, /export const PREFIX = 'loadout:'/);
-  const loadout = await fs.readFile(path.join(dir, 'functions/api/loadout.js'), 'utf8');
-  assert.match(loadout, /onRequestGet/);
-  assert.match(loadout, /onRequestPut/);
-
-  const loadoutList = await fs.readFile(path.join(dir, 'functions/api/loadout-list.js'), 'utf8');
-  assert.match(loadoutList, /onRequestGet/);
-  assert.doesNotMatch(loadoutList, /onRequestPut|onRequestPost/);   // read-only
-
+  // wrangler.toml: keeps the deploy config, drops the inbox KV binding.
   const wrangler = await fs.readFile(path.join(dir, 'wrangler.toml'), 'utf8');
-  assert.match(wrangler, /binding = "INBOX"/);
-  assert.match(wrangler, /dead-end/);            // {{PACKAGE_NAME}} substituted
   assert.match(wrangler, /pages_build_output_dir = "docs"/);
+  assert.match(wrangler, /dead-end/);                 // {{PACKAGE_NAME}} substituted
+  assert.doesNotMatch(wrangler, /\[\[kv_namespaces\]\]/);
+  assert.doesNotMatch(wrangler, /binding = "INBOX"/);
+  assert.doesNotMatch(wrangler, /PUT-YOUR-KV-NAMESPACE-ID-HERE/);
+
+  // Tier-1 ships no Functions.
+  await assert.rejects(fs.access(path.join(dir, 'functions')), /ENOENT/);
+
+  // The local build config is gitignored (it holds an absolute vaultPath).
+  const gitignore = await fs.readFile(path.join(dir, '.gitignore'), 'utf8');
+  assert.match(gitignore, /^vault\.config\.json$/m);
 });

--- a/tools/publish/test/unit/should-sync-functions.test.js
+++ b/tools/publish/test/unit/should-sync-functions.test.js
@@ -1,0 +1,43 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { shouldSyncFunctions } = require('../../lib/sync-functions');
+
+function siteDir(contents = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-gate-'));
+  if (contents.wrangler) fs.writeFileSync(path.join(dir, 'wrangler.toml'), contents.wrangler);
+  if (contents.requestFn) {
+    fs.mkdirSync(path.join(dir, 'functions/api'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'functions/api/request.js'), '// fn');
+  }
+  return dir;
+}
+
+test('explicit both-off → no sync', () => {
+  assert.strictEqual(shouldSyncFunctions(siteDir(), { statusBar: false, inbox: false }), false);
+});
+
+test('explicit inbox on → sync', () => {
+  assert.strictEqual(shouldSyncFunctions(siteDir(), { inbox: true }), true);
+});
+
+test('explicit statusBar on → sync', () => {
+  assert.strictEqual(shouldSyncFunctions(siteDir(), { statusBar: true }), true);
+});
+
+test('no explicit flags, real KV id + request Function → detected on → sync', () => {
+  const dir = siteDir({
+    wrangler: '[[kv_namespaces]]\nbinding = "INBOX"\nid = "abc123realid"\n',
+    requestFn: true,
+  });
+  assert.strictEqual(shouldSyncFunctions(dir, undefined), true);
+});
+
+test('no explicit flags, placeholder KV + no Functions → detected off → no sync', () => {
+  const dir = siteDir({
+    wrangler: '[[kv_namespaces]]\nbinding = "INBOX"\nid = "PUT-YOUR-KV-NAMESPACE-ID-HERE"\n',
+  });
+  assert.strictEqual(shouldSyncFunctions(dir, undefined), false);
+});


### PR DESCRIPTION
## Slice 4 / PR A — Tier-1 scaffold cleanup (prerequisite for Tier-2 automation)

Completes the Slice-3 Cloudflare-default flow by removing a latent deploy risk: `gm-publish init` previously scaffolded a `wrangler.toml` with a **placeholder KV namespace id** (`PUT-YOUR-KV-NAMESPACE-ID-HERE`) plus the change-request inbox / live-status-bar Cloudflare Functions into **every** site — including static Tier-1 sites that never use them. That's the same "dead backend shipped to a static site" class the client-side gating fixed earlier, but on the deploy/Functions side.

### What changed

- **Minimal Tier-1 `wrangler.toml`** — the scaffold template keeps `pages_build_output_dir = "docs"` (so the bare `wrangler pages deploy` still works) but no longer ships the `[[kv_namespaces]]` block. `gm-publish init` no longer copies the `functions/` directory. The Function *source* stays in the tool's scaffold; it's added to a site only on opt-in.
- **Build-time sync gated on backend flags** — `syncScaffoldFunctions` runs on every build to keep plugin-owned Functions current, but it now only runs when the site has `backend.statusBar` or `backend.inbox` on (new pure `shouldSyncFunctions`, delegating to the existing `resolveBackendFlags`). A Tier-1 build re-adds no Functions; real inbox/status-bar sites (explicit flags or auto-detected from a real KV id + Function) still sync as before. Existing files are never deleted.
- **`vault.config.json` gitignored by the scaffold** — it holds the absolute local `vaultPath` (username + campaign) and is only needed at build time, never served. This makes the Slice-3 wizard-prose mitigation a scaffold-level fix that covers every site.
- **Docs reconciled** — `cloudflare-pages.md` and `setup-wizard.md` no longer claim a fresh `init` auto-ships the Functions/KV; a Tier-1 site is minimal and the inbox/status-bar are added on opt-in.

### Backwards-compatibility

No user site directory is mutated. Existing deployed inbox/status-bar sites keep syncing (explicit `backend.*` true, or auto-detected). A legacy Tier-1 site resolves to both-off → no sync; its pre-existing files are left untouched.

### Scope

New-site-focused. Offering to strip the placeholder KV block + dead Functions from an *existing* Tier-1 site is intentionally out of scope (the Tier-2 setup commands will overwrite the placeholder id on opt-in). The two setup commands (`setup-status-bar`, `setup-inbox`) land in the next PR.

### Validation

- `node --test` in `tools/publish`: **1272/1272** (baseline 1267 + 5 new gate tests + retargeted scaffold test)
- `python3 scripts/validate_schema.py` — pass (41 files)
- markdownlint — clean; `skill-creator` validation — pass (SKILL.md untouched, routing unchanged)
- `./scripts/build-skill-zips.sh` — 9 valid zips
- Versions: plugin `1.8.44 → 1.8.45`, publish tool `1.11.17 → 1.11.18`; CHANGELOG entry added
