### PR TITLE
Publish-site onboarding Slice 4B: Tier-2 commands + static roster

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.45",
+  "version": "1.8.46",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.46] — 2026-07-22
+
+Publish tool 1.11.19. The live status bar and change-request inbox are now
+one-command setups, and the PC roster ships as a static initiative table on
+every site.
+
+### Added
+
+- `gm-publish setup-status-bar` and `gm-publish setup-inbox` — idempotent,
+  preflight-gated commands that turn on the live status bar (Tier 2a) and the
+  at-table change-request inbox (Tier 2b) end-to-end: create or reuse the
+  `INBOX` KV namespace, patch `wrangler.toml` (name-alignment + the
+  `[[kv_namespaces]]` block), flip the matching `backend` flag in
+  `vault.config.json`, rebuild, and deploy — one command, no manual
+  `wrangler.toml` editing. Each probes the Cloudflare token's KV permission
+  before touching anything, mapping `code: 10000` to the one-line fix (add
+  **Account · Workers KV Storage · Edit**). `setup-inbox` requires and ensures
+  the same KV namespace (inbox ⇒ KV) and is infra-only — it does not open a
+  session. The `publish-site` skill docs (`SKILL.md`, `setup-wizard.md`,
+  `cloudflare-pages.md`) point at both commands as the primary path, with the
+  existing manual steps kept as the documented fallback.
+- The PC roster / party board now renders as a static initiative table on any
+  site, even with no backend configured — useful with zero setup, and it goes
+  live (phone-updatable, real time) once `setup-status-bar` is run.
+
+### Fixed
+
+- `wrangler.toml`'s `name` is aligned to the Cloudflare project before a bare
+  `wrangler pages deploy`, so `setup-status-bar` / `setup-inbox` (and the
+  wizard's own deploy step) never target the wrong Pages project.
+
 ## [1.8.45] — 2026-07-22
 
 Publish tool 1.11.18. Tier-1 sites no longer ship the change-request inbox's

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -169,7 +169,9 @@ Workflow:
    c. Deploy. The scaffold ships a `wrangler.toml` with
       `pages_build_output_dir = "docs"`, so deploy with the **bare** form
       (no `docs/` argument — passing it positionally conflicts with the
-      config and errors):
+      config and errors). First ensure `wrangler.toml`'s `name` matches
+      the project from step (a) — the bare deploy targets that field,
+      not `cloudflarePagesProject` — then:
       `npx wrangler@4 pages deploy`
       Only if the site has no `wrangler.toml` (an older scaffold) use the
       explicit `npx wrangler@4 pages deploy docs/ --project-name=<name> --branch=main --commit-dirty=true`.

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -277,9 +277,9 @@ status bar", "let players update HP/FP live"
 
 Cloudflare Pages only. Run `node "$TOOL" setup-status-bar` from the site
 directory (defaults to `./vault.config.json`; pass `--config <path>`
-otherwise). The command is **preflight-gated** — beyond `doctor`'s check that
-wrangler is authenticated, it probes the token's KV permission before
-touching anything, mapping Cloudflare's `code: 10000` to the one-line fix
+otherwise). The command runs its own **KV-permission probe** first — it
+lists KV namespaces to confirm the token can manage KV before touching
+anything, mapping Cloudflare's `code: 10000` to the one-line fix
 (edit the token to add **Account · Workers KV Storage · Edit**) — and
 **idempotent**: safe to re-run, it reuses an existing `INBOX` KV namespace
 instead of recreating one. On success it creates or reuses that namespace,

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -69,7 +69,7 @@ npm run build    # generate docs/ from the vault
 Node 22 or later is required. If the GM hits a version error,
 advise them to install Node via https://nodejs.org (LTS release).
 
-## Seven Capabilities
+## Nine Capabilities
 
 ### 1. First-time setup
 
@@ -269,6 +269,37 @@ Follow `references/change-request-loop.md`. It runs an unattended, self-paced
 loop that drains player sheet-edit requests, applies clean GURPS edits to the
 vault, batches one rebuild + redeploy per tick, and flags edge cases. GURPS 4e
 only for now.
+
+### 8. Live status bar setup (Tier 2a)
+
+**Trigger:** "turn on the status bar", "enable live vitals", "set up the
+status bar", "let players update HP/FP live"
+
+Cloudflare Pages only. Run `node "$TOOL" setup-status-bar` from the site
+directory (defaults to `./vault.config.json`; pass `--config <path>`
+otherwise). The command is **preflight-gated** — beyond `doctor`'s check that
+wrangler is authenticated, it probes the token's KV permission before
+touching anything, mapping Cloudflare's `code: 10000` to the one-line fix
+(edit the token to add **Account · Workers KV Storage · Edit**) — and
+**idempotent**: safe to re-run, it reuses an existing `INBOX` KV namespace
+instead of recreating one. On success it creates or reuses that namespace,
+aligns `wrangler.toml`'s `name` to the Cloudflare project, flips
+`backend.statusBar` to `true` in `vault.config.json`, rebuilds, and deploys —
+one command, no manual `wrangler.toml` editing. Note: the roster/party board
+already renders as a **static** initiative table at Tier 1 with no backend at
+all; this command is what makes it live and update from players' phones.
+
+### 9. At-table inbox setup (Tier 2b)
+
+**Trigger:** "set up the inbox", "let players submit changes", "turn on the
+change-request inbox"
+
+Same command family as capability 8: run `node "$TOOL" setup-inbox` — equally
+preflight-gated and idempotent, and sharing the same KV machinery
+(**inbox ⇒ KV**: the namespace is required and ensured automatically, never a
+separate manual step). It flips `backend.inbox` and is **infra-only** — it
+does not open a session or write a `config:code`. Once the flag is live, use
+capability 7 ("start your checking loop") for the actual at-table session.
 
 ## Configuration
 

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -228,9 +228,51 @@ A fresh Tier-1 site scaffolds a **minimal** `wrangler.toml` — it has
 working) but **no** `[[kv_namespaces]]` block — and **no** `functions/`
 directory. The KV binding and the `functions/` are added only when you opt
 into the inbox or the live status bar: either the streamlined
-`gm-publish setup-inbox` / `setup-status-bar` commands (coming in the next
-release) or the manual steps in this section. Already-deployed inbox sites are
+`gm-publish setup-inbox` / `setup-status-bar` commands below, or the manual
+steps further down in this section. Already-deployed inbox sites are
 unaffected — this only changes what a brand-new site ships.
+
+> **The PC roster already renders as a static initiative table at Tier 1** —
+> with no backend at all. Setting up the live status bar (`setup-status-bar`,
+> below) is what turns that static table into a live, phone-updatable board;
+> the inbox reuses the same KV namespace.
+
+### The fast way — `setup-status-bar` / `setup-inbox`
+
+These do everything the manual steps below do — create/reuse the `INBOX` KV
+namespace, align `wrangler.toml`'s `name` to the Cloudflare project, patch in
+the `[[kv_namespaces]]` block, flip the backend flag, rebuild, and deploy —
+in one command. Run from the site directory:
+
+```bash
+node "$TOOL" setup-status-bar   # live status bar (Tier 2a)
+node "$TOOL" setup-inbox        # change-request inbox (Tier 2b)
+```
+
+Each defaults to `./vault.config.json`; pass `--config <path>` if you're
+running from elsewhere. Both are:
+
+- **Preflight-gated** — beyond `doctor`'s check that wrangler is
+  authenticated, the command probes the token's KV permission before
+  touching anything. If the token can't manage KV, it stops with the fix
+  rather than half-applying anything: edit the token (My Profile → API
+  Tokens → your token → Edit) to add **Account · Workers KV Storage · Edit**
+  (Cloudflare returns `Authentication error [code: 10000]` for this case),
+  then re-run — no undo needed.
+- **Idempotent** — safe to re-run. A namespace id already in `wrangler.toml`
+  (or an existing `INBOX` namespace) is reused rather than recreated.
+
+`setup-inbox` requires and ensures the same KV namespace as the status bar
+(**inbox ⇒ KV** — you never create it separately) and is **infra-only**: it
+flips `backend.inbox` to `true` but does not open a session or set a
+`config:code`. Opening a live session is still the `inbox open <CODE>` loop
+(Part 3 / `references/change-request-loop.md`) — run that once the flag is
+live.
+
+If you'd rather see each step yourself, or the command isn't available on
+your setup, the manual path below does the same thing by hand.
+
+### Or by hand
 
 **You do not hand-copy the Functions.** Once a backend flag (`backend.inbox` or
 `backend.statusBar`) is `true` in `vault.config.json`, the next `npm run build`

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -252,9 +252,9 @@ node "$TOOL" setup-inbox        # change-request inbox (Tier 2b)
 Each defaults to `./vault.config.json`; pass `--config <path>` if you're
 running from elsewhere. Both are:
 
-- **Preflight-gated** — beyond `doctor`'s check that wrangler is
-  authenticated, the command probes the token's KV permission before
-  touching anything. If the token can't manage KV, it stops with the fix
+- **KV-permission probe first** — the command lists KV namespaces to
+  confirm the token can manage KV before touching anything (this is the
+  command's own check, not a `doctor` run). If the token can't manage KV, it stops with the fix
   rather than half-applying anything: edit the token (My Profile → API
   Tokens → your token → Edit) to add **Account · Workers KV Storage · Edit**
   (Cloudflare returns `Authentication error [code: 10000]` for this case),

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -219,7 +219,7 @@ publish:
     project_name: "iron-crown"     # Cloudflare project (or repo_name for GitHub)
     github_username: "jsmith"      # GitHub path only
     site_dir: "/abs/path/to/site"
-    deferred: []                   # e.g. [status-bar, inbox] after the tiered close
+    deferred: []                   # e.g. [status-bar, inbox] — features deferred for later
 ---
 ```
 
@@ -795,11 +795,13 @@ Tokens → their token → Edit → add **Account · Workers KV Storage · Edit*
 Save) — the same one-tick permission mentioned in Phase A — then re-run;
 it picks up right where it left off.
 
-Record whichever the GM ran (or declined) in `setup_progress.deferred`
-(e.g. `deferred: [status-bar]`, `deferred: [inbox]`, both, or `[]` if they
-defer both).
+`setup_progress.deferred` lists the features **not yet set up** — the ones
+deferred for later. A feature the GM sets up now is **not** in `deferred`; a
+feature they defer **is**. So: set up both → `deferred: []`; set up the
+status bar but defer the inbox → `deferred: [inbox]`; defer both →
+`deferred: [status-bar, inbox]`.
 
-- **If the GM defers both:** leave `deferred: []` and tell them:
+- **If the GM defers both:** set `deferred: [status-bar, inbox]` and tell them:
 
   > "No problem — whenever you're ready, just say 'set up the status
   > bar' or 'set up the inbox' and I'll set it up with one command."

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -768,9 +768,10 @@ and each can be set up later:
 > Want to set up either now?"
 
 **If the GM wants one now, run the real command** — Cloudflare only, and
-each is **preflight-gated** (beyond `doctor`'s check that wrangler is
-authenticated, the command probes the token's KV permission before touching
-anything, mapping Cloudflare's `code: 10000` to the one-line fix: edit the
+each runs its own **KV-permission probe** (the wizard already ran `doctor`
+in its Phase A preflight; the command additionally lists KV namespaces to
+confirm the token can manage KV before touching anything, mapping
+Cloudflare's `code: 10000` to the one-line fix: edit the
 token to add **Account · Workers KV Storage · Edit**) and **idempotent**
 (safe to re-run — it reuses the existing `INBOX` KV namespace rather than
 recreating one):

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -601,7 +601,13 @@ error dump.
 The Tier-1 scaffold ships a `wrangler.toml` with
 `pages_build_output_dir = "docs"`, so the deploy uses the **bare** form
 (no `docs/` argument — passing the directory positionally conflicts with
-the config and errors). Create the project once, then deploy:
+the config and errors). The bare form deploys to whichever project is
+named in `wrangler.toml`'s `name` field, not to `cloudflarePagesProject`
+— so before deploying, make sure that field matches `<project_name>`
+(edit it if the GM chose a different Cloudflare project name than the
+one the scaffold started with). Skipping this fails the deploy with
+"The Pages project '<name>' does not exist." Create the project once,
+then deploy:
 
 ```bash
 npx wrangler@4 pages project create <project_name> --production-branch=main   # once per site

--- a/skills/publish-site/references/setup-wizard.md
+++ b/skills/publish-site/references/setup-wizard.md
@@ -752,7 +752,9 @@ named, independent** opt-ins. Neither is required for a working site,
 and each can be set up later:
 
 - **Live status bar** — players see and update their HP/FP (and similar
-  live stats) from their phones during play, in real time.
+  live stats) from their phones during play, in real time. (The roster page
+  already shows a static initiative table at Tier 1 — this is what makes it
+  live.)
 - **At-table change-request inbox** — players submit sheet edits and
   questions from their phones during a session; you review and apply
   them.
@@ -765,26 +767,40 @@ and each can be set up later:
 > - an **at-table change-request inbox** for sheet edits during play.
 > Want to set up either now?"
 
-**Honesty constraint — do not promise a one-command setup that doesn't
-exist yet.** The streamlined `setup-status-bar` / `setup-inbox` commands
-are not built yet. So:
+**If the GM wants one now, run the real command** — Cloudflare only, and
+each is **preflight-gated** (beyond `doctor`'s check that wrangler is
+authenticated, the command probes the token's KV permission before touching
+anything, mapping Cloudflare's `code: 10000` to the one-line fix: edit the
+token to add **Account · Workers KV Storage · Edit**) and **idempotent**
+(safe to re-run — it reuses the existing `INBOX` KV namespace rather than
+recreating one):
 
-- **If the GM wants one now:** record it in `setup_progress.deferred`
-  (e.g. `deferred: [status-bar]`, `deferred: [inbox]`, or both), and
-  point them at the current manual path:
-  - **Inbox:** follow `references/cloudflare-pages.md` →
-    "Change-request inbox" (create the KV namespace, paste its id into
-    `wrangler.toml`, redeploy).
-  - **Status bar:** it reuses the **same KV namespace** as the inbox —
-    so if the inbox is set up (or the token already has the
-    **Workers KV Storage · Edit** permission from Phase A), the
-    groundwork is shared.
+```bash
+node "$TOOL" setup-status-bar   # Tier 2a — live status bar
+node "$TOOL" setup-inbox        # Tier 2b — at-table change-request inbox
+```
 
-  Tell them a one-command setup for these is coming, but this manual
-  path works today.
+Run from the site directory (each defaults to `./vault.config.json`; pass
+`--config <path>` otherwise). Either command creates or reuses the `INBOX`
+KV namespace, aligns `wrangler.toml`'s `name` to the Cloudflare project,
+flips the matching `backend.statusBar` / `backend.inbox` flag in
+`vault.config.json`, rebuilds, and deploys — one step, no manual
+`wrangler.toml` editing. `setup-inbox` requires and ensures the same KV
+namespace (**inbox ⇒ KV**) and is **infra-only** — it flips the flag but
+does not open a session; that's still "start your checking loop"
+(capability 7) once the flag is live. If the command reports the
+KV-permission fix, walk the GM through editing the token (My Profile → API
+Tokens → their token → Edit → add **Account · Workers KV Storage · Edit** →
+Save) — the same one-tick permission mentioned in Phase A — then re-run;
+it picks up right where it left off.
+
+Record whichever the GM ran (or declined) in `setup_progress.deferred`
+(e.g. `deferred: [status-bar]`, `deferred: [inbox]`, both, or `[]` if they
+defer both).
+
 - **If the GM defers both:** leave `deferred: []` and tell them:
 
   > "No problem — whenever you're ready, just say 'set up the status
-  > bar' or 'set up the inbox' and I'll walk you through it."
+  > bar' or 'set up the inbox' and I'll set it up with one command."
 
 Setup is complete.

--- a/tools/publish/bin/gm-publish.js
+++ b/tools/publish/bin/gm-publish.js
@@ -16,6 +16,8 @@ Usage:
   gm-apprentice-publish inbox <cmd> [args]   Change-request queue (used by the loop)
   gm-apprentice-publish flush [options]      Write players' current KV live-state back into the vault sheets
   gm-apprentice-publish doctor [options]     Preflight: check tools/auth, save Cloudflare creds
+  gm-apprentice-publish setup-status-bar     Enable the live status bar (KV + deploy)
+  gm-apprentice-publish setup-inbox          Enable the change-request inbox (KV + deploy)
   gm-apprentice-publish --version            Show version
   gm-apprentice-publish --help               Show this help
 
@@ -188,6 +190,19 @@ if (command === 'flush') {
 if (command === 'doctor') {
   const { runDoctor } = require('../lib/doctor-cli.js');
   runDoctor(args.slice(1))
+    .then((rc) => process.exit(rc))
+    .catch((err) => { console.error(err.message); process.exit(1); });
+  return;
+}
+
+if (command === 'setup-status-bar' || command === 'setup-inbox') {
+  let configPath = './vault.config.json';
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--config' && args[i + 1]) { configPath = args[i + 1]; i++; }
+  }
+  const feature = command === 'setup-status-bar' ? 'status-bar' : 'inbox';
+  const { runSetupBackend } = require('../lib/setup-backend.js');
+  runSetupBackend(feature, { configPath })
     .then((rc) => process.exit(rc))
     .catch((err) => { console.error(err.message); process.exit(1); });
   return;

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -638,9 +638,12 @@ function build(options = {}) {
   }
 
   if (deferredRosters.length) {
-    // Status-bar tier off ⇒ no live party board (it polls /api/loadout-list, a
-    // KV backend that isn't deployed). Roster pages still render, just static.
-    const board = publishConfig.backend.statusBar ? boardFor(publishConfig.system) : null;
+    // The roster/party board always renders as a static initiative table from
+    // published values. When the status-bar tier is on it also goes live
+    // (JSON island + client poll of /api/loadout-list). When off, the same
+    // table renders without the live layer.
+    const board = boardFor(publishConfig.system);
+    const live = publishConfig.backend.statusBar === true;
     // Named partyManifest (not manifest) to avoid shadowing the outer vault
     // manifest. Guarded like every other render path so a manifest-build failure
     // does not abort the banners/story/timeline/landing stages that follow.
@@ -655,12 +658,15 @@ function build(options = {}) {
     }
     for (const deferredRoster of deferredRosters) {
       try {
-        const boardHtml = (board && partyManifest) ? board.renderBoard(partyManifest, deferredRoster.page.outputPath) : null;
-        const islandHtml = (board && partyManifest) ? partyDataScript(partyManifest, board.scriptId) : null;
+        const boardHtml = (board && partyManifest)
+          ? board.renderBoard(partyManifest, deferredRoster.page.outputPath, { live })
+          : null;
+        const islandHtml = (live && board && partyManifest)
+          ? partyDataScript(partyManifest, board.scriptId) : null;
         const html = wikiTemplate(deferredRoster.page, deferredRoster.processed, navFor, config, imageMap, {
           publishConfig, linkMap, pages,
           partyBoardHtml: boardHtml, partyDataScript: islandHtml,
-          partyClientScripts: boardHtml ? board.clientScripts : [],
+          partyClientScripts: (live && boardHtml) ? board.clientScripts : [],
         });
         const outPath = path.join(outputDir, deferredRoster.page.outputPath);
         ensureDir(outPath);

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
 const { readNamespaceId } = require('./inbox-wrangler');
 
 const KV_PLACEHOLDER = 'PUT-YOUR-KV-NAMESPACE-ID-HERE';
@@ -73,4 +76,56 @@ function patchWranglerToml(tomlText, { name, kvId }) {
   return out;
 }
 
-module.exports = { checkKvPermission, ensureKvNamespace, patchWranglerToml, INBOX_BLOCK, KV_PERMISSION_FIX };
+const defaultRunWrangler = (args) => {
+  const r = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8' });
+  return { code: r.status == null ? 1 : r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+};
+
+const FLAG_KEY = { 'status-bar': 'statusBar', inbox: 'inbox' };
+const LABEL = { 'status-bar': 'live status bar', inbox: 'change-request inbox' };
+
+async function runSetupBackend(feature, { configPath }, deps = {}) {
+  const out = deps.out || console.log;
+  const runWrangler = deps.runWrangler || defaultRunWrangler;
+  const readFile = deps.readFile || ((p) => fs.readFileSync(p, 'utf8'));
+  const writeFile = deps.writeFile || ((p, c) => fs.writeFileSync(p, c));
+  const build = deps.build || ((opts) => require('./build').build(opts));
+
+  const flagKey = FLAG_KEY[feature];
+  if (!flagKey) { out(`Unknown setup feature: ${feature}`); return 1; }
+
+  const config = JSON.parse(readFile(configPath));
+  const siteRoot = path.dirname(path.resolve(configPath));
+  const tomlPath = path.join(siteRoot, 'wrangler.toml');
+  const projectName = config.cloudflarePagesProject || path.basename(siteRoot);
+
+  // Preflight: KV permission.
+  const perm = checkKvPermission({ runWrangler });
+  if (!perm.ok) { out(perm.fix); return 1; }
+
+  // Ensure namespace (idempotent).
+  let tomlText = readFile(tomlPath);
+  let kv;
+  try { kv = ensureKvNamespace({ runWrangler, tomlText }); }
+  catch (e) { out(e.message); return 1; }
+
+  // Patch wrangler.toml (name-align + KV block) and write back.
+  tomlText = patchWranglerToml(tomlText, { name: projectName, kvId: kv.id });
+  writeFile(tomlPath, tomlText);
+
+  // Flip the backend flag.
+  config.backend = config.backend || {};
+  config.backend[flagKey] = true;
+  writeFile(configPath, JSON.stringify(config, null, 2) + '\n');
+
+  // Build (the flag is now on → Functions sync in) + deploy.
+  build({ configPath });
+  const dep = runWrangler(['pages', 'deploy']);
+  if (dep.code !== 0) { out(`Deploy failed: ${(dep.stderr || dep.stdout || '').trim()}`); return 1; }
+
+  const url = config.siteUrl || `https://${projectName}.pages.dev`;
+  out(`Your ${LABEL[feature]} is set up and deployed. Live at ${url}.`);
+  return 0;
+}
+
+module.exports = { checkKvPermission, ensureKvNamespace, patchWranglerToml, INBOX_BLOCK, KV_PERMISSION_FIX, runSetupBackend };

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -76,8 +76,8 @@ function patchWranglerToml(tomlText, { name, kvId }) {
   return out;
 }
 
-const defaultRunWrangler = (args) => {
-  const r = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8' });
+const defaultRunWrangler = (args, opts = {}) => {
+  const r = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8', cwd: opts.cwd });
   return { code: r.status == null ? 1 : r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
 };
 
@@ -100,14 +100,18 @@ async function runSetupBackend(feature, { configPath }, deps = {}) {
   const tomlPath = path.join(siteRoot, 'wrangler.toml');
   const projectName = config.cloudflarePagesProject || path.basename(siteRoot);
 
+  // All wrangler calls must run from the site root so a bare `pages deploy`
+  // finds wrangler.toml's `pages_build_output_dir`. Harmless for account-level KV ops.
+  const runWranglerAt = (args) => runWrangler(args, { cwd: siteRoot });
+
   // Preflight: KV permission.
-  const perm = checkKvPermission({ runWrangler });
+  const perm = checkKvPermission({ runWrangler: runWranglerAt });
   if (!perm.ok) { out(perm.fix); return 1; }
 
   // Ensure namespace (idempotent).
   let tomlText = readFile(tomlPath);
   let kv;
-  try { kv = ensureKvNamespace({ runWrangler, tomlText }); }
+  try { kv = ensureKvNamespace({ runWrangler: runWranglerAt, tomlText }); }
   catch (e) { out(e.message); return 1; }
 
   // Patch wrangler.toml (name-align + KV block) and write back.
@@ -122,7 +126,7 @@ async function runSetupBackend(feature, { configPath }, deps = {}) {
   // Sync plugin-owned Cloudflare Functions into the site, then build + deploy.
   syncFunctions(siteRoot);
   build({ configPath });
-  const dep = runWrangler(['pages', 'deploy']);
+  const dep = runWranglerAt(['pages', 'deploy']);
   if (dep.code !== 0) { out(`Deploy failed: ${(dep.stderr || dep.stdout || '').trim()}`); return 1; }
 
   const url = config.siteUrl || `https://${projectName}.pages.dev`;

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -23,23 +23,12 @@ function parseCreatedId(stdout) {
   return m ? m[1] : null;
 }
 
-// Find an existing namespace titled INBOX in `kv namespace list` JSON output.
-function findInboxId(listStdout) {
-  try {
-    const arr = JSON.parse(listStdout);
-    const hit = Array.isArray(arr) ? arr.find((n) => n.title === 'INBOX' || /(?:^|_)INBOX$/.test(n.title || '')) : null;
-    return hit ? hit.id : null;
-  } catch { return null; }
-}
-
 function ensureKvNamespace({ runWrangler, tomlText }) {
   const existing = readNamespaceId(tomlText || '');
   if (existing && existing !== KV_PLACEHOLDER) return { id: existing, created: false };
-  const list = runWrangler(['kv', 'namespace', 'list']);
-  if (list.code === 0) {
-    const found = findInboxId(list.stdout);
-    if (found) return { id: found, created: false };
-  }
+  // Do NOT reuse a namespace by title from `kv namespace list` — KV titles are not
+  // unique per project, so a suffix/exact title match could bind another campaign's
+  // INBOX (cross-campaign data exposure). Create a fresh namespace instead.
   const created = runWrangler(['kv', 'namespace', 'create', 'INBOX']);
   const id = parseCreatedId(created.stdout);
   if (created.code !== 0 || !id) {
@@ -53,8 +42,9 @@ const INBOX_BLOCK = (kvId) => `[[kv_namespaces]]\nbinding = "INBOX"\nid = "${kvI
 function patchWranglerToml(tomlText, { name, kvId }) {
   let out = String(tomlText);
   // 1. name
-  if (/^name\s*=\s*".*"$/m.test(out)) {
-    out = out.replace(/^name\s*=\s*".*"$/m, `name = "${name}"`);
+  const NAME_LINE = /^name\s*=\s*(?:"[^"]*"|'[^']*')\s*(?:#.*)?$/m;
+  if (NAME_LINE.test(out)) {
+    out = out.replace(NAME_LINE, `name = "${name}"`);
   } else {
     out = `name = "${name}"\n${out}`;
   }

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -90,6 +90,7 @@ async function runSetupBackend(feature, { configPath }, deps = {}) {
   const readFile = deps.readFile || ((p) => fs.readFileSync(p, 'utf8'));
   const writeFile = deps.writeFile || ((p, c) => fs.writeFileSync(p, c));
   const build = deps.build || ((opts) => require('./build').build(opts));
+  const syncFunctions = deps.syncFunctions || ((root) => require('./sync-functions').syncScaffoldFunctions(root));
 
   const flagKey = FLAG_KEY[feature];
   if (!flagKey) { out(`Unknown setup feature: ${feature}`); return 1; }
@@ -118,7 +119,8 @@ async function runSetupBackend(feature, { configPath }, deps = {}) {
   config.backend[flagKey] = true;
   writeFile(configPath, JSON.stringify(config, null, 2) + '\n');
 
-  // Build (the flag is now on → Functions sync in) + deploy.
+  // Sync plugin-owned Cloudflare Functions into the site, then build + deploy.
+  syncFunctions(siteRoot);
   build({ configPath });
   const dep = runWrangler(['pages', 'deploy']);
   if (dep.code !== 0) { out(`Deploy failed: ${(dep.stderr || dep.stdout || '').trim()}`); return 1; }

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -1,0 +1,76 @@
+const { readNamespaceId } = require('./inbox-wrangler');
+
+const KV_PLACEHOLDER = 'PUT-YOUR-KV-NAMESPACE-ID-HERE';
+const KV_PERMISSION_FIX =
+  'Your Cloudflare token lacks KV permission. Edit it (My Profile → API Tokens → your token → Edit) ' +
+  'to add the row Account · Workers KV Storage · Edit, then re-run.';
+
+function checkKvPermission({ runWrangler }) {
+  const r = runWrangler(['kv', 'namespace', 'list']);
+  if (r.code === 0) return { ok: true };
+  const blob = `${r.stdout || ''}\n${r.stderr || ''}`;
+  if (/10000|Authentication/i.test(blob)) return { ok: false, fix: KV_PERMISSION_FIX };
+  return { ok: false, fix: `wrangler could not list KV namespaces: ${(r.stderr || '').trim()}` };
+}
+
+// Parse the id from `wrangler kv namespace create` output (prints an `id = "..."`
+// line, or JSON with an "id" field depending on version).
+function parseCreatedId(stdout) {
+  const m = String(stdout).match(/id\s*=\s*"([^"]+)"/) || String(stdout).match(/"id"\s*:\s*"([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+// Find an existing namespace titled INBOX in `kv namespace list` JSON output.
+function findInboxId(listStdout) {
+  try {
+    const arr = JSON.parse(listStdout);
+    const hit = Array.isArray(arr) ? arr.find((n) => n.title === 'INBOX' || /(?:^|_)INBOX$/.test(n.title || '')) : null;
+    return hit ? hit.id : null;
+  } catch { return null; }
+}
+
+function ensureKvNamespace({ runWrangler, tomlText }) {
+  const existing = readNamespaceId(tomlText || '');
+  if (existing && existing !== KV_PLACEHOLDER) return { id: existing, created: false };
+  const list = runWrangler(['kv', 'namespace', 'list']);
+  if (list.code === 0) {
+    const found = findInboxId(list.stdout);
+    if (found) return { id: found, created: false };
+  }
+  const created = runWrangler(['kv', 'namespace', 'create', 'INBOX']);
+  const id = parseCreatedId(created.stdout);
+  if (created.code !== 0 || !id) {
+    throw new Error(`Could not create the INBOX KV namespace: ${(created.stderr || created.stdout || '').trim()}`);
+  }
+  return { id, created: true };
+}
+
+const INBOX_BLOCK = (kvId) => `[[kv_namespaces]]\nbinding = "INBOX"\nid = "${kvId}"`;
+
+function patchWranglerToml(tomlText, { name, kvId }) {
+  let out = String(tomlText);
+  // 1. name
+  if (/^name\s*=\s*".*"$/m.test(out)) {
+    out = out.replace(/^name\s*=\s*".*"$/m, `name = "${name}"`);
+  } else {
+    out = `name = "${name}"\n${out}`;
+  }
+  // 2. INBOX kv block — replace the id in an existing INBOX block, else append.
+  if (readNamespaceId(out) !== null) {
+    // Replace the id line that follows `binding = "INBOX"`.
+    const lines = out.split(/\r?\n/);
+    let inInbox = false;
+    for (let i = 0; i < lines.length; i++) {
+      const t = lines[i].trim();
+      if (t === '[[kv_namespaces]]') inInbox = false;
+      if (/^binding\s*=\s*"INBOX"/.test(t)) inInbox = true;
+      else if (inInbox && /^id\s*=\s*"/.test(t)) { lines[i] = `id = "${kvId}"`; break; }
+    }
+    out = lines.join('\n');
+  } else {
+    out = `${out.replace(/\n*$/, '')}\n\n${INBOX_BLOCK(kvId)}\n`;
+  }
+  return out;
+}
+
+module.exports = { checkKvPermission, ensureKvNamespace, patchWranglerToml, INBOX_BLOCK, KV_PERMISSION_FIX };

--- a/tools/publish/lib/templates/coc/party-board.js
+++ b/tools/publish/lib/templates/coc/party-board.js
@@ -32,7 +32,7 @@ function buildCoCPartyManifest(campaignId, entries) {
   return { campaignId, pcs };
 }
 
-function renderCoCBoard(manifest, rosterOutputPath) {
+function renderCoCBoard(manifest, rosterOutputPath, { live = true } = {}) {
   if (!manifest || !manifest.pcs || !manifest.pcs.length) return null;
   const showRep = manifest.pcs.some((pc) => pc.rep != null);
   const rows = manifest.pcs.map((pc) => {
@@ -51,10 +51,13 @@ function renderCoCBoard(manifest, rosterOutputPath) {
   }).join('\n');
 
   const repTh = showRep ? '<th>Rep</th>' : '';
+  const liveIndicator = live
+    ? '<span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>'
+    : '';
   return `<section class="gl-party" aria-label="Live party status">
   <div class="gl-party-head">
     <h2>Party Status</h2>
-    <span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>
+    ${liveIndicator}
   </div>
   <div class="gl-party-scroll">
   <table class="gl-party-table">

--- a/tools/publish/lib/templates/coc/party-board.js
+++ b/tools/publish/lib/templates/coc/party-board.js
@@ -54,7 +54,7 @@ function renderCoCBoard(manifest, rosterOutputPath, { live = true } = {}) {
   const liveIndicator = live
     ? '<span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>'
     : '';
-  return `<section class="gl-party" aria-label="Live party status">
+  return `<section class="gl-party" aria-label="${live ? 'Live party status' : 'Party status'}">
   <div class="gl-party-head">
     <h2>Party Status</h2>
     ${liveIndicator}

--- a/tools/publish/lib/templates/gurps/party-board.js
+++ b/tools/publish/lib/templates/gurps/party-board.js
@@ -28,7 +28,7 @@ function renderPartyBoard(manifest, rosterOutputPath, { live = true } = {}) {
   const liveIndicator = live
     ? '<span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>'
     : '';
-  return `<section class="gl-party" aria-label="Live party status">
+  return `<section class="gl-party" aria-label="${live ? 'Live party status' : 'Party status'}">
   <div class="gl-party-head">
     <h2>Party Status</h2>
     ${liveIndicator}

--- a/tools/publish/lib/templates/gurps/party-board.js
+++ b/tools/publish/lib/templates/gurps/party-board.js
@@ -4,7 +4,7 @@ const { rowCells } = require('../../../js/gurps-party');
 const { relativeHref, escapeHtml } = require('../../processor');
 const { avatarHtml } = require('../party-avatar');
 
-function renderPartyBoard(manifest, rosterOutputPath) {
+function renderPartyBoard(manifest, rosterOutputPath, { live = true } = {}) {
   if (!manifest || !manifest.pcs || !manifest.pcs.length) return null;
   // Rows arrive pre-sorted by Basic Speed (initiative order); the Speed column
   // surfaces that ordering value, so no separate rank number is needed.
@@ -25,10 +25,13 @@ function renderPartyBoard(manifest, rosterOutputPath) {
 </tr>`;
   }).join('\n');
 
+  const liveIndicator = live
+    ? '<span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>'
+    : '';
   return `<section class="gl-party" aria-label="Live party status">
   <div class="gl-party-head">
     <h2>Party Status</h2>
-    <span class="gl-party-live"><span class="gl-party-dot"></span><span class="gl-party-live-time">live</span></span>
+    ${liveIndicator}
   </div>
   <div class="gl-party-scroll">
   <table class="gl-party-table">

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.18",
+  "version": "1.11.19",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/build-party-board.test.js
+++ b/tools/publish/test/build-party-board.test.js
@@ -72,12 +72,15 @@ function buildRosterHtml(statusBar) {
   }
 }
 
-test('build() omits the live party board on the roster when backend.statusBar is off', () => {
-  const marker = 'id="' + boardFor('gurps-4e').scriptId + '"'; // id="gurps-party-data"
-  const html = buildRosterHtml(false);
-  assert.ok(!html.includes(marker), 'no party-board island when statusBar off');
-  assert.doesNotMatch(html, /class="gl-party"/);
-  assert.doesNotMatch(html, /js\/gurps-party\.js/);
+test('build() renders a static roster table but no live layer when backend.statusBar is off', () => {
+  const html = buildRosterHtml(false);         // statusBar off
+  // Static initiative table renders (baked authored values):
+  assert.match(html, /class="gl-party"/);
+  assert.match(html, /gl-party-table/);
+  // No live layer:
+  assert.doesNotMatch(html, /id="gurps-party-data"/);   // no JSON island
+  assert.doesNotMatch(html, /js\/gurps-party\.js/);      // no client scripts
+  assert.doesNotMatch(html, /gl-party-live/);            // no "live" indicator
 });
 
 test('build() wires the live party board on the roster when backend.statusBar is on', () => {

--- a/tools/publish/test/setup-backend-cli.test.js
+++ b/tools/publish/test/setup-backend-cli.test.js
@@ -11,10 +11,12 @@ function harness(overrides = {}) {
     'wrangler.toml': 'name = "old"\npages_build_output_dir = "docs"\n',
   };
   const calls = [];
+  const recorded = { deployCwd: undefined };
   const deps = {
     out: () => {},
-    runWrangler: (args) => {
+    runWrangler: (args, opts) => {
       calls.push(args.join(' '));
+      if (args[0] === 'pages' && args[1] === 'deploy') recorded.deployCwd = opts && opts.cwd;
       if (args[1] === 'namespace' && args[2] === 'list') return { code: 0, stdout: '[]', stderr: '' };
       if (args[1] === 'namespace' && args[2] === 'create') return { code: 0, stdout: 'id = "kv777"', stderr: '' };
       return { code: 0, stdout: 'https://proj-x.pages.dev', stderr: '' }; // pages deploy
@@ -25,11 +27,11 @@ function harness(overrides = {}) {
     writeFile: (p, c) => { files[p] = c; files[require('path').basename(p)] = c; },
     ...overrides,
   };
-  return { deps, files, calls };
+  return { deps, files, calls, recorded };
 }
 
 test('setup-status-bar: creates KV, patches toml, flips flag, builds, deploys', async () => {
-  const { deps, files, calls } = harness();
+  const { deps, files, calls, recorded } = harness();
   const rc = await runSetupBackend('status-bar', { configPath: './vault.config.json' }, deps);
   assert.strictEqual(rc, 0);
   assert.match(files['wrangler.toml'], /name = "proj-x"/);        // name aligned
@@ -37,6 +39,10 @@ test('setup-status-bar: creates KV, patches toml, flips flag, builds, deploys', 
   assert.match(files['./vault.config.json'], /"statusBar":\s*true/);
   assert.ok(calls.includes('build'));
   assert.ok(calls.some((c) => c.startsWith('pages deploy')));
+  // Bare `pages deploy` must run in the site root so it finds wrangler.toml's
+  // pages_build_output_dir; otherwise it errors on a fresh checkout.
+  const siteRoot = require('path').dirname(require('path').resolve('./vault.config.json'));
+  assert.strictEqual(recorded.deployCwd, siteRoot, 'deploy ran with cwd === siteRoot');
   // Functions must be synced BEFORE the deploy, else /api/* 404s on a fresh site.
   const syncIdx = calls.findIndex((c) => c.startsWith('sync '));
   const deployIdx = calls.findIndex((c) => c.startsWith('pages deploy'));

--- a/tools/publish/test/setup-backend-cli.test.js
+++ b/tools/publish/test/setup-backend-cli.test.js
@@ -20,6 +20,7 @@ function harness(overrides = {}) {
       return { code: 0, stdout: 'https://proj-x.pages.dev', stderr: '' }; // pages deploy
     },
     build: () => { calls.push('build'); },
+    syncFunctions: (root) => { calls.push('sync ' + root); },
     readFile: (p) => files[p] ?? files[require('path').basename(p)],
     writeFile: (p, c) => { files[p] = c; files[require('path').basename(p)] = c; },
     ...overrides,
@@ -36,6 +37,11 @@ test('setup-status-bar: creates KV, patches toml, flips flag, builds, deploys', 
   assert.match(files['./vault.config.json'], /"statusBar":\s*true/);
   assert.ok(calls.includes('build'));
   assert.ok(calls.some((c) => c.startsWith('pages deploy')));
+  // Functions must be synced BEFORE the deploy, else /api/* 404s on a fresh site.
+  const syncIdx = calls.findIndex((c) => c.startsWith('sync '));
+  const deployIdx = calls.findIndex((c) => c.startsWith('pages deploy'));
+  assert.ok(syncIdx !== -1, 'Functions sync ran');
+  assert.ok(syncIdx < deployIdx, 'sync ran before deploy');
 });
 
 test('setup-inbox flips the inbox flag (and KV is ensured — inbox⇒KV)', async () => {
@@ -57,6 +63,7 @@ test('stops with the KV-permission fix and does not deploy when the token lacks 
   const rc = await runSetupBackend('status-bar', { configPath: './vault.config.json' }, deps);
   assert.notStrictEqual(rc, 0);
   assert.ok(!calls.some((c) => c.startsWith('pages deploy')));   // never deployed
+  assert.ok(!calls.some((c) => c.startsWith('sync ')));          // sync must not run when preflight fails
 });
 
 test('idempotent: a second run with KV already bound + flag true still succeeds and does not re-create', async () => {

--- a/tools/publish/test/setup-backend-cli.test.js
+++ b/tools/publish/test/setup-backend-cli.test.js
@@ -1,0 +1,69 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { runSetupBackend } = require('../lib/setup-backend');
+
+function harness(overrides = {}) {
+  const files = {
+    './vault.config.json': JSON.stringify({
+      cloudflarePagesProject: 'proj-x', siteUrl: 'https://proj-x.pages.dev',
+      backend: { statusBar: false, inbox: false },
+    }),
+    'wrangler.toml': 'name = "old"\npages_build_output_dir = "docs"\n',
+  };
+  const calls = [];
+  const deps = {
+    out: () => {},
+    runWrangler: (args) => {
+      calls.push(args.join(' '));
+      if (args[1] === 'namespace' && args[2] === 'list') return { code: 0, stdout: '[]', stderr: '' };
+      if (args[1] === 'namespace' && args[2] === 'create') return { code: 0, stdout: 'id = "kv777"', stderr: '' };
+      return { code: 0, stdout: 'https://proj-x.pages.dev', stderr: '' }; // pages deploy
+    },
+    build: () => { calls.push('build'); },
+    readFile: (p) => files[p] ?? files[require('path').basename(p)],
+    writeFile: (p, c) => { files[p] = c; files[require('path').basename(p)] = c; },
+    ...overrides,
+  };
+  return { deps, files, calls };
+}
+
+test('setup-status-bar: creates KV, patches toml, flips flag, builds, deploys', async () => {
+  const { deps, files, calls } = harness();
+  const rc = await runSetupBackend('status-bar', { configPath: './vault.config.json' }, deps);
+  assert.strictEqual(rc, 0);
+  assert.match(files['wrangler.toml'], /name = "proj-x"/);        // name aligned
+  assert.match(files['wrangler.toml'], /id = "kv777"/);           // KV bound
+  assert.match(files['./vault.config.json'], /"statusBar":\s*true/);
+  assert.ok(calls.includes('build'));
+  assert.ok(calls.some((c) => c.startsWith('pages deploy')));
+});
+
+test('setup-inbox flips the inbox flag (and KV is ensured — inbox⇒KV)', async () => {
+  const { deps, files } = harness();
+  const rc = await runSetupBackend('inbox', { configPath: './vault.config.json' }, deps);
+  assert.strictEqual(rc, 0);
+  assert.match(files['./vault.config.json'], /"inbox":\s*true/);
+  assert.match(files['wrangler.toml'], /id = "kv777"/);
+});
+
+test('stops with the KV-permission fix and does not deploy when the token lacks KV', async () => {
+  const { deps, calls } = harness({
+    runWrangler: (args) => {
+      calls.push(args.join(' '));
+      if (args[1] === 'namespace' && args[2] === 'list') return { code: 1, stdout: '', stderr: 'code: 10000' };
+      return { code: 0, stdout: '', stderr: '' };
+    },
+  });
+  const rc = await runSetupBackend('status-bar', { configPath: './vault.config.json' }, deps);
+  assert.notStrictEqual(rc, 0);
+  assert.ok(!calls.some((c) => c.startsWith('pages deploy')));   // never deployed
+});
+
+test('idempotent: a second run with KV already bound + flag true still succeeds and does not re-create', async () => {
+  const { deps, files, calls } = harness();
+  await runSetupBackend('status-bar', { configPath: './vault.config.json' }, deps);
+  const before = calls.filter((c) => c.includes('namespace create')).length;
+  await runSetupBackend('status-bar', { configPath: './vault.config.json' }, deps);
+  const after = calls.filter((c) => c.includes('namespace create')).length;
+  assert.strictEqual(after, before);   // no second create (real id now in toml)
+});

--- a/tools/publish/test/unit/setup-backend.test.js
+++ b/tools/publish/test/unit/setup-backend.test.js
@@ -1,0 +1,59 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { checkKvPermission, ensureKvNamespace, patchWranglerToml } = require('../../lib/setup-backend');
+const { readNamespaceId } = require('../../lib/inbox-wrangler');
+
+const MINIMAL = 'name = "old-name"\npages_build_output_dir = "docs"\ncompatibility_date = "2024-11-01"\n';
+const WITH_PLACEHOLDER = MINIMAL + '\n[[kv_namespaces]]\nbinding = "INBOX"\nid = "PUT-YOUR-KV-NAMESPACE-ID-HERE"\n';
+const WITH_REAL = MINIMAL + '\n[[kv_namespaces]]\nbinding = "INBOX"\nid = "realid123"\n';
+
+test('patchWranglerToml sets name and appends an INBOX block on a minimal toml', () => {
+  const out = patchWranglerToml(MINIMAL, { name: 'proj-x', kvId: 'kv999' });
+  assert.match(out, /^name = "proj-x"$/m);
+  assert.strictEqual(readNamespaceId(out), 'kv999');
+  assert.match(out, /pages_build_output_dir = "docs"/);      // preserved
+});
+
+test('patchWranglerToml replaces the placeholder id in place (no duplicate block)', () => {
+  const out = patchWranglerToml(WITH_PLACEHOLDER, { name: 'proj-x', kvId: 'kv999' });
+  assert.strictEqual(readNamespaceId(out), 'kv999');
+  assert.strictEqual((out.match(/\[\[kv_namespaces\]\]/g) || []).length, 1);
+});
+
+test('patchWranglerToml is idempotent', () => {
+  const once = patchWranglerToml(WITH_REAL, { name: 'proj-x', kvId: 'kv999' });
+  const twice = patchWranglerToml(once, { name: 'proj-x', kvId: 'kv999' });
+  assert.strictEqual(once, twice);
+});
+
+test('checkKvPermission ok on code 0', () => {
+  const runWrangler = () => ({ code: 0, stdout: '[]', stderr: '' });
+  assert.deepStrictEqual(checkKvPermission({ runWrangler }), { ok: true });
+});
+
+test('checkKvPermission maps code 10000 to the KV-permission fix', () => {
+  const runWrangler = () => ({ code: 1, stdout: '', stderr: 'Authentication error [code: 10000]' });
+  const r = checkKvPermission({ runWrangler });
+  assert.strictEqual(r.ok, false);
+  assert.match(r.fix, /Workers KV Storage/);
+});
+
+test('ensureKvNamespace reuses a real id from the toml (no create)', () => {
+  let called = false;
+  const runWrangler = () => { called = true; return { code: 0, stdout: '', stderr: '' }; };
+  const r = ensureKvNamespace({ runWrangler, tomlText: WITH_REAL });
+  assert.deepStrictEqual(r, { id: 'realid123', created: false });
+  assert.strictEqual(called, false);   // did not shell out
+});
+
+test('ensureKvNamespace creates when only the placeholder is present', () => {
+  const calls = [];
+  const runWrangler = (args) => {
+    calls.push(args.join(' '));
+    if (args[1] === 'namespace' && args[2] === 'list') return { code: 0, stdout: '[]', stderr: '' };
+    return { code: 0, stdout: 'id = "newkv456"', stderr: '' };   // create output
+  };
+  const r = ensureKvNamespace({ runWrangler, tomlText: WITH_PLACEHOLDER });
+  assert.strictEqual(r.created, true);
+  assert.strictEqual(r.id, 'newkv456');
+});

--- a/tools/publish/test/unit/setup-backend.test.js
+++ b/tools/publish/test/unit/setup-backend.test.js
@@ -20,6 +20,20 @@ test('patchWranglerToml replaces the placeholder id in place (no duplicate block
   assert.strictEqual((out.match(/\[\[kv_namespaces\]\]/g) || []).length, 1);
 });
 
+test('patchWranglerToml replaces a single-quoted name (no duplicate name line)', () => {
+  const single = "name = 'old'\npages_build_output_dir = \"docs\"\n";
+  const out = patchWranglerToml(single, { name: 'proj-x', kvId: 'kv999' });
+  assert.match(out, /^name = "proj-x"$/m);
+  assert.strictEqual((out.match(/^name\s*=/gm) || []).length, 1);
+});
+
+test('patchWranglerToml replaces a name line with an inline comment (no duplicate)', () => {
+  const commented = 'name = "old" # existing project\npages_build_output_dir = "docs"\n';
+  const out = patchWranglerToml(commented, { name: 'proj-x', kvId: 'kv999' });
+  assert.match(out, /^name = "proj-x"$/m);
+  assert.strictEqual((out.match(/^name\s*=/gm) || []).length, 1);
+});
+
 test('patchWranglerToml is idempotent', () => {
   const once = patchWranglerToml(WITH_REAL, { name: 'proj-x', kvId: 'kv999' });
   const twice = patchWranglerToml(once, { name: 'proj-x', kvId: 'kv999' });
@@ -46,14 +60,16 @@ test('ensureKvNamespace reuses a real id from the toml (no create)', () => {
   assert.strictEqual(called, false);   // did not shell out
 });
 
-test('ensureKvNamespace creates when only the placeholder is present', () => {
+test('ensureKvNamespace creates when only the placeholder is present (never lists)', () => {
   const calls = [];
   const runWrangler = (args) => {
-    calls.push(args.join(' '));
-    if (args[1] === 'namespace' && args[2] === 'list') return { code: 0, stdout: '[]', stderr: '' };
+    calls.push(args);
     return { code: 0, stdout: 'id = "newkv456"', stderr: '' };   // create output
   };
   const r = ensureKvNamespace({ runWrangler, tomlText: WITH_PLACEHOLDER });
   assert.strictEqual(r.created, true);
   assert.strictEqual(r.id, 'newkv456');
+  // No title-based reuse: must never enumerate other namespaces.
+  assert.ok(!calls.some((a) => a.join(' ') === 'kv namespace list'));
+  assert.deepStrictEqual(calls, [['kv', 'namespace', 'create', 'INBOX']]);
 });


### PR DESCRIPTION
## Slice 4 / PR B — Tier-2 automation + static roster

Ships the two Tier-2 setup commands, the static roster/initiative table, and the `wrangler.toml` name-alignment fix — completing the painless-onboarding project. Validated end-to-end against a real Cloudflare account.

### Commands

- **`gm-publish setup-status-bar`** (Tier 2a) and **`gm-publish setup-inbox`** (Tier 2b) take a Tier-1 site to a live KV-backed status bar / at-table inbox in one preflight-gated, idempotent, end-to-end invocation: KV-permission probe → ensure the `INBOX` namespace (reuse or create) → patch `wrangler.toml` (align `name` to the project + upsert the `[[kv_namespaces]]` block) → flip the backend flag → sync the Cloudflare Functions → build → bare `wrangler pages deploy`.
- `setup-inbox` requires and ensures KV (inbox ⇒ KV) and is infra-only — the per-session code stays with the existing `inbox open <CODE>` loop.
- The KV-permission probe maps `Authentication error [code: 10000]` to the exact "add **Account · Workers KV Storage · Edit**" fix, since a Pages-only token deploys fine but can't touch KV.

### Static roster / initiative table

The PC roster / party board now renders as a **static initiative table from published values on any site** (the rows already carry authored HP/FP/Speed/DEX). When the status bar is off, only the live layer (JSON island, client poll scripts, the "live" indicator) is withheld; the table itself always renders. It goes live automatically once `setup-status-bar` runs. The per-PC status bar stays gated as before.

### wrangler.toml name-alignment

A bare `wrangler pages deploy` targets the project named in `wrangler.toml`, not `cloudflarePagesProject`. The setup commands align it automatically; the first-time wizard (Step 21a) and routine-update path now do the same before their bare deploys, so a project-name mismatch no longer fails the deploy with a confusing "project does not exist."

### End-to-end validation (real Cloudflare account)

A live e2e ran both commands against a throwaway project: after `setup-status-bar` + `setup-inbox`, `/api/loadout-list` → `200 {"states":{}}`, `/api/loadout` → `400` (validating input), and `/api/request` (no session) → `403 {"error":"code"}` — all live Functions, no 404s. Idempotent re-run reused the KV namespace with no re-create. The e2e surfaced (and this PR fixes) two issues that unit tests structurally couldn't: the setup path bypassed the Function sync, and the deploy ran in the wrong working directory.

### Validation

- `node --test` (tools/publish): **1283/1283**
- `python3 scripts/validate_schema.py` — pass (41 files); markdownlint — clean; `skill-creator` validation — pass
- `./scripts/build-skill-zips.sh` — 9 valid zips
- Versions: plugin `1.8.45 → 1.8.46`, publish tool `1.11.18 → 1.11.19`; CHANGELOG entry added
