### PR TITLE
publish-site: strip Keeper callouts from published site (#137)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.47",
+  "version": "1.8.48",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.48] — 2026-07-26
+
+Publish tool 1.11.21. Keeper callouts no longer leak onto the published site.
+
+### Fixed
+
+- `publish-site`: Obsidian callouts (`> [!type] Title`) rendered in full onto
+  the player site — the tool had no callout stripping, so Keeper-facing callouts
+  (Campaign Design Decisions, Alert Levels, Keeper-Only notes, Canon State) were
+  published verbatim (#137). Added a native `exclude_callouts` option
+  (`publish.exclude_callouts` / `excludeCallouts`): `true` strips every callout,
+  an array of types strips only those. Wired through `processContent`, the PC
+  accordion path (`extractSections`), and the `publishedMarkdown` precompute so
+  callout text also stays out of search, backlinks, and excerpts. Plain
+  blockquotes carry no `[!type]` marker and are preserved.
+
+### Changed
+
+- `publish-site`: scaffolded `vault.config.json` now defaults `excludeCallouts`
+  to `true`. Documented in `content-filtering.md` and `configuration.md`.
+
+---
+
 ## [1.8.47] — 2026-07-23
 
 Publish tool 1.11.20. Players' live HP/FP now sync from the site's KV store back

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -13,6 +13,7 @@ any equivalent in `vault.config.json`.
 |---------|----------|-------------|
 | Publish mode | `publish.mode` | `player` or `full` |
 | Excluded sections | `publish.exclude_sections` | H2 headings to strip (default: `["GM Notes"]`) |
+| Excluded callouts | `publish.exclude_callouts` | Strip Obsidian callouts (`> [!type]`): `true` for all, or an array of types (default: `false`; scaffolded sites set `true`) |
 | Excluded fields | `publish.exclude_fields` | Frontmatter fields to strip (default: `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`) |
 | Excluded directories | `publish.exclude_dirs` | Vault directories to skip (default: `["_meta", "_Templates"]`) |
 | Campaign image | `publish.theme.campaign_image` | Vault-relative path to hero image |
@@ -162,6 +163,7 @@ display settings that are specific to the generated site.
 | Folder map | `folderMap` | Maps vault folders to site output paths |
 | Exclude directories | `excludeDirs` | Fallback if `vault-config.md` doesn't set `publish.exclude_dirs` |
 | Exclude sections | `excludeSections` | Fallback if `vault-config.md` doesn't set `publish.exclude_sections` |
+| Exclude callouts | `excludeCallouts` | Fallback if `vault-config.md` doesn't set `publish.exclude_callouts`. `true` strips all callouts, or an array of types |
 | Preserve directories | `preserveDirs` | Output subdirectories to keep across builds |
 
 ## Precedence

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -11,15 +11,6 @@ All campaign content falls into three categories:
   `stage: outline | draft | ready`
 - Files with `source: "prep"` that have no played counterpart
 - H2 sections listed in `exclude_sections` (default: `["GM Notes"]`)
-- Obsidian callouts (`> [!type] Title` blocks) when
-  `exclude_callouts` is set — `true` strips every callout, an array
-  of types (e.g. `["warning", "danger", "info"]`) strips only those.
-  The gm-apprentice convention treats callouts as Keeper-facing
-  (Campaign Design Decisions, Alert Levels, Keeper-Only notes, Canon
-  State), so scaffolded sites default `excludeCallouts` to `true`.
-  Plain blockquotes (`> "in-world quote"`) carry no `[!type]` marker
-  and are always preserved — keep read-aloud text as a plain
-  blockquote, not a callout, if you want it published.
 - Content between `<!-- gm-only -->` / `<!-- /gm-only -->` markers
 - **Every other `<!-- ... -->` comment.** Private authoring notes
   (`<!-- UNVERIFIED: … -->`, change logs, import provenance) are
@@ -119,6 +110,31 @@ happen to check that session (the reveal happened in dialogue that
 never made it into the wrap-up notes, or the entity wasn't obviously
 "touched"), campaign-qa also runs a full-vault open-spoilers audit on
 demand — see `campaign-qa/references/check-procedures.md`.
+
+## Excluding Callouts (opt-in)
+
+Obsidian callouts (`> [!type] Title` blocks) are **published by
+default** — `exclude_callouts` defaults to `false`, so an existing
+vault with no explicit setting still renders every callout to the
+site. Enable stripping with `publish.exclude_callouts` (or
+`excludeCallouts` in `vault.config.json`):
+
+- `true` — strip every callout
+- an array of types, e.g. `["warning", "danger", "info"]` — strip
+  only callouts of those types
+
+The gm-apprentice convention treats callouts as Keeper-facing
+(Campaign Design Decisions, Alert Levels, Keeper-Only notes, Canon
+State), so **newly scaffolded** sites set `excludeCallouts: true` by
+default. Sites created before this option existed keep the default
+`false` until you set it explicitly — if you rely on callouts to hide
+Keeper content, turn it on, or move that content under a `## GM Notes`
+heading or `<!-- gm-only -->` markers, which are excluded regardless.
+
+Plain blockquotes (`> "an in-world quote"`) carry no `[!type]` marker
+and are never touched — keep read-aloud text as a plain blockquote,
+not a callout, if you want it published. Callout examples inside a
+fenced code block are preserved as documentation.
 
 ## Publish Manifest
 

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -11,6 +11,15 @@ All campaign content falls into three categories:
   `stage: outline | draft | ready`
 - Files with `source: "prep"` that have no played counterpart
 - H2 sections listed in `exclude_sections` (default: `["GM Notes"]`)
+- Obsidian callouts (`> [!type] Title` blocks) when
+  `exclude_callouts` is set — `true` strips every callout, an array
+  of types (e.g. `["warning", "danger", "info"]`) strips only those.
+  The gm-apprentice convention treats callouts as Keeper-facing
+  (Campaign Design Decisions, Alert Levels, Keeper-Only notes, Canon
+  State), so scaffolded sites default `excludeCallouts` to `true`.
+  Plain blockquotes (`> "in-world quote"`) carry no `[!type]` marker
+  and are always preserved — keep read-aloud text as a plain
+  blockquote, not a callout, if you want it published.
 - Content between `<!-- gm-only -->` / `<!-- /gm-only -->` markers
 - **Every other `<!-- ... -->` comment.** Private authoring notes
   (`<!-- UNVERIFIED: … -->`, change logs, import provenance) are

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
 const { optimizeImages, resolveImageConfig } = require('./image-optimize');
 const { resolveBanner, renderBanner, defaultAlt, isSvg } = require('./banners');
-const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename } = require('./processor');
+const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest } = require('./manifest');
@@ -49,6 +49,7 @@ function build(options = {}) {
   publishConfig._genrePreset = genrePreset;
   const manifest = loadManifest(config.vaultPath);
   const excludeSections = publishConfig.exclude_sections;
+  const excludeCallouts = publishConfig.exclude_callouts;
   const excludeFields = publishConfig.exclude_fields;
   const fieldOverrides = publishConfig.overrides.fields || {};
 
@@ -294,7 +295,7 @@ function build(options = {}) {
     const afterGm = typeof gmStripped === 'string' ? gmStripped : gmStripped.text;
     const spoilerStripped = stripSpoiler(afterGm);
     const text = typeof spoilerStripped === 'string' ? spoilerStripped : spoilerStripped.text;
-    page.publishedMarkdown = filterSections(text, excludeSections);
+    page.publishedMarkdown = filterSections(stripCallouts(text, excludeCallouts), excludeSections);
   }
 
   // Whether a Story section will exist. Computed early (pure function of pages) so the
@@ -478,7 +479,7 @@ function build(options = {}) {
         const basename = String(page.frontmatter.portrait).split('/').pop();
         if (basename && imageMap[basename]) usedImages.add(basename);
       }
-      const processed = processContent(page, linkMap, excludeSections, imageMap, { usedImages });
+      const processed = processContent(page, linkMap, excludeSections, imageMap, { usedImages, excludeCallouts });
       logWarnings(page.outputPath, processed.warnings);
       let html;
 
@@ -495,6 +496,7 @@ function build(options = {}) {
           // markdown, and its warnings were already reported.
           const commentResult = stripHtmlComments(filtered);
           filtered = typeof commentResult === 'string' ? commentResult : commentResult.text;
+          filtered = stripCallouts(filtered, excludeCallouts);
           filtered = filterSections(filtered, excludeSections);
           // Images before wikilinks: resolveWikiLinks' `[[…]]` pattern also matches the inner
           // brackets of an `![[image.png]]` embed and would flatten it to literal text.
@@ -511,7 +513,7 @@ function build(options = {}) {
               frontmatter: {},
               outputPath: page.outputPath,
             };
-            const storyProcessed = processContent(storyPage, linkMap, excludeSections, imageMap, { usedImages });
+            const storyProcessed = processContent(storyPage, linkMap, excludeSections, imageMap, { usedImages, excludeCallouts });
             logWarnings(page.outputPath, storyProcessed.warnings);
             storyHtml = storyProcessed.html && storyProcessed.html.trim() ? storyProcessed.html : undefined;
           }
@@ -850,7 +852,7 @@ function build(options = {}) {
     for (const pc of pages.filter(p => p.frontmatter.type === 'pc' && p.storyMarkdown)) {
       const outputPath = `story/characters/${slugify(pc.title)}.html`;
       const storyObj = { markdown: pc.storyMarkdown, frontmatter: {}, outputPath };
-      const processed = processContent(storyObj, linkMap, excludeSections, imageMap, { usedImages });
+      const processed = processContent(storyObj, linkMap, excludeSections, imageMap, { usedImages, excludeCallouts });
       logWarnings(outputPath, processed.warnings);
       const story = {
         title: pc.displayTitle, outputPath, html: processed.html,

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -5,6 +5,7 @@ const matter = require('gray-matter');
 const PUBLISH_DEFAULTS = {
   mode: 'player',
   exclude_drafts: false,
+  exclude_callouts: false,
   exclude_sections: ['GM Notes'],
   exclude_fields: ['secrets', 'current_plan', 'plan_progress', 'gm_notes', 'prep_notes'],
   exclude_dirs: ['_meta', '_Templates'],
@@ -89,6 +90,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
     // publish block first then the vault.config.json fallback (see #112).
     sheet_crest: publish.sheet_crest || jsonConfigFallback.sheet_crest || null,
     exclude_drafts: publish.exclude_drafts ?? PUBLISH_DEFAULTS.exclude_drafts,
+    // Boolean (strip all callouts) or an array of types to strip — not a union list,
+    // so a bare publish-block-first / vault.config.json fallback like sheet_crest (#137).
+    exclude_callouts: publish.exclude_callouts ?? jsonConfigFallback.excludeCallouts ?? PUBLISH_DEFAULTS.exclude_callouts,
     exclude_sections: unionExcludeList(
       publish.exclude_sections,
       jsonConfigFallback.excludeSections,

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -175,7 +175,12 @@ function stripCallouts(markdown, exclude) {
     : null; // null → strip all types
   const lines = markdown.split('\n');
   const out = [];
+  let inCodeFence = false;
   for (let i = 0; i < lines.length; i++) {
+    // A `> [!warning]` written as an example inside a fenced code block is documentation,
+    // not a real callout — copy fenced lines verbatim (matches stripMarkedBlocks).
+    if (/^```/.test(lines[i])) inCodeFence = !inCodeFence;
+    if (inCodeFence) { out.push(lines[i]); continue; }
     const m = lines[i].match(/^>[ \t]*\[!([A-Za-z][\w-]*)\][+-]?/);
     if (m && (!types || types.has(m[1].toLowerCase()))) {
       i++;

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -159,6 +159,38 @@ function stripSpoiler(markdown) {
   return stripMarkedBlocks(markdown, 'spoiler');
 }
 
+// Remove Obsidian callout blockquotes (`> [!type] Title` and their body). The gm-apprentice
+// convention treats callouts as Keeper-facing (design decisions, alert levels, keeper-only
+// notes, canon-state bookkeeping), so a player site can drop them wholesale. Plain blockquotes
+// (`> "in-world quote"`) never carry a `[!type]` marker and are preserved.
+//   exclude === true            → strip every callout
+//   exclude === ['warning', …]  → strip only callouts of those types (case-insensitive)
+//   falsy                       → unchanged
+// Matches markdown.js CALLOUT_RE on the type token (allows hyphens and a +/- fold marker),
+// then consumes the contiguous `>`-prefixed lines that form the blockquote.
+function stripCallouts(markdown, exclude) {
+  if (!exclude) return markdown;
+  const types = Array.isArray(exclude)
+    ? new Set(exclude.map(t => String(t).toLowerCase()))
+    : null; // null → strip all types
+  const lines = markdown.split('\n');
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^>[ \t]*\[!([A-Za-z][\w-]*)\][+-]?/);
+    if (m && (!types || types.has(m[1].toLowerCase()))) {
+      i++;
+      while (i < lines.length && /^>/.test(lines[i])) i++;
+      // Swallow one blank separator the callout left behind, so removing a callout that
+      // sat between two paragraphs collapses to a single blank line rather than two.
+      if (i < lines.length && lines[i].trim() === '') i++;
+      i--; // the for-loop's ++ lands on the next real line
+      continue;
+    }
+    out.push(lines[i]);
+  }
+  return out.join('\n');
+}
+
 // Remove every `<!-- ... -->` comment, including multi-line ones, outside fenced code
 // blocks. Authors keep private notes (UNVERIFIED flags, change logs, import provenance)
 // as comments; the renderer runs with `html: false`, so anything left here is escaped and
@@ -389,6 +421,7 @@ function processContent(page, linkMap, excludeSections, imageMap = {}, options =
     markdown = commentResult;
   }
   markdown = stripLeadingH1(markdown);
+  markdown = stripCallouts(markdown, options.excludeCallouts);
   markdown = filterSections(markdown, excludeSections);
   markdown = separateBoldLabelLines(markdown);
   markdown = resolveImageEmbeds(markdown, imageMap, page.outputPath, options.usedImages, {
@@ -434,4 +467,4 @@ function filterFields(frontmatter, excludeFields = [], overrides = {}) {
   return filtered;
 }
 
-module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields };
+module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields };

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.20",
+  "version": "1.11.21",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/templates-scaffold/vault.config.json.tmpl
+++ b/tools/publish/templates-scaffold/vault.config.json.tmpl
@@ -23,5 +23,6 @@
   },
   "excludeDirs": ["_meta", "_Templates", "_resources"],
   "excludeSections": ["GM Notes", "DM Notes", "Player Notes", "Source References"],
+  "excludeCallouts": true,
   "backend": { "statusBar": false, "inbox": false }
 }

--- a/tools/publish/test/fixtures/with-gm-only-markers/Characters/PCs/Test_PC.md
+++ b/tools/publish/test/fixtures/with-gm-only-markers/Characters/PCs/Test_PC.md
@@ -11,6 +11,9 @@ status: active
 
 An investigator drawn into events beyond their understanding.
 
+> [!info] Keeper Only
+> The investigator is possessed by Hastur.
+
 <!-- gm-only -->
 Secretly serves Zalgorath, an entity beyond the veil.
 <!-- /gm-only -->

--- a/tools/publish/test/fixtures/with-gm-only-markers/Locations/Market.md
+++ b/tools/publish/test/fixtures/with-gm-only-markers/Locations/Market.md
@@ -28,6 +28,11 @@ The blacksmith is also a fence for stolen goods.
 
 The apothecary sells herbs and tonics.
 
+> [!warning] Keeper Only
+> The apothecary answers to Nyarlathotep.
+
+> "Buy fresh apples here!" calls the fruit-seller.
+
 <!-- spoiler -->
 The market square is a fading dream of Carcosa, waiting to be
 revealed once the players find the Yellow Sign.

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -1188,6 +1188,59 @@ describe('build integration', () => {
     });
   });
 
+  describe('excludeCallouts (issue #137)', () => {
+    let outputDir;
+    let configPath;
+
+    before(() => {
+      outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-callouts-'));
+      configPath = path.join(outputDir, 'config.json');
+      const config = {
+        vaultPath: path.join(fixturesDir, 'with-gm-only-markers'),
+        outputDir: path.join(outputDir, 'docs'),
+        attachmentsDir: '_attachments',
+        siteTitle: 'Callout Test',
+        siteUrl: 'https://example.github.io/test-callouts',
+        excludeDirs: ['_meta'],
+        excludeSections: [],
+        excludeCallouts: true,
+        folderMap: {
+          'Locations': 'locations',
+          'Characters/PCs': 'characters/pcs',
+        },
+      };
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      build({ configPath });
+    });
+
+    after(() => {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    });
+
+    it('strips a Keeper callout from a Location page (processContent path)', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'locations', 'market.html'), 'utf-8');
+      assert.ok(!html.includes('Nyarlathotep'));
+      assert.ok(!html.includes('callout'));
+    });
+
+    it('strips a Keeper callout from a PC page (accordion path — the Emma_Wentworth case)', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'characters', 'pcs', 'test-pc.html'), 'utf-8');
+      assert.ok(!html.includes('Hastur'));
+      assert.ok(!html.includes('callout'));
+    });
+
+    it('preserves plain in-world blockquotes', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'locations', 'market.html'), 'utf-8');
+      assert.ok(html.includes('Buy fresh apples here'));
+    });
+
+    it('keeps callout text out of the search index', () => {
+      const indexJson = fs.readFileSync(path.join(outputDir, 'docs', 'search-index.json'), 'utf-8').toLowerCase();
+      assert.ok(!indexJson.includes('nyarlathotep'));
+      assert.ok(!indexJson.includes('hastur'));
+    });
+  });
+
   describe('with-story fixture', () => {
     let outputDir;
     let configPath;

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -31,6 +31,19 @@ describe('exclude_drafts', () => {
   });
 });
 
+describe('exclude_callouts (issue #137)', () => {
+  it('defaults to false', () => {
+    assert.strictEqual(PUBLISH_DEFAULTS.exclude_callouts, false);
+    const config = loadPublishConfig('/nonexistent/path');
+    assert.strictEqual(config.exclude_callouts, false);
+  });
+
+  it('reads excludeCallouts from vault.config.json fallback', () => {
+    const config = loadPublishConfig('/nonexistent/path', { excludeCallouts: true });
+    assert.strictEqual(config.exclude_callouts, true);
+  });
+});
+
 describe('loadPublishConfig', () => {
   it('returns defaults when vault-config.md has no publish section', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -260,6 +260,11 @@ describe('stripCallouts (issue #137)', () => {
     const md = '> [!WARNING] Design\n> secret\n\nKeep.';
     assert.strictEqual(stripCallouts(md, ['warning']), 'Keep.');
   });
+
+  it('preserves a callout example inside a fenced code block', () => {
+    const md = 'Docs:\n\n```\n> [!warning] Example\n> body\n```\n\nAfter.';
+    assert.strictEqual(stripCallouts(md, true), md);
+  });
 });
 
 describe('filterFields', () => {

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { escapeHtml, relativePath, relativeHref, parseWikiRef, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, stripSpoiler, filterFields, renderRelationships } = require('../../lib/processor');
+const { escapeHtml, relativePath, relativeHref, parseWikiRef, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, stripSpoiler, stripCallouts, filterFields, renderRelationships } = require('../../lib/processor');
 
 describe('escapeHtml', () => {
   it('escapes angle brackets', () => {
@@ -219,6 +219,46 @@ describe('stripSpoiler', () => {
     const md = '<!-- gm-only -->\nA\n<!-- /gm-only -->\n<!-- spoiler -->\nB\n<!-- /spoiler -->';
     assert.strictEqual(stripSpoiler(md), '<!-- gm-only -->\nA\n<!-- /gm-only -->\n');
     assert.strictEqual(stripGmOnly(md), '\n<!-- spoiler -->\nB\n<!-- /spoiler -->');
+  });
+});
+
+describe('stripCallouts (issue #137)', () => {
+  it('returns markdown unchanged when exclude is falsy', () => {
+    const md = '> [!info] Keeper Only\n> Secret note.\n\nBody.';
+    assert.strictEqual(stripCallouts(md, false), md);
+    assert.strictEqual(stripCallouts(md, undefined), md);
+  });
+
+  it('strips a whole callout blockquote when exclude is true', () => {
+    const md = 'Intro.\n\n> [!info] Keeper Only\n> The name is a cover.\n> More secret.\n\nOutro.';
+    assert.strictEqual(stripCallouts(md, true), 'Intro.\n\nOutro.');
+  });
+
+  it('leaves ordinary blockquotes untouched', () => {
+    const md = '> "An ordinary in-world quote."\n\nBody.';
+    assert.strictEqual(stripCallouts(md, true), md);
+  });
+
+  it('strips multiple callouts of different types', () => {
+    const md = '> [!warning] Campaign Design Decision\n> A.\n\nKeep.\n\n> [!danger] Alert Level\n> B.';
+    assert.strictEqual(stripCallouts(md, true), 'Keep.\n');
+  });
+
+  it('handles the fold marker and a title-less callout', () => {
+    const md = '> [!note]- Folded\n> hidden\n\n> [!tip]\n> also hidden\n\nEnd.';
+    assert.strictEqual(stripCallouts(md, true), 'End.');
+  });
+
+  it('strips only the listed types when given an array', () => {
+    const md = '> [!danger] Alert\n> secret\n\n> [!info] Read-Aloud\n> player text';
+    const result = stripCallouts(md, ['danger']);
+    assert.doesNotMatch(result, /Alert/);
+    assert.match(result, /Read-Aloud/);
+  });
+
+  it('is case-insensitive on type names in the array form', () => {
+    const md = '> [!WARNING] Design\n> secret\n\nKeep.';
+    assert.strictEqual(stripCallouts(md, ['warning']), 'Keep.');
   });
 });
 


### PR DESCRIPTION
Fixes #137.

## Problem

Obsidian callouts (`> [!type] Title`) render in full onto the **public player site**. `lib/markdown.js` rewrites them to `<div class="callout callout-{type}">`, but `lib/processor.js` never strips them — so Keeper-facing callouts (Campaign Design Decisions, Alert Levels, Keeper-Only notes, Canon State) are published verbatim. On the Canticle vault that was **37 pages** leaking. The scaffold's `strip-keeper-callouts.js` stopgap matches the old `<blockquote>[!type]` output and is a silent no-op against the current renderer (`cleaned 0 page(s)` every build).

## Fix

Native `exclude_callouts` option — the one the stopgap's own TODO promised:

- **config** (`lib/config.js`): `exclude_callouts` default `false`, resolved from `publish.exclude_callouts` / `excludeCallouts`. Accepts `true` (strip all) or an array of types (`["warning","danger","info"]`).
- **processor** (`lib/processor.js`): `stripCallouts(markdown, exclude)` operates on `> [!type]` blockquote source — plain `>` quotes and read-aloud prose are untouched. Added to the `processContent` pipeline.
- **build** (`lib/build.js`): wired into `processContent`, the `type: 'pc'` accordion path (`extractSections`) — the page class where the leak was found — and the `publishedMarkdown` precompute, so callout text also stays out of search / backlinks / excerpts (B6).
- **scaffold + docs**: new `vault.config.json` defaults `excludeCallouts: true`; documented in `content-filtering.md` and `configuration.md`.

## Verification

- Full suite **1311 pass** (+13: 7 unit for `stripCallouts`, 2 config, 4 integration covering both render paths and the search index).
- Built the real Canticle vault with `excludeCallouts: true`: **37 → 0** pages with rendered callouts, 0 Keeper titles exposed, in-world blockquotes preserved.

## Notes

- `exclude_callouts: true` also drops `Read-Aloud` callouts; that matches the convention (read-aloud belongs in plain blockquotes) and the old stripping behaviour.
- Existing `strip-keeper-callouts.js` in already-scaffolded sites can be retired once a site sets `excludeCallouts` and repoints to this build.