### PR TITLE
Publish-site release fixes: content leaks, link encoding, unicode normalization, predicate validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.48",
+  "version": "1.8.49",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,6 +127,12 @@ jobs:
       - name: gurps-check tests
         run: python tests/test_gurps_check.py
 
+      - name: Vault check assistance regression
+        run: python tests/test_vault_check.py
+
+      - name: Relationship predicate vocabulary regression
+        run: python tests/test_relationship_predicates.py
+
   pr-discipline:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,19 @@ guarded lifecycle helper for ephemeral e2e test resources.
   `recency.js` and `story-spine.js` (a session's narrative recap silently
   vanished from the Story page), the flat-vault chapter↔session match, and
   the chapter page's constituent-sessions sidebar (#139).
+  The same sweep then ran over `lib/templates/`, where eight more
+  comparisons of the same shape were fixed: an accented location page lost
+  its "Places Within", "Known Figures" and "What Happened Here" rollups; an
+  accented faction page lost its members list; the locations index rendered
+  a child as a root sibling instead of nesting it, and split one parent
+  region into two headings; the landing page featured a *different* session
+  than the campaign overview names, recap and link included; and a PC's
+  route map listed one location twice. The search index is built NFC and
+  the search box normalizes its query to match, so a note typed with
+  decomposed accents is findable. A three-way differential build test
+  (all-NFD, all-NFC, and the two forms mixed in one vault) now asserts the
+  generated site is byte-identical across all three, which is what proves
+  the class closed rather than a reading of the code (#139).
 - `publish-site`: the built-in default `exclude_sections` had drifted from
   the scaffold template, and `## Reconciliation Context` /
   `## Handoff to Reconcile` — written automatically by `reconcile` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,16 +72,20 @@ guarded lifecycle helper for ephemeral e2e test resources.
   `recency.js` and `story-spine.js` (a session's narrative recap silently
   vanished from the Story page), the flat-vault chapter↔session match, and
   the chapter page's constituent-sessions sidebar (#139).
-  The same sweep then ran over `lib/templates/`, where eight more
+  The same sweep then ran over `lib/templates/`, where seven more live
   comparisons of the same shape were fixed: an accented location page lost
   its "Places Within", "Known Figures" and "What Happened Here" rollups; an
   accented faction page lost its members list; the locations index rendered
   a child as a root sibling instead of nesting it, and split one parent
   region into two headings; the landing page featured a *different* session
   than the campaign overview names, recap and link included; and a PC's
-  route map listed one location twice. The search index is built NFC and
-  the search box normalizes its query to match, so a note typed with
-  decomposed accents is findable. A three-way differential build test
+  route map listed one location twice. An eighth copy of the chapter
+  matcher (`sessionsForChapter`) was normalized alongside its two live
+  siblings so the three cannot drift, but its ref clauses are unreachable
+  today and nothing about the rendered site changes. The search index is
+  built NFC and the search box normalizes its query to match, so a note
+  typed with decomposed accents is findable. A three-way differential build
+  test
   (all-NFD, all-NFC, and the two forms mixed in one vault) now asserts the
   generated site is byte-identical across all three, which is what proves
   the class closed rather than a reading of the code (#139).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,13 @@ guarded lifecycle helper for ephemeral e2e test resources.
   path and accented pages silently never rendered. Canonicalized to NFC at
   the manifest/scanner comparison boundary and strip combining marks in
   `slugify`; `overrides.fields` keys are now canonicalized the same way at
-  config load. **Slugs change for every page with accented characters.**
+  config load. **Slugs change for every page whose name carries an accent
+  that decomposes into a combining mark** (`é`, `á`, `ñ`, `ü`, …);
+  characters with no such decomposition (`ø`, `ł`, `đ`, `ß`) are
+  unaffected and keep their old slug — `Bjørn` still slugs to `bj-rn`.
+  Two pages in one folder can now collide where they used to slug apart
+  (`Renée` and `Renee` both give `renee.html`); the scan warns when that
+  happens, and the later page wins.
   The manifest only ever filtered pages on `mode: player` sites, so on
   `mode: full` sites (and on `mode: player` sites where the manifest and
   scanned path already agreed) accented pages always rendered — just at
@@ -54,6 +60,14 @@ guarded lifecycle helper for ephemeral e2e test resources.
   `session-wrapup` — were publishing GM plot state to players. Both lists
   now carry the same six entries (`GM Notes`, `DM Notes`, `Player Notes`,
   `Source References`, `Reconciliation Context`, `Handoff to Reconcile`).
+  The built-in default was previously just `GM Notes`, so a hand-configured
+  site with **no** exclude-sections list in either config file also stops
+  publishing `## DM Notes`, `## Player Notes` and `## Source References`
+  from this release — not only the two reconcile sections. Sites
+  scaffolded before this release already carry those four in
+  `vault.config.json`'s `excludeSections`, so the default never applied
+  to them and nothing changes for them until the reconcile pair is added
+  by hand; new scaffolds get all six.
   **Existing sites with an explicit exclude-sections list do not pick
   this up automatically** — add `Reconciliation Context` and `Handoff to
   Reconcile` by hand, either to `excludeSections` in `vault.config.json`
@@ -72,7 +86,12 @@ guarded lifecycle helper for ephemeral e2e test resources.
   with nearest-match suggestions; campaign-qa's graph-health checks now
   run the audit. `skills/shared/templates/plan.md`'s example relationship
   swaps its blank `type: ""` for a real predicate (`located_at`), which
-  the new check would otherwise flag on day one (#130).
+  the new check would otherwise flag on day one. **Expect a burst of
+  errors on the first run after upgrading:** every plan note already
+  scaffolded from the old template carries that blank `type: ""` and
+  reports as a `blank relationship type` ERROR. That is the check working
+  — fill each one in with a sanctioned predicate from the ontology, or
+  drop the placeholder edge (#130).
 - `tools/publish/lib/e2e-resources.js`: a guarded lifecycle helper for
   ephemeral test resources used by the Cloudflare setup flow's e2e tests.
   Names are always `e2e-<runId>-<label>`; cleanup deletes only records the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.49] — 2026-08-12
 
-Publish tool 1.11.22. Six published-site content-leak and encoding bugs
-fixed, relationship-predicate validation added to the vault-authoring gate,
-and a guarded lifecycle helper for ephemeral e2e test resources.
+Publish tool 1.11.22. Published-site content-leak and encoding bugs fixed,
+relationship-predicate validation added to the vault-authoring gate, and a
+guarded lifecycle helper for ephemeral e2e test resources.
 
 ### Fixed
 
@@ -36,27 +36,36 @@ and a guarded lifecycle helper for ephemeral e2e test resources.
   path and accented pages silently never rendered. Canonicalized to NFC at
   the manifest/scanner comparison boundary and strip combining marks in
   `slugify`; `overrides.fields` keys are now canonicalized the same way at
-  config load. **Slugs for previously-broken accented pages change as a
-  result** — those pages never rendered before, so nothing that worked
-  breaks. Vaults with manually-pinned NFD manifest entries should update
-  them to NFC now that matching no longer needs the workaround (#139).
+  config load. **Slugs change for every page with accented characters.**
+  The manifest only ever filtered pages on `mode: player` sites, so on
+  `mode: full` sites (and on `mode: player` sites where the manifest and
+  scanned path already agreed) accented pages always rendered — just at
+  the mangled slug the old naive `slugify` produced (`gonz-lez` for
+  "González"). Every one of those pages now renders at the corrected slug
+  (`gonzalez`) instead, so existing links and bookmarks to them break.
+  Pages that never rendered at all (`mode: player` sites where the
+  manifest and scanned path normalization forms mismatched) start
+  rendering for the first time, at the same corrected slug. Vaults with
+  manually-pinned NFD manifest entries should update them to NFC now that
+  matching no longer needs the workaround (#139).
 - `publish-site`: the built-in default `exclude_sections` had drifted from
   the scaffold template, and `## Reconciliation Context` /
   `## Handoff to Reconcile` — written automatically by `reconcile` and
   `session-wrapup` — were publishing GM plot state to players. Both lists
   now carry the same six entries (`GM Notes`, `DM Notes`, `Player Notes`,
   `Source References`, `Reconciliation Context`, `Handoff to Reconcile`).
-  **Existing sites with an explicit `excludeSections` list in
-  `vault.config.json` do not pick this up automatically** — add the two
-  new entries by hand, or re-run `gm-publish init` to re-scaffold. Also
-  corrected `configuration.md`'s Precedence section, which described
-  strict shadowing when list settings actually union across both config
-  sources (#144).
+  **Existing sites with an explicit exclude-sections list do not pick
+  this up automatically** — add `Reconciliation Context` and `Handoff to
+  Reconcile` by hand, either to `excludeSections` in `vault.config.json`
+  or to `publish.exclude_sections` in the vault's `vault-config.md` (the
+  two union, so either works). Also corrected `configuration.md`'s
+  Precedence section, which described strict shadowing when list settings
+  actually union across both config sources (#144).
 
 ### Added
 
-- `campaign-organizer` / `campaign-qa`: relationship predicates are now
-  validated against the authoritative vocabulary in
+- `campaign-qa`: relationship predicates are now validated against the
+  authoritative vocabulary in
   `skills/shared/gm-apprentice-ontology.json`. `vault_check.py
   relationships` (also folded into `vault_check.py all`) and a parallel
   check in `scripts/validate_schema.py` flag off-vocabulary predicates
@@ -79,7 +88,11 @@ and a guarded lifecycle helper for ephemeral e2e test resources.
   change-request loop (persistent monitor primitive preferred, a
   documented shell-loop fallback, a heartbeat liveness artifact, failure
   emission, request-id dedup, capped backoff) and pointers to the
-  manifest spec at the top of the relevant `SKILL.md` capability entries
+  manifest spec at the top of the relevant `SKILL.md` capability entries.
+  Also clarified the manifest's actual semantics in
+  `content-filtering.md`: it's an inclusion filter only on `mode: player`
+  sites — checking a box under `## Excluded` or `## Needs Decision` never
+  publishes a file — and `mode: full` ignores the manifest entirely
   (#143, #136).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,49 @@ guarded lifecycle helper for ephemeral e2e test resources.
   `configuration.md` also drops its claim that a per-PC `crest`
   frontmatter value overrides `publish.sheet_crest` — nothing reads
   `frontmatter.crest`; the crest is campaign-wide.
+  A malformed *per-file* entry under `overrides.fields` is now caught the
+  same way: an `include` written as a bare string made `filterFields` do
+  substring matching (`include: sec` re-admitting `secrets`), and any
+  other truthy non-list threw mid-build. Each bad entry is named, warned
+  about once, and dropped, so the exclusions stay in force. An explicitly
+  falsy `fields:` value reaches that validator now too — `||` used to swap
+  `fields: false` for the default before anything could report it.
+- `publish-site`: a relationship whose `description:` is a YAML block
+  scalar (`description: |`) put its indented prose back into the
+  predicate scan, so a line of narration beginning `type:` was reported as
+  an off-vocabulary predicate and failed both `validate_schema.py` and
+  `vault_check.py` on a perfectly valid note. Block-scalar content is now
+  skipped by column across the whole frontmatter walk. `scalar_value`
+  separately accepted a quoted scalar with trailing junk (`type: "npc"
+  trailing` validated as an `npc`); the closing quote must now be the last
+  thing on the line apart from blanks or a comment, and it is found past
+  `\"`/`''` escapes so a value like `"5'4\" - 6'0\""` survives whole
+  instead of truncating at the first inner quote.
+- `publish-site`: the landing page picked its "Latest Session" recap with
+  a substring test, so `[[Session 10]]` answered a lookup for `Session 1`
+  and the wrong session's narrative recap went out. The wrap-up's
+  `session:` ref is now parsed as a wikilink and compared for exact
+  equality, and that lookup runs *before* the `session_number` fallback,
+  which chapters make ambiguous by restarting the count. The looser
+  "ref mentions the session inside longer prose" match is kept as a last
+  resort but can no longer run on into a longer number. NFC
+  canonicalization at the comparison boundary is unchanged (#139).
+- `publish-site`: `inbox pull` spawned `wrangler` with no timeout, so a
+  hung network turn froze the change-request watcher before it could tick
+  `.watcher-heartbeat` — a live-but-stalled loop looked exactly like a
+  dead one, which is the single thing the heartbeat exists to tell apart.
+  Every wrangler call the inbox CLI makes is now bounded at 60s via the
+  shared `runCommand`, so a hang surfaces as a failed poll and the loop's
+  existing failure streak reports it. The documented fallback loop also
+  clamps `WATCHER_SLEEP` once up front: `${WATCHER_SLEEP:-30}` covered
+  unset and empty but not `0` (a flat-out poll against Cloudflare KV) or a
+  non-numeric value (`sleep` fails, loop keeps polling).
+- `publish-site`: the e2e resource helper's cleanup called `wrangler kv
+  namespace delete` and `wrangler pages project delete` without their
+  non-interactive confirmation flags. Both prompt by default, and cleanup
+  runs unattended, so the prompt would hang or read EOF as "no" and leak
+  the resource it was meant to remove. Added `--skip-confirmation` and
+  `--yes` respectively (the two commands spell it differently).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ guarded lifecycle helper for ephemeral e2e test resources.
   rendering for the first time, at the same corrected slug. Vaults with
   manually-pinned NFD manifest entries should update them to NFC now that
   matching no longer needs the workaround (#139).
+  The same normalization now covers every other table keyed by
+  author-typed text, not just the manifest: `buildLinkMap` (page titles
+  and aliases), `scanAttachments` (attachment basenames), `buildBacklinks`,
+  and the relationship graph's title map. A `[[wikilink]]`, `portrait:`
+  value, relationship target, or `![[embed]]` typed in a different normal
+  form than the file it names used to render as plain text or vanish
+  silently; each of those tables now canonicalizes keys and lookups, so
+  the whole boundary is covered rather than the manifest alone. Only
+  comparison keys are canonicalized — stored output paths and attachment
+  `relPath`s keep their exact bytes, so this stays orthogonal to the
+  `encodeHref` percent-encoding above (#139).
 - `publish-site`: the built-in default `exclude_sections` had drifted from
   the scaffold template, and `## Reconciliation Context` /
   `## Handoff to Reconcile` — written automatically by `reconcile` and
@@ -75,6 +86,14 @@ guarded lifecycle helper for ephemeral e2e test resources.
   two union, so either works). Also corrected `configuration.md`'s
   Precedence section, which described strict shadowing when list settings
   actually union across both config sources (#144).
+- `publish-site`: `publish.overrides` advertised three keys but the build
+  only ever read `overrides.fields`; a top-level `overrides.exclude` or
+  `overrides.include` was a silent no-op. Dropped both from the defaults,
+  and a config that still carries one now warns instead of ignoring it.
+  `configuration.md` documents the real shape — per-file field
+  re-admission keyed by vault-relative path — with a copyable example,
+  and no longer implies whole-file include/exclude lives there (it lives
+  in the publish manifest).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.49] — 2026-08-12
+
+Publish tool 1.11.22. Six published-site content-leak and encoding bugs
+fixed, relationship-predicate validation added to the vault-authoring gate,
+and a guarded lifecycle helper for ephemeral e2e test resources.
+
+### Fixed
+
+- `publish-site`: HTML comments (`<!-- ... -->`) were never stripped from
+  `publishedMarkdown`, so authoring notes leaked onto the homepage's
+  "Latest Session" teaser and into every story-spine page body. Added
+  `stripHtmlComments` to that chain, plus a site-wide regression test
+  asserting no generated `.html` contains a comment (#149).
+- `publish-site`: hand-built link destinations were not percent-encoded, so
+  any output path containing a space or parenthesis (vault subfolder names,
+  attachment filenames) rendered as literal bracket text instead of a link,
+  and the typographer separately mangled a leading `../` into `…/`.
+  Generalized the image-only `encodeImageUrl` into `encodeHref` and routed
+  every hand-built href through it across templates, the relationship
+  graph, breadcrumbs, and the context sidebar; `encodeImageUrl` stays as an
+  alias so existing image call sites are unchanged. Also fixed the
+  client-side search overlay (`js/search.js`), which built result links
+  from the same raw, unencoded path — there a stray `#` or `?` could
+  truncate or corrupt the link rather than just look odd (#145).
+- `publish-site`: manifest matching and slugs were Unicode-normalization-
+  naive, so an NFC manifest entry never matched an NFD-decomposed scanned
+  path and accented pages silently never rendered. Canonicalized to NFC at
+  the manifest/scanner comparison boundary and strip combining marks in
+  `slugify`; `overrides.fields` keys are now canonicalized the same way at
+  config load. **Slugs for previously-broken accented pages change as a
+  result** — those pages never rendered before, so nothing that worked
+  breaks. Vaults with manually-pinned NFD manifest entries should update
+  them to NFC now that matching no longer needs the workaround (#139).
+- `publish-site`: the built-in default `exclude_sections` had drifted from
+  the scaffold template, and `## Reconciliation Context` /
+  `## Handoff to Reconcile` — written automatically by `reconcile` and
+  `session-wrapup` — were publishing GM plot state to players. Both lists
+  now carry the same six entries (`GM Notes`, `DM Notes`, `Player Notes`,
+  `Source References`, `Reconciliation Context`, `Handoff to Reconcile`).
+  **Existing sites with an explicit `excludeSections` list in
+  `vault.config.json` do not pick this up automatically** — add the two
+  new entries by hand, or re-run `gm-publish init` to re-scaffold. Also
+  corrected `configuration.md`'s Precedence section, which described
+  strict shadowing when list settings actually union across both config
+  sources (#144).
+
+### Added
+
+- `campaign-organizer` / `campaign-qa`: relationship predicates are now
+  validated against the authoritative vocabulary in
+  `skills/shared/gm-apprentice-ontology.json`. `vault_check.py
+  relationships` (also folded into `vault_check.py all`) and a parallel
+  check in `scripts/validate_schema.py` flag off-vocabulary predicates
+  with nearest-match suggestions; campaign-qa's graph-health checks now
+  run the audit. `skills/shared/templates/plan.md`'s example relationship
+  swaps its blank `type: ""` for a real predicate (`located_at`), which
+  the new check would otherwise flag on day one (#130).
+- `tools/publish/lib/e2e-resources.js`: a guarded lifecycle helper for
+  ephemeral test resources used by the Cloudflare setup flow's e2e tests.
+  Names are always `e2e-<runId>-<label>`; cleanup deletes only records the
+  factory itself minted (checked by object identity, not name-prefix
+  matching); there is no list-and-delete or delete-by-title API at all;
+  dry-run reports without calling `wrangler`. Motivated by an incident
+  where an ad-hoc cleanup sweep deleted a production KV namespace. Policy
+  documented in `cloudflare-pages.md` (#142).
+
+### Changed
+
+- `publish-site` skill docs: added watcher-resilience guidance for the
+  change-request loop (persistent monitor primitive preferred, a
+  documented shell-loop fallback, a heartbeat liveness artifact, failure
+  emission, request-id dedup, capped backoff) and pointers to the
+  manifest spec at the top of the relevant `SKILL.md` capability entries
+  (#143, #136).
+
+---
+
 ## [1.8.48] — 2026-07-26
 
 Publish tool 1.11.21. Keeper callouts no longer leak onto the published site.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ guarded lifecycle helper for ephemeral e2e test resources.
   comparison keys are canonicalized — stored output paths and attachment
   `relPath`s keep their exact bytes, so this stays orthogonal to the
   `encodeHref` percent-encoding above (#139).
+  The `Map`/`Set`/`===` comparisons that no lookup table can cover are
+  normalized at their call sites too: recency scoring (an accented NPC
+  mentioned in the latest session never scored, so it never reached the
+  landing page's recent cards), wrap-up↔session pairing in both
+  `recency.js` and `story-spine.js` (a session's narrative recap silently
+  vanished from the Story page), the flat-vault chapter↔session match, and
+  the chapter page's constituent-sessions sidebar (#139).
 - `publish-site`: the built-in default `exclude_sections` had drifted from
   the scaffold template, and `## Reconciliation Context` /
   `## Handoff to Reconcile` — written automatically by `reconcile` and
@@ -93,7 +100,12 @@ guarded lifecycle helper for ephemeral e2e test resources.
   `configuration.md` documents the real shape — per-file field
   re-admission keyed by vault-relative path — with a copyable example,
   and no longer implies whole-file include/exclude lives there (it lives
-  in the publish manifest).
+  in the publish manifest). A malformed block (`overrides: fields`, or a
+  non-map `overrides.fields`) is now reported once with the expected
+  shape instead of being walked per character into invented keys.
+  `configuration.md` also drops its claim that a per-PC `crest`
+  frontmatter value overrides `publish.sheet_crest` — nothing reads
+  `frontmatter.crest`; the crest is campaign-wide.
 
 ### Added
 

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -39,6 +39,9 @@ from schema_rules import (  # noqa: E402
     SESSION_STATUS,
     WORLD_DOMAIN_STATUS,
     extract_frontmatter,
+    iter_relationship_predicates,
+    predicate_problem,
+    predicate_vocabulary,
 )
 
 
@@ -248,6 +251,30 @@ def validate_file(filepath: Path) -> list[str]:
     return errors
 
 
+def validate_relationships(filepath: Path) -> list[str]:
+    """Check every relationship predicate against the sanctioned vocabulary.
+
+    Runs beside validate_file rather than inside it: an off-vocabulary
+    edge is a defect whatever the entity type is, including on the files
+    validate_file bails out of early.
+    """
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return []  # validate_file already reports the unreadable file
+
+    vocabulary = predicate_vocabulary()
+    errors = []
+    for lineno, key, predicate in iter_relationship_predicates(content):
+        if predicate in vocabulary:
+            continue
+        errors.append(
+            f"Line {lineno}: {predicate_problem(key, predicate)} "
+            f"(map it via skills/shared/relationship-normalization.md)"
+        )
+    return errors
+
+
 # Content filtering rules — scenes that should be auto-excluded or auto-included
 FILTERING_EXCLUDE_STATUSES = {"cut", "skipped"}
 FILTERING_INCLUDE_STATUSES = {"played", "modified"}
@@ -419,7 +446,7 @@ def validate_campaign(campaign_dir: Path) -> int:
     files_with_errors = 0
 
     for filepath in sorted(md_files):
-        errors = validate_file(filepath)
+        errors = validate_file(filepath) + validate_relationships(filepath)
         if errors:
             files_with_errors += 1
             rel_path = filepath.relative_to(campaign_dir.parent) if campaign_dir.parent != Path(".") else filepath

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -39,6 +39,7 @@ from schema_rules import (  # noqa: E402
     SESSION_STATUS,
     WORLD_DOMAIN_STATUS,
     extract_frontmatter,
+    inverse_predicates,
     iter_relationship_predicates,
     predicate_problem,
     predicate_vocabulary,
@@ -443,6 +444,10 @@ def validate_campaign(campaign_dir: Path) -> int:
 
     try:
         vocabulary = predicate_vocabulary()
+        # Warm the inverse map here too: validate_relationships reaches it
+        # through predicate_problem() on a second cache, and an unguarded
+        # load there would abort the run mid-loop.
+        inverse_predicates()
     except (OSError, ValueError, KeyError, TypeError) as e:
         print(f"Error: cannot read the predicate vocabulary from the "
               f"ontology export: {e}")

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -45,14 +45,19 @@ from schema_rules import (  # noqa: E402
 )
 
 
-def validate_file(filepath: Path) -> list[str]:
-    """Validate a single markdown file. Returns list of errors."""
+def validate_file(filepath: Path, content: str | None = None) -> list[str]:
+    """Validate a single markdown file. Returns list of errors.
+
+    Pass `content` when the caller has already read the file, so a run
+    that applies several checks reads each note exactly once.
+    """
     errors = []
 
-    try:
-        content = filepath.read_text(encoding="utf-8")
-    except (OSError, UnicodeError) as e:
-        return [f"Could not read file: {e}"]
+    if content is None:
+        try:
+            content = filepath.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            return [f"Could not read file: {e}"]
 
     frontmatter = extract_frontmatter(content)
     if frontmatter is None:
@@ -251,19 +256,13 @@ def validate_file(filepath: Path) -> list[str]:
     return errors
 
 
-def validate_relationships(filepath: Path) -> list[str]:
+def validate_relationships(content: str, vocabulary: frozenset[str]) -> list[str]:
     """Check every relationship predicate against the sanctioned vocabulary.
 
     Runs beside validate_file rather than inside it: an off-vocabulary
-    edge is a defect whatever the entity type is, including on the files
+    edge is a defect whatever the entity type is, including in the files
     validate_file bails out of early.
     """
-    try:
-        content = filepath.read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
-        return []  # validate_file already reports the unreadable file
-
-    vocabulary = predicate_vocabulary()
     errors = []
     for lineno, key, predicate in iter_relationship_predicates(content):
         if predicate in vocabulary:
@@ -442,11 +441,25 @@ def validate_campaign(campaign_dir: Path) -> int:
         print(f"Warning: No markdown files found in {campaign_dir}")
         return 0
 
+    try:
+        vocabulary = predicate_vocabulary()
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        print(f"Error: cannot read the predicate vocabulary from the "
+              f"ontology export: {e}")
+        return 1
+
     total_errors = 0
     files_with_errors = 0
 
     for filepath in sorted(md_files):
-        errors = validate_file(filepath) + validate_relationships(filepath)
+        # One read per note, shared by every check below.
+        try:
+            content = filepath.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            errors = [f"Could not read file: {e}"]
+        else:
+            errors = (validate_file(filepath, content)
+                      + validate_relationships(content, vocabulary))
         if errors:
             files_with_errors += 1
             rel_path = filepath.relative_to(campaign_dir.parent) if campaign_dir.parent != Path(".") else filepath

--- a/skills/campaign-qa/references/checks/graph-health.md
+++ b/skills/campaign-qa/references/checks/graph-health.md
@@ -127,7 +127,14 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_check.py" \
 
 Walk each ERROR row with the GM fix-or-dismiss: rename to the
 suggested predicate, re-store an inverse on the other endpoint, or
-drop the edge if it is not entity-to-entity. Flag:
+drop the edge if it is not entity-to-entity.
+
+The check enforces the **full** vocabulary, not the campaign's
+genre-filtered subset — a predicate that is globally sanctioned but
+absent from this vault's `_meta/relationship-types.md` passes the
+tool and still breaks the rule above. Silence means "no invented
+predicates", not "genre-appropriate": scan the surviving types
+against `_meta/relationship-types.md` yourself. Flag:
 
 - **Off-vocabulary** — a `type:` not in the vocabulary at all
   (`hosts`, `contains`, `adjacent_to`, `carved_by`, `patrols`,

--- a/skills/campaign-qa/references/checks/graph-health.md
+++ b/skills/campaign-qa/references/checks/graph-health.md
@@ -112,7 +112,22 @@ in the vault must be a predicate listed in
 `shared/entity-schema.md`'s vocabulary). This is separate from,
 and more fundamental than, the vagueness check below — an
 invented predicate is worse than a vague one because no query,
-inverse-inference, or publish step knows about it. Flag:
+inverse-inference, or publish step knows about it.
+
+**Preferred procedure:** run the bundled check rather than
+eyeballing frontmatter — it reads the sanctioned vocabulary from
+`shared/gm-apprentice-ontology.json` and reports every off-vocabulary
+predicate (top-level `type:` and `mobrpg:` node `predicate:` alike)
+with its note, line, and the nearest sanctioned predicates:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_check.py" \
+  <vault-path> relationships
+```
+
+Walk each ERROR row with the GM fix-or-dismiss: rename to the
+suggested predicate, re-store an inverse on the other endpoint, or
+drop the edge if it is not entity-to-entity. Flag:
 
 - **Off-vocabulary** — a `type:` not in the vocabulary at all
   (`hosts`, `contains`, `adjacent_to`, `carved_by`, `patrols`,

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -129,10 +129,11 @@ Workflow:
    d. If everything matches, continue silently.
 3. **Check manifest freshness.** Compare the vault's publishable
    files against `_meta/publish-manifest.md`. Read
-   `references/content-filtering.md` § Manifest Format first — a file
-   publishes only as a **checked** entry under `## Publishing`; checking
-   the box under `## Excluded` or `## Needs Decision` doesn't publish it.
-   Look for:
+   `references/content-filtering.md` § Manifest Format first — in
+   `mode: player`, a file publishes only as a **checked** entry under
+   `## Publishing`; checking the box under `## Excluded` or
+   `## Needs Decision` doesn't publish it. `mode: full` doesn't filter
+   by the manifest at all. Look for:
    - **New files:** vault files not in the manifest. Apply the
      same categorization rules as capability 6 (always-exclude
      directories, prep files, etc.). Present new publishable
@@ -237,9 +238,11 @@ individually before pushing.
 "filter my campaign for players", "set up player view",
 "what will players see", "publish without spoilers"
 
-Read `references/content-filtering.md` § Manifest Format first — a file
-publishes only as a **checked** entry under `## Publishing`; checking the
-box under `## Excluded` or `## Needs Decision` doesn't publish it.
+Read `references/content-filtering.md` § Manifest Format first — in
+`mode: player`, a file publishes only as a **checked** entry under
+`## Publishing`; checking the box under `## Excluded` or
+`## Needs Decision` doesn't publish it. `mode: full` doesn't filter by
+the manifest at all.
 
 Workflow:
 1. Read `_meta/vault-config.md` for existing publish settings.

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -128,7 +128,10 @@ Workflow:
         {old version} to {new version}."
    d. If everything matches, continue silently.
 3. **Check manifest freshness.** Compare the vault's publishable
-   files against `_meta/publish-manifest.md`. Look for:
+   files against `_meta/publish-manifest.md`. Read
+   `references/content-filtering.md` § Manifest Format first — the H2
+   section (`## Publishing` / `## Excluded` / `## Needs Decision`), not
+   the checkbox state, determines inclusion. Look for:
    - **New files:** vault files not in the manifest. Apply the
      same categorization rules as capability 6 (always-exclude
      directories, prep files, etc.). Present new publishable
@@ -232,6 +235,10 @@ individually before pushing.
 **Trigger:** "only publish player content", "hide GM notes",
 "filter my campaign for players", "set up player view",
 "what will players see", "publish without spoilers"
+
+Read `references/content-filtering.md` § Manifest Format first — the H2
+section (`## Publishing` / `## Excluded` / `## Needs Decision`), not the
+checkbox state, determines inclusion.
 
 Workflow:
 1. Read `_meta/vault-config.md` for existing publish settings.

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -261,7 +261,8 @@ Workflow:
      files that don't match clear conventions.
 3. Write the publish manifest to `_meta/publish-manifest.md`.
 4. Present a summary and walk through ambiguous items.
-5. Save GM decisions to `vault-config.md` overrides.
+5. Record each decision in the manifest itself — checked under
+   `## Publishing`, or moved to `## Excluded` with a reason.
 6. Confirm the manifest is ready for the build tool.
 
 For subsequent publishes, the manifest delta check in

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -129,9 +129,10 @@ Workflow:
    d. If everything matches, continue silently.
 3. **Check manifest freshness.** Compare the vault's publishable
    files against `_meta/publish-manifest.md`. Read
-   `references/content-filtering.md` § Manifest Format first — the H2
-   section (`## Publishing` / `## Excluded` / `## Needs Decision`), not
-   the checkbox state, determines inclusion. Look for:
+   `references/content-filtering.md` § Manifest Format first — a file
+   publishes only as a **checked** entry under `## Publishing`; checking
+   the box under `## Excluded` or `## Needs Decision` doesn't publish it.
+   Look for:
    - **New files:** vault files not in the manifest. Apply the
      same categorization rules as capability 6 (always-exclude
      directories, prep files, etc.). Present new publishable
@@ -236,9 +237,9 @@ individually before pushing.
 "filter my campaign for players", "set up player view",
 "what will players see", "publish without spoilers"
 
-Read `references/content-filtering.md` § Manifest Format first — the H2
-section (`## Publishing` / `## Excluded` / `## Needs Decision`), not the
-checkbox state, determines inclusion.
+Read `references/content-filtering.md` § Manifest Format first — a file
+publishes only as a **checked** entry under `## Publishing`; checking the
+box under `## Excluded` or `## Needs Decision` doesn't publish it.
 
 Workflow:
 1. Read `_meta/vault-config.md` for existing publish settings.

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -238,9 +238,18 @@ stale by more than a tick or two (60-90s) means it died silently. But if
 you last relaunched it with a longer `WATCHER_SLEEP` for a stuck batch or a
 failing inbox (see the backoff notes in Start step 4 and "When the watcher
 reports failure"), a heartbeat that old is exactly what a *healthy* watcher
-looks like — check against roughly 2-3× whatever interval you set, and
-don't relaunch on top of a live watcher just because it looks stale by the
-30s yardstick.
+looks like — check against roughly 2-3× whatever interval you set before
+concluding it's dead.
+
+Once staleness is actually confirmed, act on it the same way "When the
+watcher reports failure" does:
+
+- **Fallback:** relaunch it (Start step 4) before assuming the queue is
+  simply empty.
+- **Primitive:** there's nothing to relaunch on your end — a supervised
+  task dying silently means the supervision itself failed, so ask the host
+  whether the task is still running rather than starting a second poller
+  on top of a primitive you can't directly restart.
 
 On "stop", **flush live state to the vault, then terminate the background
 watcher** and do not relaunch it:

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -35,11 +35,16 @@ does the waiting, and you only wake when a request actually arrives.
    - **dedup by request id** — track which ids it has already surfaced, so
      a batch that's still pending on the next poll (e.g. a deploy failure
      left it unresolved) notifies you once, not again every ~30s.
+   - **tick a heartbeat** — write something the GM can check in seconds to
+     confirm the loop is alive right now, not just when it has news (see
+     the Stop section's mid-session check — same file, same check, either
+     mode).
 
    **Fallback — plain background shell loop** (use this where the host has
    no such primitive; it can only notify you when the command exits, so it
    has to break out on purpose — on a batch *or* on a failure streak — and
-   get relaunched each time):
+   get relaunched each time). Run it **from `<site_dir>`** so the heartbeat
+   file lands somewhere the Stop-section check can find it:
 
    ```bash
    fail=0
@@ -59,7 +64,7 @@ does the waiting, and you only wake when a request actually arrives.
      else
        fail=0
      fi
-     sleep 30
+     sleep "${WATCHER_SLEEP:-30}"
    done
    ```
 
@@ -67,10 +72,22 @@ does the waiting, and you only wake when a request actually arrives.
    harness re-invokes you when it exits, either with a pending batch or with
    a failure-streak line — that covers the loop reporting its own trouble.
    What it can't self-report is dying outright (terminal closed, process
-   killed) with no exit notification at all; that's what `.watcher-heartbeat`
-   is for — see Stop below for the mid-session check. Idle time between
-   requests still costs no model tokens; you only think when there is real
-   work or a failure to report.
+   killed) with no exit notification at all; that's what
+   `<site_dir>/.watcher-heartbeat` is for — see Stop below for the
+   mid-session check. Idle time between requests still costs no model
+   tokens; you only think when there is real work or a failure to report.
+
+   Because the fallback exits and gets relaunched fresh each time, it has no
+   memory of its own — dedup here is **your** job, not the script's: keep
+   track (in your own working context, across the session) of which request
+   ids you've already surfaced. If a relaunch immediately hands you back the
+   exact same id set (a batch still stuck on a failed deploy, see "When a
+   batch arrives" step 4), that's not news — don't re-run the full
+   classify-and-apply flow, just retry the deploy, and relaunch with a
+   longer `WATCHER_SLEEP` (e.g. `120`, doubling on each repeat) instead of
+   the default 30s so a stuck batch doesn't wake you every half-minute
+   while you wait it out. Reset to the default 30s once a relaunch turns up
+   a genuinely new id.
 
 ## When a batch arrives
 
@@ -153,14 +170,34 @@ submission order (`timestamp` ascending), tracking **running unspent points**
      Log the failure.
 5. **Get the watcher running again for the next request**, per Start step 4:
    if you're on a persistent monitor primitive it's still running — nothing
-   to do. On the plain-shell fallback, relaunch the same loop. Idle resumes
-   at zero model-token cost either way.
+   to do. On the plain-shell fallback, relaunch the same loop — with a
+   longer `WATCHER_SLEEP` if you're relaunching because a deploy failed
+   and the same ids are still pending (see Start step 4's dedup note), the
+   default 30s otherwise. Idle resumes at zero model-token cost either way.
 
 Once a request reaches a terminal outcome it returns exactly one response to
 the chat log: `applied` (sheet redeployed), `rejected` (with the point-math
 reason), or `advice`. A deploy failure leaves the applied items `pending` to
 retry next tick, unreplied for now. `reply` is the single finalizer for every
 item — it supersedes the old `handled`/`flag` commands.
+
+## When the watcher reports failure
+
+The fallback loop can also wake you with `WATCHER: inbox pull failed N
+times in a row` instead of a batch — that's the inbox itself in trouble
+(KV outage, bad credentials, a network blip), not "nothing to do," and it
+needs diagnosis before you relaunch straight back into it:
+
+1. Run `npx gm-apprentice-publish inbox pull` once by hand and read the
+   actual error.
+2. **Fixable now** (e.g. re-authenticate, stale `wrangler` credentials):
+   fix it, confirm with one more manual pull, then relaunch at the normal
+   30s interval (Start step 4).
+3. **Not fixable immediately** (e.g. a Cloudflare outage): tell the GM the
+   change-request loop is degraded, then relaunch anyway so it keeps
+   trying — but with a longer `WATCHER_SLEEP` (e.g. `120`) so a still-broken
+   inbox doesn't wake you again every 30s while you wait it out. Drop back
+   to the default once a pull succeeds.
 
 ## Terminal log format
 
@@ -176,12 +213,12 @@ One line per request so a glance tells the whole story:
 
 **Mid-session liveness check.** A dead watcher and a quiet table look
 identical — no output either way. If a GM asks "is it still checking?", or a
-player says they submitted something and nothing happened, check
-`.watcher-heartbeat` (fallback loop) or ask the host whether the persistent
-monitor task is still running: `cat .watcher-heartbeat` shows the Unix
-timestamp of the last poll tick, written every ~30s. Stale by more than a
-tick or two (60-90s) means it died silently — relaunch it (Start step 4)
-before assuming the queue is simply empty.
+player says they submitted something and nothing happened, run
+`cat <site_dir>/.watcher-heartbeat` — it shows the Unix timestamp of the
+last poll tick, written every ~30s in both modes (Start step 4's
+primitive path and the fallback both tick it). Stale by more than a tick
+or two (60-90s) means it died silently — relaunch it (Start step 4) before
+assuming the queue is simply empty.
 
 On "stop", **flush live state to the vault, then terminate the background
 watcher** and do not relaunch it:
@@ -198,7 +235,9 @@ watcher** and do not relaunch it:
    body block) is skipped with a warning: the build reads vitals from that
    frontmatter and ignores the body, so a body write wouldn't take effect —
    author current status in the body block to let flush sync it.
-2. Terminate the background watcher.
+2. Terminate the background watcher, then `rm -f <site_dir>/.watcher-heartbeat`
+   — it's session-scoped scratch state, not something to leave behind in
+   the GM's site repo between sessions.
 
 The session code stays set in KV until the next "start your checking loop"
 replaces it. `flush` is also safe to run ad hoc at any time — it is idempotent,

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -52,6 +52,16 @@ does the waiting, and you only wake when a request actually arrives.
    file lands somewhere the Stop-section check can find it:
 
    ```bash
+   # WATCHER_SLEEP is GM-supplied: a non-numeric value would make `sleep` fail
+   # without stopping the loop, and 0 would poll flat out against Cloudflare KV.
+   # Clamp it once, up front, rather than trusting it each pass.
+   sleep_for=${WATCHER_SLEEP:-30}
+   case "$sleep_for" in
+     ''|*[!0-9]*) sleep_for=30 ;;
+   esac
+   [ "$sleep_for" -lt 1 ] && sleep_for=1
+   [ "$sleep_for" -gt 300 ] && sleep_for=300
+
    fail=0
    while :; do
      out=$(npx gm-apprentice-publish inbox pull 2>/dev/null)
@@ -69,9 +79,15 @@ does the waiting, and you only wake when a request actually arrives.
      else
        fail=0
      fi
-     sleep "${WATCHER_SLEEP:-30}"
+     sleep "$sleep_for"
    done
    ```
+
+   The poll itself needs no timeout wrapper: `inbox pull` bounds every
+   wrangler call it makes at 60s internally, so a hung network turn comes back
+   as a failed poll (counted toward the streak above) rather than freezing the
+   loop before it can tick the heartbeat. That holds for the primitive path in
+   Start step 4 too — same command, same bound.
 
    Run it as a **background command** (`run_in_background: true`). The
    harness re-invokes you when it exits, either with a pending batch or with

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -31,7 +31,10 @@ does the waiting, and you only wake when a request actually arrives.
    session, and make it:
    - **fail loud, not silent** — after N (e.g. 5) consecutive `inbox pull`
      failures, emit a visible failure line instead of staying quiet, so a
-     broken inbox looks different from an empty one.
+     broken inbox looks different from an empty one. Keep re-alerting every
+     N failures for as long as the outage lasts, not just once — it never
+     exits, so a single alert followed by silence would be the same dead
+     end this whole section exists to avoid.
    - **dedup by request id** — track which ids it has already surfaced, so
      a batch that's still pending on the next poll (e.g. a deploy failure
      left it unresolved) notifies you once, not again every ~30s.
@@ -84,10 +87,13 @@ does the waiting, and you only wake when a request actually arrives.
    exact same id set (a batch still stuck on a failed deploy, see "When a
    batch arrives" step 4), that's not news — don't re-run the full
    classify-and-apply flow, just retry the deploy, and relaunch with a
-   longer `WATCHER_SLEEP` (e.g. `120`, doubling on each repeat) instead of
-   the default 30s so a stuck batch doesn't wake you every half-minute
-   while you wait it out. Reset to the default 30s once a relaunch turns up
-   a genuinely new id.
+   longer `WATCHER_SLEEP` (e.g. `120`, doubling on each repeat but never
+   past `300`) instead of the default 30s so a stuck batch doesn't wake you
+   every half-minute while you wait it out. Cap it — a player's request
+   submitted after the deploy gets fixed still has to wait out whatever
+   interval is currently active before you see it, so don't let the backoff
+   run away past a few minutes. Reset to the default 30s once a relaunch
+   turns up a genuinely new id.
 
 ## When a batch arrives
 
@@ -183,21 +189,31 @@ item — it supersedes the old `handled`/`flag` commands.
 
 ## When the watcher reports failure
 
-The fallback loop can also wake you with `WATCHER: inbox pull failed N
-times in a row` instead of a batch — that's the inbox itself in trouble
-(KV outage, bad credentials, a network blip), not "nothing to do," and it
-needs diagnosis before you relaunch straight back into it:
+Either mode can wake you with a failure signal instead of a batch — the
+fallback with a `WATCHER: inbox pull failed N times in a row` line before
+it exits, the primitive by emitting the same kind of line without exiting
+(see Start step 4). Either way that's the inbox itself in trouble (KV
+outage, bad credentials, a network blip), not "nothing to do," and it
+needs diagnosis before you do anything else:
 
 1. Run `npx gm-apprentice-publish inbox pull` once by hand and read the
    actual error.
 2. **Fixable now** (e.g. re-authenticate, stale `wrangler` credentials):
-   fix it, confirm with one more manual pull, then relaunch at the normal
-   30s interval (Start step 4).
+   fix it, confirm with one more manual pull.
+   - **Fallback:** relaunch at the normal 30s interval (Start step 4) —
+     the process actually exited and stays dead until you do.
+   - **Primitive:** nothing to relaunch. It never exited; it picks up
+     cleanly on its next poll now that the inbox is healthy.
 3. **Not fixable immediately** (e.g. a Cloudflare outage): tell the GM the
-   change-request loop is degraded, then relaunch anyway so it keeps
-   trying — but with a longer `WATCHER_SLEEP` (e.g. `120`) so a still-broken
-   inbox doesn't wake you again every 30s while you wait it out. Drop back
-   to the default once a pull succeeds.
+   change-request loop is degraded.
+   - **Fallback:** relaunch anyway so it keeps trying, but with a longer
+     `WATCHER_SLEEP` (see Start step 4's backoff, capped at `300`) so a
+     still-broken inbox doesn't wake you again every 30s while you wait it
+     out. Drop back to the default once a pull succeeds.
+   - **Primitive:** still running on its own — expect a repeat alert every
+     N failures until the inbox recovers; there's nothing to relaunch or
+     back off, just don't mistake the repeat alerts for a new problem each
+     time.
 
 ## Terminal log format
 
@@ -215,10 +231,16 @@ One line per request so a glance tells the whole story:
 identical — no output either way. If a GM asks "is it still checking?", or a
 player says they submitted something and nothing happened, run
 `cat <site_dir>/.watcher-heartbeat` — it shows the Unix timestamp of the
-last poll tick, written every ~30s in both modes (Start step 4's
-primitive path and the fallback both tick it). Stale by more than a tick
-or two (60-90s) means it died silently — relaunch it (Start step 4) before
-assuming the queue is simply empty.
+last poll tick, written every poll in both modes (Start step 4's primitive
+path and the fallback both tick it). Judge staleness against the interval
+that's **currently active**, not a fixed number: at the default 30s cadence,
+stale by more than a tick or two (60-90s) means it died silently. But if
+you last relaunched it with a longer `WATCHER_SLEEP` for a stuck batch or a
+failing inbox (see the backoff notes in Start step 4 and "When the watcher
+reports failure"), a heartbeat that old is exactly what a *healthy* watcher
+looks like — check against roughly 2-3× whatever interval you set, and
+don't relaunch on top of a live watcher just because it looks stale by the
+30s yardstick.
 
 On "stop", **flush live state to the vault, then terminate the background
 watcher** and do not relaunch it:

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -38,10 +38,12 @@ does the waiting, and you only wake when a request actually arrives.
    - **dedup by request id** — track which ids it has already surfaced, so
      a batch that's still pending on the next poll (e.g. a deploy failure
      left it unresolved) notifies you once, not again every ~30s.
-   - **tick a heartbeat** — write something the GM can check in seconds to
-     confirm the loop is alive right now, not just when it has news (see
-     the Stop section's mid-session check — same file, same check, either
-     mode).
+   - **tick a heartbeat** — on every poll, write the current Unix timestamp
+     (`date +%s`) to `<site_dir>/.watcher-heartbeat`, overwriting it each
+     time, so the GM can confirm in seconds that the loop is alive right
+     now and not just when it has news. Same path and same format as the
+     shell fallback below, so the Stop section's mid-session check
+     (`cat <site_dir>/.watcher-heartbeat`) reads either mode identically.
 
    **Fallback — plain background shell loop** (use this where the host has
    no such primitive; it can only notify you when the command exits, so it

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -91,6 +91,7 @@ submission order (`timestamp` ascending), tracking **running unspent points**
 3. **Question → answer** using **player-safe scope only** — the published
    sheet/site + GURPS rules + the character's own non-GM sections. NEVER use
    `GM Notes`, `DM Notes`, `Player Notes`, `Source References`,
+   `Reconciliation Context`, `Handoff to Reconcile`,
    `<!-- gm-only -->` regions, other PCs' private data, or hidden plot/secret.
    If a good answer would need GM-only info, reply that it's beyond what you
    can see — never the hidden info itself. Answer as a brief bullet list, then

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -20,23 +20,57 @@ does the waiting, and you only wake when a request actually arrives.
    (or `node <tool>/bin/gm-publish.js inbox open WOLF`).
 3. Print it prominently for the GM to read to the table:
    `╔═══════════════╗  SESSION CODE: WOLF  ╚═══════════════╝`
-4. Launch the **background watcher** (below), then leave the session idle. The
-   watcher is a plain shell loop that polls the queue every ~30s and **sleeps
-   while it is empty — spending no model tokens**. It exits (waking you) only
-   when a request arrives.
+4. Launch the **watcher**, then leave the session idle. **If the host offers
+   a supervised or persistent monitor primitive — something that runs a task
+   for the whole session and notifies you as it produces output, rather than
+   only when the process exits — prefer it over a bare background shell
+   command.** That was the live-session workaround that actually held up: a
+   plain background shell loop can die without anyone noticing, and a dead
+   watcher looks exactly like a quiet table. Under a primitive like that, run
+   the poll continuously (no `break`, no relaunching) for the rest of the
+   session, and make it:
+   - **fail loud, not silent** — after N (e.g. 5) consecutive `inbox pull`
+     failures, emit a visible failure line instead of staying quiet, so a
+     broken inbox looks different from an empty one.
+   - **dedup by request id** — track which ids it has already surfaced, so
+     a batch that's still pending on the next poll (e.g. a deploy failure
+     left it unresolved) notifies you once, not again every ~30s.
+
+   **Fallback — plain background shell loop** (use this where the host has
+   no such primitive; it can only notify you when the command exits, so it
+   has to break out on purpose — on a batch *or* on a failure streak — and
+   get relaunched each time):
 
    ```bash
+   fail=0
    while :; do
      out=$(npx gm-apprentice-publish inbox pull 2>/dev/null)
-     if [ -n "$out" ] && [ "$out" != "[]" ]; then printf '%s\n' "$out"; break; fi
+     status=$?
+     date +%s > .watcher-heartbeat
+     if [ "$status" -ne 0 ]; then
+       fail=$((fail + 1))
+       if [ "$fail" -ge 5 ]; then
+         printf 'WATCHER: inbox pull failed %d times in a row\n' "$fail"
+         break
+       fi
+     elif [ -n "$out" ] && [ "$out" != "[]" ]; then
+       printf '%s\n' "$out"
+       break
+     else
+       fail=0
+     fi
      sleep 30
    done
    ```
 
-   Run it as a **background command** (`run_in_background: true`). The harness
-   re-invokes you when it exits — i.e. when the queue is non-empty — handing you
-   the pending JSON. Idle time between requests therefore costs no model tokens;
-   you only think when there is real work.
+   Run it as a **background command** (`run_in_background: true`). The
+   harness re-invokes you when it exits, either with a pending batch or with
+   a failure-streak line — that covers the loop reporting its own trouble.
+   What it can't self-report is dying outright (terminal closed, process
+   killed) with no exit notification at all; that's what `.watcher-heartbeat`
+   is for — see Stop below for the mid-session check. Idle time between
+   requests still costs no model tokens; you only think when there is real
+   work or a failure to report.
 
 ## When a batch arrives
 
@@ -117,8 +151,10 @@ submission order (`timestamp` ascending), tracking **running unspent points**
    - **On deploy failure:** do **not** reply — the entries stay `pending`
      (nothing else marks them) and are pulled again on the next watcher cycle.
      Log the failure.
-5. **Relaunch the background watcher** (the same command as in Start step 4) so
-   the next request wakes you. Idle resumes at zero model-token cost.
+5. **Get the watcher running again for the next request**, per Start step 4:
+   if you're on a persistent monitor primitive it's still running — nothing
+   to do. On the plain-shell fallback, relaunch the same loop. Idle resumes
+   at zero model-token cost either way.
 
 Once a request reaches a terminal outcome it returns exactly one response to
 the chat log: `applied` (sheet redeployed), `rejected` (with the point-math
@@ -137,6 +173,15 @@ One line per request so a glance tells the whole story:
 ```
 
 ## Stop
+
+**Mid-session liveness check.** A dead watcher and a quiet table look
+identical — no output either way. If a GM asks "is it still checking?", or a
+player says they submitted something and nothing happened, check
+`.watcher-heartbeat` (fallback loop) or ask the host whether the persistent
+monitor task is still running: `cat .watcher-heartbeat` shows the Unix
+timestamp of the last poll tick, written every ~30s. Stale by more than a
+tick or two (60-90s) means it died silently — relaunch it (Start step 4)
+before assuming the queue is simply empty.
 
 On "stop", **flush live state to the vault, then terminate the background
 watcher** and do not relaunch it:

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -354,7 +354,10 @@ skip it only if the loadout endpoint already put it there), then re-deploy.
    It prints an `id`.
 
    > **This command is for a real site's namespace only — never for test or
-   > session cleanup.** Issue #142: an ad-hoc cleanup sweep ran hand-typed
+   > session cleanup.** The "never hand-delete" rule applies to everyone; the
+   > tooling paragraph below is *for contributors and agent-driven test
+   > sessions* — it names a file in the gm-apprentice repo, not something a
+   > marketplace install has. Issue #142: an ad-hoc cleanup sweep ran hand-typed
    > `wrangler` commands and deleted a **production** `INBOX` namespace by
    > matching on its title. Ephemeral resources for E2E/session test work
    > must be created and torn down only through

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -353,6 +353,19 @@ skip it only if the loadout endpoint already put it there), then re-deploy.
 
    It prints an `id`.
 
+   > **This command is for a real site's namespace only — never for test or
+   > session cleanup.** Issue #142: an ad-hoc cleanup sweep ran hand-typed
+   > `wrangler` commands and deleted a **production** `INBOX` namespace by
+   > matching on its title. Ephemeral resources for E2E/session test work
+   > must be created and torn down only through
+   > `tools/publish/lib/e2e-resources.js`, which names everything
+   > `e2e-<runId>-<label>` and refuses to delete anything without that
+   > prefix — never `wrangler kv namespace delete` /
+   > `wrangler pages project delete` typed by hand or matched by listing.
+   > A plain `INBOX` (or any other production-shaped name) is never a valid
+   > deletion target, and cleanup always runs dry-run first to confirm the
+   > deletion list before anything is actually deleted.
+
 2. **Bind it in `wrangler.toml`.** A minimal Tier-1 `wrangler.toml` has no KV
    block yet — add one, pasting the id from step 1:
 

--- a/skills/publish-site/references/cloudflare-pages.md
+++ b/skills/publish-site/references/cloudflare-pages.md
@@ -364,7 +364,9 @@ skip it only if the loadout endpoint already put it there), then re-deploy.
    > `wrangler pages project delete` typed by hand or matched by listing.
    > A plain `INBOX` (or any other production-shaped name) is never a valid
    > deletion target, and cleanup always runs dry-run first to confirm the
-   > deletion list before anything is actually deleted.
+   > deletion list before anything is actually deleted. Each test run must
+   > pick its own unique `runId` — two runs sharing one would let one run's
+   > cleanup delete the other's still-in-use resources.
 
 2. **Bind it in `wrangler.toml`.** A minimal Tier-1 `wrangler.toml` has no KV
    block yet — add one, pasting the id from step 1:

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -165,6 +165,7 @@ display settings that are specific to the generated site.
 | Folder map | `folderMap` | Maps vault folders to site output paths |
 | Exclude directories | `excludeDirs` | Unioned with `publish.exclude_dirs` in `vault-config.md` (see § Precedence) |
 | Exclude sections | `excludeSections` | Unioned with `publish.exclude_sections` in `vault-config.md` (see § Precedence) |
+| Exclude fields | `excludeFields` | Unioned with `publish.exclude_fields` in `vault-config.md` (see § Precedence) |
 | Exclude callouts | `excludeCallouts` | Fallback if `vault-config.md` doesn't set `publish.exclude_callouts`. `true` strips all callouts, or an array of types |
 | Preserve directories | `preserveDirs` | Output subdirectories to keep across builds |
 
@@ -183,20 +184,30 @@ when **neither** file provides a list for that setting; as soon as
 either does, the default stops applying on its own (it is not unioned
 in alongside them).
 
-**`vault-config.md`-only settings** — `mode`, `system`,
-`exclude_drafts`, `theme`, `four_oh_four`, `overrides`,
-`section_titles`, and `setting_year` — are never read from
-`vault.config.json` at all: the `vault-config.md` value applies when
-set, otherwise the built-in default (`system` and `setting_year` have
-none — unset just means unset). Putting them in the JSON file does
-nothing.
+**`vault-config.md`-only settings** — `mode`, `exclude_drafts`,
+`theme`, `four_oh_four`, `overrides`, `section_titles`, and
+`setting_year` — are never read from `vault.config.json` at all: the
+`vault-config.md` value applies when set, otherwise the built-in
+default (`setting_year` has none — unset just means unset). Putting
+them in the JSON file does nothing.
+
+`publish.system` is *almost* one of them: the build reads it from
+`vault-config.md` only, but the `flush` command falls back to a
+top-level `system` in `vault.config.json` when `publish.system` is
+unset, to pick the GURPS vs CoC writeback. Set it in `vault-config.md`
+and both agree; if a legacy site has it only in the JSON, leave it
+there — deleting it would change what `flush` writes back.
 
 **Scalar and passthrough settings** — `sheet_crest`, `exclude_callouts`,
 `backend.statusBar`/`backend.inbox`, and the per-key settings inside
 `images`, `banners`, and `locations` — follow simple precedence: the
 `vault-config.md` `publish.*` value wins when set, `vault.config.json`
 is used only as a fallback when `vault-config.md` doesn't set it, and
-the built-in default applies only when neither file sets it.
+where the setting has a built-in default (`exclude_callouts` and the
+`images` keys) that default applies only when neither file sets it.
+`sheet_crest`, `banners`, `locations` and `backend.*` have no built-in
+default at all — unset stays unset, deliberately, so the build can tell
+"never configured" apart from "configured off".
 
 ---
 

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -29,7 +29,7 @@ each other — see § Precedence.
 | Image optimization | `publish.images` | Opt-in WebP re-encoding of copied images (default: off) |
 | Section banners | `publish.banners` | Hero image or clickable map at the top of a section index |
 | Locations grouping | `publish.locations` | Pivot the Locations index on a `location_type` (default: genre-derived) |
-| CoC sheet crest | `publish.sheet_crest` | Vault-relative image for the Order crest / wax seal in the CoC investigator-sheet masthead. Renders only when set and the image exists; a per-PC `crest` frontmatter value overrides it |
+| CoC sheet crest | `publish.sheet_crest` | Vault-relative image for the Order crest / wax seal in the CoC investigator-sheet masthead. Renders only when set and the image exists. Campaign-wide — there is no per-PC override |
 | Setting year | `setting_year` | Fallback in-game date on the landing page (used only when the campaign overview has no `current_game_date`) |
 
 > **Landing page state.** The landing hero (in-game date, session count) and the

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -6,8 +6,10 @@ which file owns which setting prevents confusion.
 ## `_meta/vault-config.md` (in the vault)
 
 YAML frontmatter under `publish:`. This is the authoritative
-source for content filtering and theming. Values here override
-any equivalent in `vault.config.json`.
+source for content filtering and theming. Values here take
+precedence over `vault.config.json` for scalar settings; the
+exclude **lists** union across both files rather than shadowing
+each other — see § Precedence.
 
 | Setting | Key path | Description |
 |---------|----------|-------------|
@@ -161,14 +163,14 @@ display settings that are specific to the generated site.
 | Cloudflare project | `cloudflarePagesProject` | Optional. Cloudflare Pages project name for deploys. Defaults to the site directory's folder name. |
 | Attachments directory | `attachmentsDir` | Subfolder in vault holding images |
 | Folder map | `folderMap` | Maps vault folders to site output paths |
-| Exclude directories | `excludeDirs` | Fallback if `vault-config.md` doesn't set `publish.exclude_dirs` |
-| Exclude sections | `excludeSections` | Fallback if `vault-config.md` doesn't set `publish.exclude_sections` |
+| Exclude directories | `excludeDirs` | Unioned with `publish.exclude_dirs` in `vault-config.md` (see § Precedence) |
+| Exclude sections | `excludeSections` | Unioned with `publish.exclude_sections` in `vault-config.md` (see § Precedence) |
 | Exclude callouts | `excludeCallouts` | Fallback if `vault-config.md` doesn't set `publish.exclude_callouts`. `true` strips all callouts, or an array of types |
 | Preserve directories | `preserveDirs` | Output subdirectories to keep across builds |
 
 ## Precedence
 
-Two different rules apply, depending on the setting.
+Three different rules apply, depending on the setting.
 
 **List settings** — `exclude_sections`, `exclude_fields`, `exclude_dirs`
 — are **unioned**, not overridden. If `publish.exclude_sections` (etc.)
@@ -180,6 +182,14 @@ neither file shadows the other. The built-in default list is used only
 when **neither** file provides a list for that setting; as soon as
 either does, the default stops applying on its own (it is not unioned
 in alongside them).
+
+**`vault-config.md`-only settings** — `mode`, `system`,
+`exclude_drafts`, `theme`, `four_oh_four`, `overrides`,
+`section_titles`, and `setting_year` — are never read from
+`vault.config.json` at all: the `vault-config.md` value applies when
+set, otherwise the built-in default (`system` and `setting_year` have
+none — unset just means unset). Putting them in the JSON file does
+nothing.
 
 **Scalar and passthrough settings** — `sheet_crest`, `exclude_callouts`,
 `backend.statusBar`/`backend.inbox`, and the per-key settings inside

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -23,7 +23,7 @@ each other — see § Precedence.
 | Theme fonts | `publish.theme.fonts` | Heading and body font families |
 | Theme genre | `publish.theme.genre` | Genre tag for theming hints |
 | 404 message | `publish.four_oh_four.message` | Custom in-world 404 text |
-| Overrides | `publish.overrides` | Per-file include/exclude/field overrides |
+| Per-file field overrides | `publish.overrides.fields` | Re-admit an excluded frontmatter field for one named file (see § Per-file field overrides) |
 | Section index titles | `publish.section_titles` | Override h1 titles on the Locations/Factions/Items/Creatures index pages |
 | Exclude drafts | `publish.exclude_drafts` | When `true`, DRAFT entities are excluded entirely (default: `false`) |
 | Image optimization | `publish.images` | Opt-in WebP re-encoding of copied images (default: off) |
@@ -146,6 +146,34 @@ scaffolding above the pivot (the Republic, the Sector) is demoted to a
 small context caption rather than rendered as tree rows. Grouping is
 skipped — falling back to the flat view — when fewer than two locations
 match the pivot, since one section is not a grouping.
+
+### Per-file field overrides
+
+`exclude_fields` strips a frontmatter field from every page. When one
+page needs a stripped field back, name that page under
+`publish.overrides.fields` and list the fields to re-admit:
+
+```yaml
+publish:
+  exclude_fields: [secrets, gm_notes]
+  overrides:
+    fields:
+      "Characters/NPCs/Vex Ambrose.md":
+        include: [secrets]
+```
+
+The key is the **vault-relative path** of the note, extension included —
+not its title, and not a glob. `include` is an allowlist checked against
+`exclude_fields`: it re-admits a field that would otherwise be stripped,
+and naming a field that isn't excluded does nothing. There is no
+per-file `exclude`; to strip a field from one page only, remove it from
+that page's frontmatter.
+
+`fields` is the only key under `overrides` that the build reads. Whole
+files are included or excluded through the publish manifest
+(`_meta/publish-manifest.md`), not here — see
+`content-filtering.md`. A build warns on any other
+`publish.overrides.*` key rather than ignoring it silently.
 
 ## `vault.config.json` (in the site repo)
 

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -12,7 +12,7 @@ any equivalent in `vault.config.json`.
 | Setting | Key path | Description |
 |---------|----------|-------------|
 | Publish mode | `publish.mode` | `player` or `full` |
-| Excluded sections | `publish.exclude_sections` | H2 headings to strip (default: `["GM Notes"]`) |
+| Excluded sections | `publish.exclude_sections` | H2 headings to strip (default: `["GM Notes", "DM Notes", "Player Notes", "Source References", "Reconciliation Context", "Handoff to Reconcile"]`) |
 | Excluded callouts | `publish.exclude_callouts` | Strip Obsidian callouts (`> [!type]`): `true` for all, or an array of types (default: `false`; scaffolded sites set `true`) |
 | Excluded fields | `publish.exclude_fields` | Frontmatter fields to strip (default: `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`) |
 | Excluded directories | `publish.exclude_dirs` | Vault directories to skip (default: `["_meta", "_Templates"]`) |

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -168,10 +168,25 @@ display settings that are specific to the generated site.
 
 ## Precedence
 
-When both files define the same setting (e.g. `excludeSections`
-in `vault.config.json` and `publish.exclude_sections` in
-`vault-config.md`), the vault-config.md value wins. The JSON
-file values are used only as fallbacks.
+Two different rules apply, depending on the setting.
+
+**List settings** — `exclude_sections`, `exclude_fields`, `exclude_dirs`
+— are **unioned**, not overridden. If `publish.exclude_sections` (etc.)
+in `vault-config.md` and the matching `excludeSections`/`excludeFields`/
+`excludeDirs` in `vault.config.json` both supply a list, the two lists
+are merged (case-insensitively deduplicated, first-seen casing kept), so
+a section/field/directory named in only one file is still excluded —
+neither file shadows the other. The built-in default list is used only
+when **neither** file provides a list for that setting; as soon as
+either does, the default stops applying on its own (it is not unioned
+in alongside them).
+
+**Scalar and passthrough settings** — `sheet_crest`, `exclude_callouts`,
+`backend.statusBar`/`backend.inbox`, and the per-key settings inside
+`images`, `banners`, and `locations` — follow simple precedence: the
+`vault-config.md` `publish.*` value wins when set, `vault.config.json`
+is used only as a fallback when `vault-config.md` doesn't set it, and
+the built-in default applies only when neither file sets it.
 
 ---
 

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -10,7 +10,7 @@ All campaign content falls into three categories:
 - All prep files: sessions/scenes with `status: planned | prepped`,
   `stage: outline | draft | ready`
 - Files with `source: "prep"` that have no played counterpart
-- H2 sections listed in `exclude_sections` (default: `["GM Notes"]`)
+- H2 sections listed in `exclude_sections` (default: `["GM Notes", "DM Notes", "Player Notes", "Source References", "Reconciliation Context", "Handoff to Reconcile"]`)
 - Content between `<!-- gm-only -->` / `<!-- /gm-only -->` markers
 - **Every other `<!-- ... -->` comment.** Private authoring notes
   (`<!-- UNVERIFIED: … -->`, change logs, import provenance) are

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -149,11 +149,15 @@ The build tool reads this file directly — no rescanning needed.
 The manifest is a markdown file with YAML frontmatter and three
 H2 sections. The build tool's parser (`lib/manifest.js`) uses the
 heading to bucket each entry into Publishing/Excluded/Needs
-Decision, and only the Publishing bucket ever reaches the build —
-so a file publishes if and only if it's a **checked** entry there.
-Checking the box under `## Excluded` or `## Needs Decision` records
-that the GM confirmed the categorization; it does not publish the
-file, because those buckets are never read for inclusion.
+Decision. Only `mode: player` (see § Publish Modes) enforces the
+manifest as an inclusion filter — and even there, a file publishes
+if and only if it's a **checked** entry under `## Publishing`.
+Checking the box under `## Excluded` or `## Needs Decision` never
+publishes the file: those buckets are read (Excluded, to suppress a
+separate "missing from manifest" warning) but never for inclusion.
+In `mode: full` (the GM's own copy), the manifest isn't applied as
+a filter at all — every scanned page publishes regardless of what's
+checked.
 
 **Frontmatter** (metadata, not used by the build tool):
 

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -147,8 +147,13 @@ The build tool reads this file directly — no rescanning needed.
 ### Manifest Format
 
 The manifest is a markdown file with YAML frontmatter and three
-H2 sections. The build tool's parser (`lib/manifest.js`) reads
-the sections by heading prefix and checkbox state.
+H2 sections. The build tool's parser (`lib/manifest.js`) uses the
+heading to bucket each entry into Publishing/Excluded/Needs
+Decision, and only the Publishing bucket ever reaches the build —
+so a file publishes if and only if it's a **checked** entry there.
+Checking the box under `## Excluded` or `## Needs Decision` records
+that the GM confirmed the categorization; it does not publish the
+file, because those buckets are never read for inclusion.
 
 **Frontmatter** (metadata, not used by the build tool):
 

--- a/skills/shared/scripts/schema_rules.py
+++ b/skills/shared/scripts/schema_rules.py
@@ -90,13 +90,33 @@ DEPRECATED_FIELDS: dict[str, list[tuple[str, str, str]]] = {
 }
 
 
+# A complete quoted scalar and nothing else after it but blanks or a comment.
+# The closing quote is the *unescaped* one (`\"` inside double quotes, `''`
+# inside single), so `"5'4\" - 6'0\""` is one value rather than a truncated
+# prefix. Content after the closing quote means the line is not a valid quoted
+# scalar at all — see scalar_value.
+QUOTED_SCALAR_RE = re.compile(
+    r"""^(?:"((?:\\.|[^"\\])*)"|'((?:''|[^'])*)')\s*(?:\#.*)?$"""
+)
+
+
 def scalar_value(value: str) -> str:
-    """Unwrap a YAML scalar: quoted content, or unquoted up to a comment."""
-    m = re.match(r"""^(['"])(.*?)\1""", value.strip())
+    """Unwrap a YAML scalar: quoted content, or unquoted up to a comment.
+
+    A quoted scalar with trailing content (`type: "npc" trailing`) is not
+    valid YAML. Unwrapping it would hand a clean-looking `npc` to the type
+    and predicate checks and pass malformed frontmatter silently, so the raw
+    text is returned instead and the caller reports it.
+    """
+    text = value.strip()
+    m = QUOTED_SCALAR_RE.match(text)
     if m:
-        return m.group(2)
+        # Escapes are left as authored — nothing downstream compares against
+        # an unescaped form, and decoding them here would be a second guess
+        # at YAML this parser is deliberately not implementing.
+        return m.group(1) if m.group(1) is not None else m.group(2)
     # Unquoted: a ' #' starts a YAML comment.
-    return re.split(r"\s+#", value.strip(), maxsplit=1)[0].strip()
+    return re.split(r"\s+#", text, maxsplit=1)[0].strip()
 
 
 def extract_frontmatter(content: str) -> dict | None:
@@ -185,6 +205,11 @@ ONTOLOGY_PATH = Path(__file__).resolve().parent.parent / "gm-apprentice-ontology
 # authored frontmatter, `predicate` in the machine-managed `mobrpg:` node.
 RELATIONSHIP_KEY_RE = re.compile(r"^(?:-\s+)?(type|predicate):\s*(.*)$")
 FRONTMATTER_KEY_RE = re.compile(r"^([\w-]+):\s*(.*)$")
+# A key whose value is a YAML block scalar header (`|`, `>`, with optional
+# indentation/chomping indicators and a trailing comment). Matched against the
+# *raw* line so group 1 gives the key's own column — content belonging to the
+# block is indented past it, and the next sibling key is not.
+BLOCK_SCALAR_OPEN_RE = re.compile(r"^(\s*(?:-\s+)?)[\w-]+:\s*[|>][0-9+-]*\s*(?:#.*)?$")
 
 
 def _ontology_predicates() -> list[dict]:
@@ -245,11 +270,20 @@ def iter_relationship_predicates(content: str):
     if not match:
         return
     block_indent = None
+    scalar_indent = None
     for offset, line in enumerate(match.group(1).split("\n")):
         stripped = line.strip()
         if not stripped:
             continue
         indent = len(line) - len(line.lstrip())
+        # Inside a block scalar (`description: |`), every more-indented line is
+        # literal text, not YAML. A relationship description whose prose begins
+        # `type:` is not an edge, and a folded note that quotes a whole
+        # `relationships:` block does not open one.
+        if scalar_indent is not None:
+            if indent > scalar_indent:
+                continue
+            scalar_indent = None
         # The block ends at the next key at or above its own indent.
         if block_indent is not None and indent <= block_indent \
                 and not stripped.startswith("-"):
@@ -260,6 +294,10 @@ def iter_relationship_predicates(content: str):
             # still opens a block whose edges follow.
             value = key.group(2).strip()
             block_indent = indent if not value or value.startswith("#") else None
+            continue
+        opener = BLOCK_SCALAR_OPEN_RE.match(line)
+        if opener:
+            scalar_indent = len(opener.group(1))
             continue
         if block_indent is None:
             continue

--- a/skills/shared/scripts/schema_rules.py
+++ b/skills/shared/scripts/schema_rules.py
@@ -256,7 +256,10 @@ def iter_relationship_predicates(content: str):
             block_indent = None
         key = FRONTMATTER_KEY_RE.match(stripped)
         if key and key.group(1) == "relationships":
-            block_indent = indent if not key.group(2).strip() else None
+            # A trailing comment is not a value: `relationships:  # later`
+            # still opens a block whose edges follow.
+            value = key.group(2).strip()
+            block_indent = indent if not value or value.startswith("#") else None
             continue
         if block_indent is None:
             continue

--- a/skills/shared/scripts/schema_rules.py
+++ b/skills/shared/scripts/schema_rules.py
@@ -8,7 +8,11 @@ skills/shared/ so it ships with the plugin; the dev validator
 imports it from the repo. Stdlib only.
 """
 
+import json
 import re
+from difflib import get_close_matches
+from functools import lru_cache
+from pathlib import Path
 
 # Valid enum values
 CANON_STATUS_VALUES = {"DRAFT", "AUTHORITATIVE", "SUPERSEDED", "STUB"}
@@ -86,6 +90,15 @@ DEPRECATED_FIELDS: dict[str, list[tuple[str, str, str]]] = {
 }
 
 
+def scalar_value(value: str) -> str:
+    """Unwrap a YAML scalar: quoted content, or unquoted up to a comment."""
+    m = re.match(r"""^(['"])(.*?)\1""", value.strip())
+    if m:
+        return m.group(2)
+    # Unquoted: a ' #' starts a YAML comment.
+    return re.split(r"\s+#", value.strip(), maxsplit=1)[0].strip()
+
+
 def extract_frontmatter(content: str) -> dict | None:
     """Extract YAML frontmatter from markdown content."""
     # Handle both LF and CRLF line endings
@@ -116,16 +129,7 @@ def extract_frontmatter(content: str) -> dict | None:
         if ":" in line and not line.startswith(" ") and not line.startswith("\t"):
             key, _, value = line.partition(":")
             key = key.strip()
-            value = value.strip()
-
-            # Quoted value: take the quoted content, drop anything after
-            # (including trailing YAML comments).
-            m = re.match(r"""^(['"])(.*?)\1""", value)
-            if m:
-                value = m.group(2)
-            else:
-                # Unquoted: a ' #' starts a YAML comment.
-                value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
+            value = scalar_value(value)
 
             # Handle empty value (might be start of array)
             if value == "" or value == "[]":
@@ -165,3 +169,98 @@ def parse_session_number(value) -> int | None:
         return None
     n = int(m.group(1))
     return n if n <= MAX_PLAUSIBLE_SESSION else None
+
+
+# Relationship predicate vocabulary
+#
+# The authoritative list is the predicate table in entity-schema.md; the
+# ontology export beside this package restates it machine-readably (and
+# scripts/validate_ontology.py fails CI when the two disagree), so the
+# export is what code reads. Resolved from this file's own location: the
+# vocabulary travels with the plugin, never with the vault under audit.
+
+ONTOLOGY_PATH = Path(__file__).resolve().parent.parent / "gm-apprentice-ontology.json"
+
+# Predicate-bearing keys inside a `relationships:` block: `type` in
+# authored frontmatter, `predicate` in the machine-managed `mobrpg:` node.
+RELATIONSHIP_KEY_RE = re.compile(r"^(?:-\s+)?(type|predicate):\s*(.*)$")
+FRONTMATTER_KEY_RE = re.compile(r"^([\w-]+):\s*(.*)$")
+
+
+def _ontology_predicates() -> list[dict]:
+    return json.loads(ONTOLOGY_PATH.read_text(encoding="utf-8"))["predicates"]
+
+
+@lru_cache(maxsize=1)
+def predicate_vocabulary() -> frozenset[str]:
+    """The sanctioned relationship predicates. Raises if the export is unusable."""
+    return frozenset(p["type"] for p in _ontology_predicates())
+
+
+@lru_cache(maxsize=1)
+def inverse_predicates() -> dict[str, str]:
+    """Inverse name -> the sanctioned predicate it inverts.
+
+    Inverse names (`led_by`, `owned_by`, `imprisoned_by`) are implied, never
+    stored, so they are off-vocabulary — but they are the one class of bad
+    predicate whose fix is exact rather than a guess.
+    """
+    return {p["inverse"]: p["type"]
+            for p in _ontology_predicates() if p.get("inverse")}
+
+
+def suggest_predicates(predicate: str) -> list[str]:
+    """Up to three sanctioned predicates close to an off-vocabulary one."""
+    return get_close_matches(predicate, sorted(predicate_vocabulary()), n=3)
+
+
+def predicate_problem(key: str, predicate: str) -> str:
+    """Describe what is wrong with a predicate, and how to fix it.
+
+    Shared by both reporters so the vault-facing check and CI say the same
+    thing about the same edge; each wraps it in its own row format.
+    """
+    if not predicate:
+        return f"blank relationship {key} — every edge needs a sanctioned predicate"
+    problem = f"off-vocabulary relationship {key} '{predicate}'"
+    base = inverse_predicates().get(predicate)
+    if base:
+        return (f"{problem} — inverse of '{base}'; storage is single-direction, "
+                f"so record '{base}' on the other endpoint")
+    near = suggest_predicates(predicate)
+    if near:
+        return f"{problem} — did you mean {', '.join(near)}?"
+    return f"{problem} — no close match"
+
+
+def iter_relationship_predicates(content: str):
+    """Yield (lineno, key, predicate) for every edge in a `relationships:` block.
+
+    Covers both storage shapes: the authored top-level block (`type:`) and
+    the `mobrpg:` node's nested one (`predicate:`). Block style only — a
+    `relationships: []` or inline-flow value carries no edges to check.
+    Line numbers are 1-based within the file, so findings are navigable.
+    """
+    match = re.match(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", content, re.DOTALL)
+    if not match:
+        return
+    block_indent = None
+    for offset, line in enumerate(match.group(1).split("\n")):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        indent = len(line) - len(line.lstrip())
+        # The block ends at the next key at or above its own indent.
+        if block_indent is not None and indent <= block_indent \
+                and not stripped.startswith("-"):
+            block_indent = None
+        key = FRONTMATTER_KEY_RE.match(stripped)
+        if key and key.group(1) == "relationships":
+            block_indent = indent if not key.group(2).strip() else None
+            continue
+        if block_indent is None:
+            continue
+        edge = RELATIONSHIP_KEY_RE.match(stripped)
+        if edge:
+            # +2: line 1 is the opening `---`, so frontmatter starts at 2.
+            yield offset + 2, edge.group(1), scalar_value(edge.group(2))

--- a/skills/shared/scripts/vault_check.py
+++ b/skills/shared/scripts/vault_check.py
@@ -14,6 +14,7 @@ Usage:
   vault_check.py VAULT tables
   vault_check.py VAULT timeline
   vault_check.py VAULT read-aloud
+  vault_check.py VAULT relationships
   vault_check.py VAULT all
 
 Skips hidden directories, `_Templates/`, and `_inbox/` (staging).
@@ -40,7 +41,10 @@ from schema_rules import (
     SCENE_TYPES,
     SESSION_STATUS,
     extract_frontmatter,
+    iter_relationship_predicates,
     parse_session_number,
+    predicate_problem,
+    predicate_vocabulary,
 )
 
 SKIP_DIRS = {"_Templates", "_templates", "_inbox"}
@@ -493,12 +497,37 @@ def check_read_aloud(vault: Path) -> list[str]:
     return rows
 
 
+def check_relationships(vault: Path) -> list[str]:
+    """Every relationship predicate must come from the sanctioned vocabulary.
+
+    An invented `type:` is worse than a vague one: no query, no
+    inverse-inference and no publish step knows about it, so the edge is
+    written and then silently ignored (issue #130 — one session's entity
+    generation invented eleven of them). ERROR, with the nearest
+    sanctioned predicates so the fix is a rename, not a hunt."""
+    try:
+        vocabulary = predicate_vocabulary()
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        return [f"ERROR\t(vault)\tcannot read the predicate vocabulary "
+                f"from shared/gm-apprentice-ontology.json: {e}"]
+    rows = []
+    for rel, text in vault_files(vault):
+        for lineno, key, predicate in iter_relationship_predicates(text):
+            if predicate in vocabulary:
+                continue
+            rows.append(f"ERROR\t{rel}:{lineno}\t"
+                        f"{predicate_problem(key, predicate)} "
+                        f"(map it via shared/relationship-normalization.md)")
+    return rows
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("vault", type=Path)
     ap.add_argument("command", choices=["frontmatter", "names", "index",
                                         "stale-drafts", "changed", "tables",
-                                        "timeline", "read-aloud", "all"])
+                                        "timeline", "read-aloud",
+                                        "relationships", "all"])
     ap.add_argument("--folder", help="restrict frontmatter check to subfolder")
     ap.add_argument("--threshold", type=float, default=0.85,
                     help="similarity ratio for names (default 0.85)")
@@ -530,6 +559,8 @@ def main() -> int:
         emit("timeline", check_timeline(args.vault))
     if args.command in ("read-aloud", "all"):
         emit("read-aloud", check_read_aloud(args.vault))
+    if args.command in ("relationships", "all"):
+        emit("relationships", check_relationships(args.vault))
     return 0
 
 

--- a/skills/shared/scripts/vault_check.py
+++ b/skills/shared/scripts/vault_check.py
@@ -41,6 +41,7 @@ from schema_rules import (
     SCENE_TYPES,
     SESSION_STATUS,
     extract_frontmatter,
+    inverse_predicates,
     iter_relationship_predicates,
     parse_session_number,
     predicate_problem,
@@ -507,6 +508,9 @@ def check_relationships(vault: Path) -> list[str]:
     sanctioned predicates so the fix is a rename, not a hunt."""
     try:
         vocabulary = predicate_vocabulary()
+        # Warm the inverse map here too: predicate_problem() reads it through
+        # a second cache, and an unguarded load there would abort `all`.
+        inverse_predicates()
     except (OSError, ValueError, KeyError, TypeError) as e:
         return [f"ERROR\t(vault)\tcannot read the predicate vocabulary "
                 f"from shared/gm-apprentice-ontology.json: {e}"]

--- a/skills/shared/templates/plan.md
+++ b/skills/shared/templates/plan.md
@@ -17,7 +17,7 @@ leads_to: []                # wiki-links to the plan node(s) this leads to
                             # (node-based sequencing; 2+ targets = a branch)
 relationships:
   - target: "[[]]"
-    type: ""
+    type: located_at
     tone: neutral
     strength: 5
     bidirectional: false

--- a/skills/shared/vault-access.md
+++ b/skills/shared/vault-access.md
@@ -62,7 +62,9 @@ required fields, enums, legacy fields, unquoted frontmatter
 links), `names` (duplicate and confusable entity names and
 aliases), `index` (`_meta/index.md` drift, both directions),
 `stale-drafts`, `changed --since N` (entities touched at or
-after session N — the incremental-audit scope), `all`.
+after session N — the incremental-audit scope),
+`relationships` (every `relationships[].type` checked against
+the sanctioned predicate vocabulary), `all`.
 Findings are `LEVEL<TAB>path<TAB>message`; fix every ERROR,
 triage WARNINGs with the GM, treat INFO as context.
 

--- a/tests/fixtures/relationship-predicates/Block Scalar Description.md
+++ b/tests/fixtures/relationship-predicates/Block Scalar Description.md
@@ -1,0 +1,26 @@
+---
+canon_status: AUTHORITATIVE
+summary: |
+  A top-level folded note whose prose opens a block the scan must not read
+  as YAML:
+  relationships:
+    - type: not_an_edge_at_all
+relationships:
+  - target: "[[The Order]]"
+    type: member_of
+    description: |
+      They met during the siege and never spoke of it again.
+      type: informal, but binding
+      predicate: also just prose
+  - target: "[[Vienna Station]]"
+    type: located_at
+    description: >
+      A folded note whose second line reads
+      type: of posting unclear
+type: npc
+lastUpdated: ""
+---
+
+Sanctioned predicates only. Every `type:`/`predicate:` line inside a block
+scalar (`|` or `>`) is literal prose, not an edge — including the ones in
+the top-level `summary` block above the `relationships:` key.

--- a/tests/fixtures/relationship-predicates/Clean NPC.md
+++ b/tests/fixtures/relationship-predicates/Clean NPC.md
@@ -1,0 +1,16 @@
+---
+canon_status: AUTHORITATIVE
+relationships:
+  - target: "[[The Order]]"
+    type: member_of
+    tone: professional
+    strength: 7
+    description: "Recruited in 1893 — the type: of loyalty that survives"
+  - target: "[[Vienna Station]]"
+    type: located_at
+type: npc
+lastUpdated: ""
+---
+
+Sanctioned predicates only. The `type: npc` line below the block and the
+colon inside `description` are both traps for a naive scan.

--- a/tests/fixtures/relationship-predicates/Empty Edges.md
+++ b/tests/fixtures/relationship-predicates/Empty Edges.md
@@ -1,0 +1,7 @@
+---
+type: location
+canon_status: STUB
+relationships: []
+---
+
+No edges at all.

--- a/tests/fixtures/relationship-predicates/Mobrpg Sync.md
+++ b/tests/fixtures/relationship-predicates/Mobrpg Sync.md
@@ -1,0 +1,19 @@
+---
+type: npc
+canon_status: AUTHORITATIVE
+relationships:
+  - target: "[[Dr Erasmus Hume]]"
+    type: imprisons
+mobrpg:
+  world_id: "w1"
+  element_kind: "Person"
+  relationships:
+    - predicate: "imprisoned_by"
+      target: "[[Dr Erasmus Hume]]"
+      event_type: "Generic"
+      event_id: null
+  languages: []
+---
+
+The machine-managed sync ledger stores the same edge under `predicate:`,
+here in the inverse direction the vocabulary does not carry.

--- a/tests/fixtures/relationship-predicates/Off Vocabulary NPC.md
+++ b/tests/fixtures/relationship-predicates/Off Vocabulary NPC.md
@@ -1,0 +1,32 @@
+---
+type: npc
+canon_status: DRAFT
+relationships:
+  - target: "[[The Order]]"
+    type: works_for
+    tone: professional
+    strength: 6
+  - target: "[[Vienna Station]]"
+    type: captured_by
+  - target: "[[Vienna Station]]"
+    type: commands_at
+  - target: "[[The Silent Choir]]"
+    type: controlled_by
+  - target: "[[Bell Tower]]"
+    type: controls
+  - target: "[[Adrien Marchand]]"
+    type: deceives
+  - target: "[[Ritual Blade]]"
+    type: equipped_with
+  - target: "[[The Order]]"
+    type: led_by
+  - target: "[[Bell Tower]]"
+    type: occupied_by
+  - target: "[[The Kestrel]]"
+    type: piloted_by
+  - target: "[[Ritual Blade]]"
+    type: taken_from
+---
+
+The eleven predicates a single session's entity generation invented
+(issue #130). Every one of them is off-vocabulary.

--- a/tests/test_relationship_predicates.py
+++ b/tests/test_relationship_predicates.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Regression tests for relationship predicate-vocabulary validation (#130).
+
+A single session's entity generation invented eleven predicates
+(`works_for`, `captured_by`, …) that nothing validated, so they landed in
+the vault and silently degraded the graph: no query, inverse-inference or
+publish step knows an off-vocabulary edge. These tests pin the two places
+that now catch them — `vault_check.py relationships` at authoring/QA time
+and `validate_schema.py` in CI — against the authoritative vocabulary in
+`skills/shared/gm-apprentice-ontology.json`.
+
+Run: python tests/test_relationship_predicates.py
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SHARED_SCRIPTS = REPO / "skills" / "shared" / "scripts"
+sys.path.insert(0, str(SHARED_SCRIPTS))
+sys.path.insert(0, str(REPO / "scripts"))
+
+import schema_rules as sr  # noqa: E402
+import validate_schema as vs  # noqa: E402
+import vault_check as vc  # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "relationship-predicates"
+
+# The exact predicates issue #130 found in one session's output.
+SESSION_03_PREDICATES = [
+    "works_for", "captured_by", "commands_at", "controlled_by", "controls",
+    "deceives", "equipped_with", "led_by", "occupied_by", "piloted_by",
+    "taken_from",
+]
+
+
+def rows_for(rows, needle):
+    return [r for r in rows if needle in r]
+
+
+class PredicateVocabularyTests(unittest.TestCase):
+    def test_vocabulary_matches_the_ontology_export(self):
+        ontology = json.loads(
+            (REPO / "skills" / "shared" / "gm-apprentice-ontology.json")
+            .read_text(encoding="utf-8"))
+        self.assertEqual(sr.predicate_vocabulary(),
+                         frozenset(p["type"] for p in ontology["predicates"]))
+
+    def test_sanctioned_predicates_are_in_the_vocabulary(self):
+        for predicate in ("employs", "located_at", "member_of", "imprisons"):
+            self.assertIn(predicate, sr.predicate_vocabulary())
+
+    def test_invented_predicates_are_not_in_the_vocabulary(self):
+        for predicate in SESSION_03_PREDICATES:
+            self.assertNotIn(predicate, sr.predicate_vocabulary())
+
+    def test_inverses_are_not_stored_predicates(self):
+        # Storage is single-direction; the inverse name is implied, so it
+        # is not part of the vocabulary an edge may carry.
+        self.assertNotIn("imprisoned_by", sr.predicate_vocabulary())
+
+    def test_suggestions_are_capped_at_three_real_predicates(self):
+        for predicate in SESSION_03_PREDICATES:
+            suggestions = sr.suggest_predicates(predicate)
+            self.assertLessEqual(len(suggestions), 3)
+            for s in suggestions:
+                self.assertIn(s, sr.predicate_vocabulary())
+
+    def test_near_miss_suggests_the_predicate_it_meant(self):
+        self.assertIn("commands", sr.suggest_predicates("commands_at"))
+        self.assertIn("deceived", sr.suggest_predicates("deceives"))
+
+    def test_no_suggestion_when_nothing_is_close(self):
+        self.assertEqual(sr.suggest_predicates("works_for"), [])
+
+    def test_inverse_names_map_back_to_their_base_predicate(self):
+        # Storage is single-direction, so an inverse name is off-vocabulary
+        # — but the export knows exactly which predicate it inverts.
+        self.assertEqual(sr.inverse_predicates()["led_by"], "leads")
+        self.assertEqual(sr.inverse_predicates()["imprisoned_by"], "imprisons")
+        self.assertNotIn("leads", sr.inverse_predicates())
+
+
+class IterRelationshipPredicatesTests(unittest.TestCase):
+    def predicates(self, name):
+        text = (FIXTURE / name).read_text(encoding="utf-8")
+        return list(sr.iter_relationship_predicates(text))
+
+    def test_reads_every_edge_in_a_block(self):
+        found = [p for _, _, p in self.predicates("Off Vocabulary NPC.md")]
+        self.assertEqual(found, SESSION_03_PREDICATES)
+
+    def test_reports_the_file_line_of_each_edge(self):
+        first_line, _, first_pred = self.predicates("Off Vocabulary NPC.md")[0]
+        self.assertEqual(first_pred, "works_for")
+        self.assertEqual(first_line, 6)  # `    type: works_for`
+
+    def test_ignores_frontmatter_type_outside_the_block(self):
+        # `type: npc` sits *below* the relationships block in this fixture.
+        found = [p for _, _, p in self.predicates("Clean NPC.md")]
+        self.assertEqual(found, ["member_of", "located_at"])
+
+    def test_empty_block_yields_nothing(self):
+        self.assertEqual(self.predicates("Empty Edges.md"), [])
+
+    def test_reads_the_mobrpg_node_predicate_key(self):
+        found = self.predicates("Mobrpg Sync.md")
+        self.assertEqual([(k, p) for _, k, p in found],
+                         [("type", "imprisons"), ("predicate", "imprisoned_by")])
+
+    def test_reads_crlf_notes(self):
+        # Windows-authored vaults; the line number must still be the file's.
+        text = ("---\r\ntype: npc\r\nrelationships:\r\n"
+                "  - target: \"[[X]]\"\r\n    type: bogus_thing\r\n---\r\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)),
+                         [(5, "type", "bogus_thing")])
+
+    def test_reads_list_items_flush_with_their_key(self):
+        # YAML allows the dash at the key's own indent; still one block.
+        text = ("---\ntype: npc\nrelationships:\n"
+                "- target: \"[[X]]\"\n  type: works_for\ntags: []\n---\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)),
+                         [(5, "type", "works_for")])
+
+    def test_no_frontmatter_yields_nothing(self):
+        self.assertEqual(list(sr.iter_relationship_predicates("# Just a body\n")), [])
+
+
+class CheckRelationshipsTests(unittest.TestCase):
+    def setUp(self):
+        self.rows = vc.check_relationships(FIXTURE)
+        self.bad = rows_for(self.rows, "Off Vocabulary NPC.md")
+
+    def test_all_rows_are_errors(self):
+        self.assertTrue(all(r.startswith("ERROR\t") for r in self.rows))
+
+    def test_every_invented_predicate_is_flagged_once(self):
+        self.assertEqual(len(self.bad), len(SESSION_03_PREDICATES))
+        for predicate in SESSION_03_PREDICATES:
+            self.assertEqual(len(rows_for(self.bad, f"'{predicate}'")), 1,
+                             f"expected exactly one row for {predicate}")
+
+    def test_rows_carry_the_note_path_and_line(self):
+        self.assertTrue(any("Off Vocabulary NPC.md:6\t" in r for r in self.bad))
+
+    def test_rows_carry_suggestions_when_something_is_close(self):
+        row = rows_for(self.bad, "'commands_at'")[0]
+        self.assertIn("commands", row)
+
+    def test_inverse_edges_are_told_which_way_to_store(self):
+        # `led_by` is the inverse of `leads`; the nearest *string* match
+        # (`cursed_by`) would be a wrong answer.
+        row = rows_for(self.bad, "'led_by'")[0]
+        self.assertIn("'leads'", row)
+        self.assertIn("single-direction", row)
+        self.assertNotIn("cursed_by", row)
+
+    def test_rows_say_so_when_nothing_is_close(self):
+        row = rows_for(self.bad, "'works_for'")[0]
+        self.assertIn("no close match", row)
+        self.assertIn("relationship-normalization.md", row)
+
+    def test_sanctioned_edges_are_silent(self):
+        self.assertFalse(rows_for(self.rows, "Clean NPC.md"))
+        self.assertFalse(rows_for(self.rows, "Empty Edges.md"))
+
+    def test_mobrpg_node_predicate_is_validated_too(self):
+        mobrpg = rows_for(self.rows, "Mobrpg Sync.md")
+        self.assertEqual(len(mobrpg), 1)
+        self.assertIn("imprisoned_by", mobrpg[0])
+
+    def test_blank_predicate_is_named_as_blank_not_as_a_bad_word(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "Blank.md").write_text(
+                "---\ntype: npc\ncanon_status: DRAFT\n"
+                "relationships:\n  - target: \"[[Somewhere]]\"\n"
+                "    type: \"\"\n---\n\nbody\n",
+                encoding="utf-8")
+            rows = vc.check_relationships(Path(d))
+        self.assertEqual(len(rows), 1)
+        self.assertIn("blank", rows[0])
+        self.assertNotIn("no close match", rows[0])
+
+    def test_missing_ontology_reports_instead_of_crashing(self):
+        original = sr.ONTOLOGY_PATH
+        sr.ONTOLOGY_PATH = original.with_name("no-such-ontology.json")
+        sr.predicate_vocabulary.cache_clear()
+        try:
+            rows = vc.check_relationships(FIXTURE)
+        finally:
+            sr.ONTOLOGY_PATH = original
+            sr.predicate_vocabulary.cache_clear()
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0].startswith("ERROR\t"))
+        self.assertIn("predicate vocabulary", rows[0])
+
+
+class VaultCheckCommandTests(unittest.TestCase):
+    def run_vault_check(self, command):
+        result = subprocess.run(
+            [sys.executable, str(SHARED_SCRIPTS / "vault_check.py"),
+             str(FIXTURE), command],
+            capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
+    def test_relationships_command_reports_a_labelled_section(self):
+        out = self.run_vault_check("relationships")
+        self.assertIn("## relationships\n", out)
+        self.assertIn("# count: 12\n", out)
+        self.assertIn("works_for", out)
+
+    def test_all_includes_the_relationships_section(self):
+        self.assertIn("## relationships\n", self.run_vault_check("all"))
+
+
+class ValidateSchemaRelationshipTests(unittest.TestCase):
+    def test_off_vocabulary_edges_are_schema_errors(self):
+        errors = vs.validate_relationships(FIXTURE / "Off Vocabulary NPC.md")
+        self.assertEqual(len(errors), len(SESSION_03_PREDICATES))
+        self.assertTrue(any("works_for" in e for e in errors))
+
+    def test_sanctioned_edges_pass(self):
+        self.assertEqual(vs.validate_relationships(FIXTURE / "Clean NPC.md"), [])
+
+    def test_mobrpg_node_predicate_is_validated_too(self):
+        errors = vs.validate_relationships(FIXTURE / "Mobrpg Sync.md")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("imprisoned_by", errors[0])
+        self.assertIn("'imprisons'", errors[0])
+
+    def test_blank_predicate_is_named_as_blank(self):
+        with tempfile.TemporaryDirectory() as d:
+            note = Path(d) / "Blank.md"
+            note.write_text(
+                "---\ntype: npc\ncanon_status: DRAFT\n"
+                "relationships:\n  - target: \"[[Somewhere]]\"\n"
+                "    type: \"\"\n---\n\nbody\n",
+                encoding="utf-8")
+            errors = vs.validate_relationships(note)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("blank", errors[0])
+
+    def test_campaign_validation_fails_on_off_vocabulary_edges(self):
+        # The fixture vault is schema-clean apart from its predicates, so a
+        # non-zero exit here can only come from the new check.
+        result = subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "validate_schema.py"),
+             str(FIXTURE)],
+            capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("works_for", result.stdout)
+        self.assertIn("Off Vocabulary NPC.md", result.stdout)
+
+    def test_benchmark_campaign_has_no_off_vocabulary_edges(self):
+        for path in sorted((REPO / "tests" / "benchmark-campaign").rglob("*.md")):
+            self.assertEqual(vs.validate_relationships(path), [], path.name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_relationship_predicates.py
+++ b/tests/test_relationship_predicates.py
@@ -12,11 +12,13 @@ and `validate_schema.py` in CI — against the authoritative vocabulary in
 Run: python tests/test_relationship_predicates.py
 """
 
+import io
 import json
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -126,6 +128,25 @@ class IterRelationshipPredicatesTests(unittest.TestCase):
         self.assertEqual(list(sr.iter_relationship_predicates(text)),
                          [(5, "type", "works_for")])
 
+    def test_reads_a_predicate_trailed_by_a_comment(self):
+        text = ("---\ntype: npc\nrelationships:\n"
+                "  - target: \"[[X]]\"\n    type: member_of  # legacy\n---\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)),
+                         [(5, "type", "member_of")])
+
+    def test_ignores_a_description_that_starts_with_type(self):
+        text = ("---\ntype: npc\nrelationships:\n"
+                "  - target: \"[[X]]\"\n    type: knows\n"
+                "    description: type: of thing he is\n---\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)),
+                         [(5, "type", "knows")])
+
+    def test_a_comment_after_the_block_key_still_opens_the_block(self):
+        text = ("---\ntype: npc\nrelationships:  # filled in later\n"
+                "  - target: \"[[X]]\"\n    type: bogus_thing\n---\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)),
+                         [(5, "type", "bogus_thing")])
+
     def test_no_frontmatter_yields_nothing(self):
         self.assertEqual(list(sr.iter_relationship_predicates("# Just a body\n")), [])
 
@@ -185,17 +206,33 @@ class CheckRelationshipsTests(unittest.TestCase):
         self.assertIn("blank", rows[0])
         self.assertNotIn("no close match", rows[0])
 
-    def test_missing_ontology_reports_instead_of_crashing(self):
+    def missing_ontology_rows(self, *caches_to_clear):
+        """Run the check with the export gone and the named caches cold."""
         original = sr.ONTOLOGY_PATH
+        sr.predicate_vocabulary()  # warm both caches from the real export
+        sr.inverse_predicates()
+        for cache in caches_to_clear:
+            cache.cache_clear()
         sr.ONTOLOGY_PATH = original.with_name("no-such-ontology.json")
-        sr.predicate_vocabulary.cache_clear()
         try:
-            rows = vc.check_relationships(FIXTURE)
+            return vc.check_relationships(FIXTURE)
         finally:
             sr.ONTOLOGY_PATH = original
             sr.predicate_vocabulary.cache_clear()
+            sr.inverse_predicates.cache_clear()
+
+    def test_missing_ontology_reports_instead_of_crashing(self):
+        rows = self.missing_ontology_rows(sr.predicate_vocabulary,
+                                          sr.inverse_predicates)
         self.assertEqual(len(rows), 1)
         self.assertTrue(rows[0].startswith("ERROR\t"))
+        self.assertIn("predicate vocabulary", rows[0])
+
+    def test_missing_ontology_caught_even_with_the_vocabulary_cached(self):
+        # The two loads go through separate caches; a warm vocabulary and a
+        # cold inverse map must still report, not abort the whole pass.
+        rows = self.missing_ontology_rows(sr.inverse_predicates)
+        self.assertEqual(len(rows), 1)
         self.assertIn("predicate vocabulary", rows[0])
 
 
@@ -219,31 +256,62 @@ class VaultCheckCommandTests(unittest.TestCase):
 
 
 class ValidateSchemaRelationshipTests(unittest.TestCase):
+    def errors_for(self, note: Path) -> list[str]:
+        return vs.validate_relationships(note.read_text(encoding="utf-8"),
+                                         sr.predicate_vocabulary())
+
     def test_off_vocabulary_edges_are_schema_errors(self):
-        errors = vs.validate_relationships(FIXTURE / "Off Vocabulary NPC.md")
+        errors = self.errors_for(FIXTURE / "Off Vocabulary NPC.md")
         self.assertEqual(len(errors), len(SESSION_03_PREDICATES))
         self.assertTrue(any("works_for" in e for e in errors))
 
     def test_sanctioned_edges_pass(self):
-        self.assertEqual(vs.validate_relationships(FIXTURE / "Clean NPC.md"), [])
+        self.assertEqual(self.errors_for(FIXTURE / "Clean NPC.md"), [])
 
     def test_mobrpg_node_predicate_is_validated_too(self):
-        errors = vs.validate_relationships(FIXTURE / "Mobrpg Sync.md")
+        errors = self.errors_for(FIXTURE / "Mobrpg Sync.md")
         self.assertEqual(len(errors), 1)
         self.assertIn("imprisoned_by", errors[0])
         self.assertIn("'imprisons'", errors[0])
 
     def test_blank_predicate_is_named_as_blank(self):
-        with tempfile.TemporaryDirectory() as d:
-            note = Path(d) / "Blank.md"
-            note.write_text(
-                "---\ntype: npc\ncanon_status: DRAFT\n"
-                "relationships:\n  - target: \"[[Somewhere]]\"\n"
-                "    type: \"\"\n---\n\nbody\n",
-                encoding="utf-8")
-            errors = vs.validate_relationships(note)
+        errors = vs.validate_relationships(
+            "---\ntype: npc\ncanon_status: DRAFT\n"
+            "relationships:\n  - target: \"[[Somewhere]]\"\n"
+            "    type: \"\"\n---\n\nbody\n",
+            sr.predicate_vocabulary())
         self.assertEqual(len(errors), 1)
         self.assertIn("blank", errors[0])
+
+    def run_campaign(self, directory: Path) -> tuple[int, str]:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = vs.validate_campaign(directory)
+        return code, out.getvalue()
+
+    def test_unreadable_note_is_reported_by_the_caller(self):
+        # A directory named *.md is not readable as text: validate_campaign
+        # must say so itself, not lean on another checker having said it.
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "Broken.md").mkdir()
+            code, out = self.run_campaign(Path(d))
+        self.assertEqual(code, 1, out)
+        self.assertIn("Could not read file", out)
+
+    def test_missing_ontology_reports_instead_of_tracebacking(self):
+        # Raising here would fail this test outright — that is the point.
+        original = sr.ONTOLOGY_PATH
+        sr.ONTOLOGY_PATH = original.with_name("no-such-ontology.json")
+        sr.predicate_vocabulary.cache_clear()
+        sr.inverse_predicates.cache_clear()
+        try:
+            code, out = self.run_campaign(FIXTURE)
+        finally:
+            sr.ONTOLOGY_PATH = original
+            sr.predicate_vocabulary.cache_clear()
+            sr.inverse_predicates.cache_clear()
+        self.assertEqual(code, 1)
+        self.assertIn("predicate vocabulary", out)
 
     def test_campaign_validation_fails_on_off_vocabulary_edges(self):
         # The fixture vault is schema-clean apart from its predicates, so a
@@ -258,7 +326,13 @@ class ValidateSchemaRelationshipTests(unittest.TestCase):
 
     def test_benchmark_campaign_has_no_off_vocabulary_edges(self):
         for path in sorted((REPO / "tests" / "benchmark-campaign").rglob("*.md")):
-            self.assertEqual(vs.validate_relationships(path), [], path.name)
+            self.assertEqual(self.errors_for(path), [], path.name)
+
+    def test_shipped_templates_have_no_off_vocabulary_edges(self):
+        # Scaffolded notes inherit these placeholders, so a bad predicate in a
+        # template lands in the GM's vault as a finding the plugin authored.
+        for path in sorted((REPO / "skills" / "shared" / "templates").glob("*.md")):
+            self.assertEqual(self.errors_for(path), [], path.name)
 
 
 if __name__ == "__main__":

--- a/tests/test_relationship_predicates.py
+++ b/tests/test_relationship_predicates.py
@@ -147,6 +147,28 @@ class IterRelationshipPredicatesTests(unittest.TestCase):
         self.assertEqual(list(sr.iter_relationship_predicates(text)),
                          [(5, "type", "bogus_thing")])
 
+    def test_block_scalar_prose_is_not_scanned_for_predicates(self):
+        # `description: |` opens literal text; a line of prose that happens to
+        # begin `type:` is not an edge. Regression: it was reported as an
+        # off-vocabulary predicate, failing both validators on a valid note.
+        found = self.predicates("Block Scalar Description.md")
+        self.assertEqual([(k, p) for _, k, p in found],
+                         [("type", "member_of"), ("type", "located_at")])
+
+    def test_a_folded_block_scalar_ends_at_the_next_sibling_key(self):
+        # `>` folds the same way `|` does, and the edge *after* it must still
+        # be read — the skip has to stop at the dedent, not swallow the rest.
+        text = ("---\ntype: npc\nrelationships:\n"
+                "  - target: \"[[X]]\"\n    description: >\n"
+                "      type: of thing\n    type: bogus_thing\n---\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)),
+                         [(7, "type", "bogus_thing")])
+
+    def test_a_top_level_block_scalar_cannot_open_the_relationships_block(self):
+        text = ("---\ntype: npc\nsummary: |\n  relationships:\n"
+                "    - type: not_an_edge\n---\n")
+        self.assertEqual(list(sr.iter_relationship_predicates(text)), [])
+
     def test_no_frontmatter_yields_nothing(self):
         self.assertEqual(list(sr.iter_relationship_predicates("# Just a body\n")), [])
 
@@ -188,6 +210,7 @@ class CheckRelationshipsTests(unittest.TestCase):
     def test_sanctioned_edges_are_silent(self):
         self.assertFalse(rows_for(self.rows, "Clean NPC.md"))
         self.assertFalse(rows_for(self.rows, "Empty Edges.md"))
+        self.assertFalse(rows_for(self.rows, "Block Scalar Description.md"))
 
     def test_mobrpg_node_predicate_is_validated_too(self):
         mobrpg = rows_for(self.rows, "Mobrpg Sync.md")

--- a/tests/test_relationship_predicates.py
+++ b/tests/test_relationship_predicates.py
@@ -298,18 +298,35 @@ class ValidateSchemaRelationshipTests(unittest.TestCase):
         self.assertEqual(code, 1, out)
         self.assertIn("Could not read file", out)
 
-    def test_missing_ontology_reports_instead_of_tracebacking(self):
-        # Raising here would fail this test outright — that is the point.
+    def missing_ontology_campaign(self, *caches_to_clear) -> tuple[int, str]:
+        """Validate the fixture vault with the export gone and caches cold.
+
+        Raising instead of returning fails the calling test — that is the point.
+        """
         original = sr.ONTOLOGY_PATH
+        sr.predicate_vocabulary()  # warm both caches from the real export
+        sr.inverse_predicates()
+        for cache in caches_to_clear:
+            cache.cache_clear()
         sr.ONTOLOGY_PATH = original.with_name("no-such-ontology.json")
-        sr.predicate_vocabulary.cache_clear()
-        sr.inverse_predicates.cache_clear()
         try:
-            code, out = self.run_campaign(FIXTURE)
+            return self.run_campaign(FIXTURE)
         finally:
             sr.ONTOLOGY_PATH = original
             sr.predicate_vocabulary.cache_clear()
             sr.inverse_predicates.cache_clear()
+
+    def test_missing_ontology_reports_instead_of_tracebacking(self):
+        code, out = self.missing_ontology_campaign(sr.predicate_vocabulary,
+                                                   sr.inverse_predicates)
+        self.assertEqual(code, 1)
+        self.assertIn("predicate vocabulary", out)
+
+    def test_missing_ontology_caught_even_with_the_vocabulary_cached(self):
+        # The asymmetry case: the vocabulary loads fine up front, then the
+        # export goes away before the loop reaches its first bad predicate
+        # and needs the inverse map through its own separate cache.
+        code, out = self.missing_ontology_campaign(sr.inverse_predicates)
         self.assertEqual(code, 1)
         self.assertIn("predicate vocabulary", out)
 

--- a/tests/test_vault_utilities.py
+++ b/tests/test_vault_utilities.py
@@ -212,6 +212,40 @@ for value, expected, label in [
     check(f"parse_session_number: {label}",
           [parse_session_number(value)], [expected])
 
+# --- schema_rules.scalar_value quoting ---
+
+from schema_rules import scalar_value  # noqa: E402
+
+for raw, expected, label in [
+    ('"npc"', "npc", "plain double-quoted scalar unwraps"),
+    ("'npc'", "npc", "plain single-quoted scalar unwraps"),
+    ('"npc"  # legacy', "npc", "a trailing comment is not content"),
+    ("'npc' # legacy", "npc", "single-quoted, trailing comment"),
+    ("npc # legacy", "npc", "unquoted value stops at the comment"),
+    # A quoted scalar with anything else after the closing quote is not a
+    # valid YAML scalar. Unwrapping it would hand `npc` to the type check and
+    # pass malformed frontmatter silently; the raw text fails loudly instead.
+    ('"npc" trailing', '"npc" trailing', "trailing text is not unwrapped"),
+    ('"npc",', '"npc",', "a stray flow comma is not unwrapped"),
+    ('"unterminated', '"unterminated', "an unclosed quote stays raw"),
+    # Escapes belong to the scalar: the closing quote is the unescaped one,
+    # so a value like a height range survives whole instead of truncating.
+    ('"5\'4\\" - 6\'0\\""', "5'4\\\" - 6'0\\\"", "escaped inner quote is kept"),
+    ("'O''Brien'", "O''Brien", "single-quote escape is kept"),
+]:
+    check(f"scalar_value: {label}", [scalar_value(raw)], [expected])
+
+sys.path.insert(0, str(ROOT / "scripts"))
+from validate_schema import validate_file  # noqa: E402
+
+# Otherwise-complete npc frontmatter, so the only thing that can fail is the
+# malformed type. Unwrapping the quoted prefix used to make this note valid.
+check("validate_file: malformed quoted type is reported, not accepted",
+      [[e.split(" —")[0] for e in validate_file(
+          Path("Trailing.md"),
+          '---\ntype: "npc" trailing\ncanon_status: AUTHORITATIVE\n---\n')]],
+      [["Unknown type '\"npc\" trailing'"]])
+
 # --- stamp_entities.py ---
 
 dry = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",

--- a/tools/publish/js/search.js
+++ b/tools/publish/js/search.js
@@ -19,8 +19,20 @@
       .join('/');
   }
 
+  // Fold a query into the index's normal form (#139). lib/search-index.js indexes NFC, so a
+  // query typed with decomposed accents can never match an NFC index unless it is folded the
+  // same way. Guarded for pre-ES6 engines, where it degrades to the old exact-match behavior
+  // rather than throwing. Exported (and asserted in test/search.test.js) because deleting it
+  // breaks accented search in the browser while every server-side test stays green.
+  function normalizeQuery(raw) {
+    var q = String(raw == null ? '' : raw);
+    return q.normalize ? q.normalize('NFC') : q;
+  }
+
   if (typeof document === 'undefined') {
-    if (typeof module !== 'undefined' && module.exports) module.exports = { esc: esc, encodeHref: encodeHref };
+    if (typeof module !== 'undefined' && module.exports) {
+      module.exports = { esc: esc, encodeHref: encodeHref, normalizeQuery: normalizeQuery };
+    }
     return;
   }
 
@@ -63,10 +75,7 @@
   }
 
   function search(rawQuery) {
-    // Match the index's normal form (#139): the index is built NFC, so a query typed with
-    // decomposed accents must be folded the same way or it can never match.
-    var query = String(rawQuery == null ? '' : rawQuery);
-    query = query.normalize ? query.normalize('NFC') : query;
+    var query = normalizeQuery(rawQuery);
     if (!idx || !query.trim()) {
       resultsDiv.innerHTML = query.trim() ? '<div class="search-results-empty">Loading...</div>' : '';
       return;

--- a/tools/publish/js/search.js
+++ b/tools/publish/js/search.js
@@ -62,7 +62,11 @@
     document.head.appendChild(script);
   }
 
-  function search(query) {
+  function search(rawQuery) {
+    // Match the index's normal form (#139): the index is built NFC, so a query typed with
+    // decomposed accents must be folded the same way or it can never match.
+    var query = String(rawQuery == null ? '' : rawQuery);
+    query = query.normalize ? query.normalize('NFC') : query;
     if (!idx || !query.trim()) {
       resultsDiv.innerHTML = query.trim() ? '<div class="search-results-empty">Loading...</div>' : '';
       return;

--- a/tools/publish/js/search.js
+++ b/tools/publish/js/search.js
@@ -3,6 +3,27 @@
     return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
   }
 
+  // Percent-encode each segment of a search result's href. Mirrors lib/processor.js's
+  // encodeHref (#145) — duplicated rather than imported because this file ships to the
+  // browser as a static asset and can't `require('../lib/processor')`. doc.href is the raw
+  // page.outputPath from search-index.json (lib/search-index.js deliberately stores it
+  // unencoded — lunr ref keys and the documents map must match). A raw space merely looked
+  // wrong via browser leniency; "#" or "?" in a vault folder/file name actively truncates or
+  // corrupts the link.
+  function encodeHref(hrefPath) {
+    return String(hrefPath)
+      .split('/')
+      .map(function(segment) {
+        return encodeURIComponent(segment).replace(/\(/g, '%28').replace(/\)/g, '%29');
+      })
+      .join('/');
+  }
+
+  if (typeof document === 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) module.exports = { esc: esc, encodeHref: encodeHref };
+    return;
+  }
+
   var searchOverlay = document.createElement('div');
   searchOverlay.className = 'search-overlay';
   searchOverlay.innerHTML =
@@ -75,7 +96,7 @@
     for (var type in grouped) {
       html += '<div class="search-result-group"><h4>' + esc(type) + '</h4>';
       grouped[type].forEach(function(doc) {
-        html += '<a class="search-result-item" href="' + esc(base + doc.href) + '">' +
+        html += '<a class="search-result-item" href="' + esc(base + encodeHref(doc.href)) + '">' +
           '<strong>' + esc(doc.title) + '</strong>' +
           (doc.subtitle ? ' <span style="opacity:0.6">' + esc(doc.subtitle) + '</span>' : '') +
           '</a>';

--- a/tools/publish/lib/backlinks.js
+++ b/tools/publish/lib/backlinks.js
@@ -1,4 +1,5 @@
 const { publishedSource } = require('./processor');
+const { canonicalNfc, nfcLookupTable } = require('./unicode');
 const WIKI_LINK_RE = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 
 function buildBacklinks(pages) {
@@ -12,7 +13,10 @@ function buildBacklinks(pages) {
     let match;
     WIKI_LINK_RE.lastIndex = 0;
     while ((match = WIKI_LINK_RE.exec(md)) !== null) {
-      const target = match[1].trim();
+      // Keyed in NFC (#139): the key is the mention as typed inside a note, but every read is
+      // `_backlinks[page.title]` — the scanned filename. Two authors, two normal forms, and a
+      // mismatch silently drops the entity's whole "Mentioned in" sidebar.
+      const target = canonicalNfc(match[1].trim());
       if (!target) continue;
       if (seen.has(target)) continue;
       seen.add(target);
@@ -27,7 +31,7 @@ function buildBacklinks(pages) {
     }
   }
 
-  return backlinks;
+  return nfcLookupTable(backlinks);
 }
 
 module.exports = { buildBacklinks };

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -8,6 +8,7 @@ const { processContent, extractSections, filterSections, stripDataview, stripGmO
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest, canonicalPath } = require('./manifest');
+const { canonicalNfc } = require('./unicode');
 const { generateThemeCSS, resolveGenrePreset } = require('./theme');
 const { buildStorySpine, unitRefs, characterStoryGroup } = require('./story-spine');
 const { storyPage: renderStoryUnit, characterStoryPage } = require('./templates/story');
@@ -472,7 +473,11 @@ function build(options = {}) {
   // The CoC sheet masthead renders a campaign-level crest (publishConfig.sheet_crest);
   // register it so the image-manifest pruning below doesn't drop it from the output.
   if (publishConfig.sheet_crest) {
-    const crestBase = String(publishConfig.sheet_crest).split('/').pop();
+    // Canonical NFC (#139): usedImages is matched against imageMap's own (NFC) keys by the
+    // player-mode prune below, so a crest named in the other normal form must register the
+    // key the map actually holds — otherwise the crest resolves on the page and is then
+    // never copied.
+    const crestBase = canonicalNfc(String(publishConfig.sheet_crest).split('/').pop());
     if (crestBase && imageMap[crestBase]) usedImages.add(crestBase);
   }
   let errorCount = 0;
@@ -483,7 +488,7 @@ function build(options = {}) {
     try {
       if (page.frontmatter.type === 'world_flags') continue;
       if (page.frontmatter.portrait) {
-        const basename = String(page.frontmatter.portrait).split('/').pop();
+        const basename = canonicalNfc(String(page.frontmatter.portrait).split('/').pop());
         if (basename && imageMap[basename]) usedImages.add(basename);
       }
       const processed = processContent(page, linkMap, excludeSections, imageMap, { usedImages, excludeCallouts });

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -617,15 +617,20 @@ function build(options = {}) {
             extraSidebar = { mentionedNPCs: sessionMentionedNPCs, events: sessionEvents };
           }
           if (page.frontmatter.type === 'chapter') {
-            const chapterTitle = String(page.frontmatter.title || page.displayTitle || '');
+            // All three comparisons below are author-typed `chapter:` ref vs filename-derived
+            // title, matched with `===`/`includes` rather than through a lookup table, so both
+            // sides are canonicalized to NFC here (#139) — otherwise an accented chapter shows
+            // an empty constituent-sessions sidebar.
+            const chapterTitle = canonicalNfc(String(page.frontmatter.title || page.displayTitle || ''));
             const chapterTitleNorm = chapterTitle.toLowerCase();
-            const chapterFilename = page.title.replace(/_/g, ' ');
+            const chapterFileTitle = canonicalNfc(page.title);
+            const chapterFilename = chapterFileTitle.replace(/_/g, ' ');
             const chapterSessions = (pages || []).filter(p => {
               if (p.frontmatter.type !== 'session') return false;
-              const chapterRef = String(p.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '').trim();
+              const chapterRef = canonicalNfc(String(p.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '').trim());
               if (!chapterRef) return false;
               // 1. Exact match against page filename stem (e.g. "Chapter_1_Overview")
-              if (chapterRef === page.title) return true;
+              if (chapterRef === chapterFileTitle) return true;
               // 2. Match against filename stem with underscores as spaces (e.g. "Chapter 1 Overview")
               if (chapterRef === chapterFilename) return true;
               // 3. Case-insensitive substring: chapter's display title appears in the session's chapter ref

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -294,7 +294,9 @@ function build(options = {}) {
     const gmStripped = stripGmOnly(page.markdown || '');
     const afterGm = typeof gmStripped === 'string' ? gmStripped : gmStripped.text;
     const spoilerStripped = stripSpoiler(afterGm);
-    const text = typeof spoilerStripped === 'string' ? spoilerStripped : spoilerStripped.text;
+    const afterSpoiler = typeof spoilerStripped === 'string' ? spoilerStripped : spoilerStripped.text;
+    const commentStripped = stripHtmlComments(afterSpoiler);
+    const text = typeof commentStripped === 'string' ? commentStripped : commentStripped.text;
     page.publishedMarkdown = filterSections(stripCallouts(text, excludeCallouts), excludeSections);
   }
 

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -7,7 +7,7 @@ const { resolveBanner, renderBanner, defaultAlt, isSvg } = require('./banners');
 const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename, encodeHref } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
-const { loadManifest } = require('./manifest');
+const { loadManifest, canonicalPath } = require('./manifest');
 const { generateThemeCSS, resolveGenrePreset } = require('./theme');
 const { buildStorySpine, unitRefs, characterStoryGroup } = require('./story-spine');
 const { storyPage: renderStoryUnit, characterStoryPage } = require('./templates/story');
@@ -185,8 +185,13 @@ function build(options = {}) {
   // fields stripped from a *published* page.
   const corpus = pages.slice();
 
+  // NFC-normalized (#139): manifest.publishing/excluded entries are already canonicalized
+  // by manifest.js's stripInlineComment, so every Set.has()/lookup comparison against them
+  // below needs the scanned path in the same normal form — otherwise an NFD-typed filename
+  // (e.g. from an editor or OS that decomposes accents) silently fails to match its NFC
+  // manifest entry, or vice versa.
   function vaultRelPathOf(page) {
-    return path.relative(config.vaultPath, page.sourcePath).split(path.sep).join('/');
+    return canonicalPath(path.relative(config.vaultPath, page.sourcePath).split(path.sep).join('/'));
   }
 
   // A Publishing entry that matches no scanned file silently removes nothing and publishes

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
 const { optimizeImages, resolveImageConfig } = require('./image-optimize');
 const { resolveBanner, renderBanner, defaultAlt, isSvg } = require('./banners');
-const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename } = require('./processor');
+const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename, encodeHref } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest } = require('./manifest');
@@ -781,7 +781,7 @@ function build(options = {}) {
   for (const [dir, label] of Object.entries(DIR_LABELS)) {
     if (dir === 'characters/pcs' && pcRedirectTarget) {
       const depth = dir.split('/').length;
-      const rel = '../'.repeat(depth) + pcRedirectTarget;
+      const rel = encodeHref('../'.repeat(depth) + pcRedirectTarget);
       const redirectHtml = `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=${rel}"><link rel="canonical" href="${rel}"></head><body><a href="${rel}">Player Characters</a></body></html>`;
       const outPath = path.join(outputDir, dir, 'index.html');
       ensureDir(outPath);
@@ -792,7 +792,7 @@ function build(options = {}) {
     // Redirect events/ at the timeline only when one exists; with no timeline the redirect
     // would dangle, so fall through and give events its own index.
     if (dir === 'events' && timelineHref) {
-      const rel = relativePath(dir, timelineHref);
+      const rel = encodeHref(relativePath(dir, timelineHref));
       const redirectHtml = `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=${rel}"><link rel="canonical" href="${rel}"></head><body><a href="${rel}">Timeline</a></body></html>`;
       const outPath = path.join(outputDir, dir, 'index.html');
       ensureDir(outPath);
@@ -837,12 +837,12 @@ function build(options = {}) {
     const items = [];
     for (const p of refs.participants) {
       const out = linkMap[p.target];
-      items.push(out ? `<li><a href="${relativeHref(unit.outputPath, out)}">${escapeHtml(p.label)}</a></li>`
+      items.push(out ? `<li><a href="${encodeHref(relativeHref(unit.outputPath, out))}">${escapeHtml(p.label)}</a></li>`
                      : `<li>${escapeHtml(p.label)}</li>`);
     }
     if (refs.location) {
       const out = linkMap[refs.location.target];
-      items.push(out ? `<li>Location: <a href="${relativeHref(unit.outputPath, out)}">${escapeHtml(refs.location.label)}</a></li>`
+      items.push(out ? `<li>Location: <a href="${encodeHref(relativeHref(unit.outputPath, out))}">${escapeHtml(refs.location.label)}</a></li>`
                      : `<li>Location: ${escapeHtml(refs.location.label)}</li>`);
     }
     return items.length ? `<ul>${items.join('')}</ul>` : '';

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -7,7 +7,13 @@ const PUBLISH_DEFAULTS = {
   mode: 'player',
   exclude_drafts: false,
   exclude_callouts: false,
-  exclude_sections: ['GM Notes'],
+  // Keep in sync with templates-scaffold/vault.config.json.tmpl's
+  // "excludeSections" — the scaffold ships this same list as the JSON
+  // fallback for new sites. Reconciliation Context / Handoff to Reconcile
+  // are written automatically by reconcile and session-wrapup and carry GM
+  // plot state; they must never reach a published player-mode site (#144).
+  // test/unit/config.test.js has a sync check that fails if these drift apart.
+  exclude_sections: ['GM Notes', 'DM Notes', 'Player Notes', 'Source References', 'Reconciliation Context', 'Handoff to Reconcile'],
   exclude_fields: ['secrets', 'current_plan', 'plan_progress', 'gm_notes', 'prep_notes'],
   exclude_dirs: ['_meta', '_Templates'],
   theme: {

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -84,8 +84,18 @@ function unionExcludeList(primary, fallback, defaults) {
 // accented filename) would otherwise never match — canonicalize once here, at load, so
 // build.js's single query-side normalization is enough.
 function canonicalizeOverrideFieldKeys(fields) {
+  if (fields == null) return {};
+  // Same trap as the block above: Object.entries on a string yields per-character keys, which
+  // would become override entries no page path can ever match.
+  if (typeof fields !== 'object' || Array.isArray(fields)) {
+    console.warn(
+      `config: publish.overrides.fields must be a map keyed by vault-relative path, but is ` +
+      `${Array.isArray(fields) ? 'a list' : typeof fields}. No field overrides applied.`
+    );
+    return {};
+  }
   const out = {};
-  for (const [key, value] of Object.entries(fields || {})) {
+  for (const [key, value] of Object.entries(fields)) {
     out[canonicalPath(key)] = value;
   }
   return out;
@@ -95,7 +105,19 @@ function canonicalizeOverrideFieldKeys(fields) {
 // published site, and the GM has no way to tell that from "the override didn't match".
 // Name it, and say where the real one lives.
 function warnUnreadOverrideKeys(overrides) {
-  for (const key of Object.keys(overrides || {})) {
+  if (overrides == null) return;
+  // A malformed block — `overrides: fields` (a bare string), or a list — must not be walked
+  // as a key/value map: Object.keys('fields') is ['0'..'5'], which would report six invented
+  // keys and bury the real problem.
+  if (typeof overrides !== 'object' || Array.isArray(overrides)) {
+    console.warn(
+      `config: publish.overrides must be a map, but is ${Array.isArray(overrides) ? 'a list' : typeof overrides}. ` +
+      'Nothing under it is being read. Expected shape: overrides: { fields: ' +
+      '{ "Characters/NPCs/Vex.md": { include: ["secrets"] } } }.'
+    );
+    return;
+  }
+  for (const key of Object.keys(overrides)) {
     if (key === 'fields') continue;
     console.warn(
       `config: publish.overrides.${key} is not read by the build and has no effect. ` +

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
+const { canonicalPath } = require('./manifest');
 
 const PUBLISH_DEFAULTS = {
   mode: 'player',
@@ -63,6 +64,19 @@ function unionExcludeList(primary, fallback, defaults) {
         out.push(item);
       }
     }
+  }
+  return out;
+}
+
+// build.js looks up per-page field overrides via `fieldOverrides[vaultRelPathOf(page)]`,
+// and vaultRelPathOf() canonicalizes the scanned path to NFC (#139). An overrides.fields
+// key typed by the config author in a different normal form (e.g. an NFD-decomposed
+// accented filename) would otherwise never match — canonicalize once here, at load, so
+// build.js's single query-side normalization is enough.
+function canonicalizeOverrideFieldKeys(fields) {
+  const out = {};
+  for (const [key, value] of Object.entries(fields || {})) {
+    out[canonicalPath(key)] = value;
   }
   return out;
 }
@@ -138,6 +152,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
     overrides: {
       ...PUBLISH_DEFAULTS.overrides,
       ...publish.overrides,
+      fields: canonicalizeOverrideFieldKeys(
+        (publish.overrides && publish.overrides.fields) || PUBLISH_DEFAULTS.overrides.fields
+      ),
     },
     section_titles: { ...PUBLISH_DEFAULTS.section_titles, ...publish.section_titles },
     // Explicit flags win, publish block over json fallback; absent stays undefined.

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -96,9 +96,38 @@ function canonicalizeOverrideFieldKeys(fields) {
   }
   const out = {};
   for (const [key, value] of Object.entries(fields)) {
+    const problem = overrideEntryProblem(value);
+    if (problem) {
+      // Dropping the entry leaves the exclusions in force, which is the safe
+      // direction: a malformed `include` must never re-admit a field by accident.
+      console.warn(
+        `config: publish.overrides.fields["${key}"] ${problem}. That override is ignored. ` +
+        'Expected shape: "Characters/NPCs/Vex.md": { include: ["secrets"] }.'
+      );
+      continue;
+    }
     out[canonicalPath(key)] = value;
   }
   return out;
+}
+
+// build.js hands each per-file entry straight to filterFields, which does
+// `overrides.include.includes(field)`. A string there is substring matching
+// (`include: sec` would re-admit `secrets`); any other truthy non-array throws.
+// Say which it is rather than letting the build guess or crash.
+function overrideEntryProblem(value) {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return `must be a map, but is ${Array.isArray(value) ? 'a list' : typeof value}`;
+  }
+  if (!('include' in value)) return null;
+  if (!Array.isArray(value.include)) {
+    return `has an "include" that must be a list of field names, but is ` +
+      `${typeof value.include}`;
+  }
+  if (!value.include.every((f) => typeof f === 'string')) {
+    return 'has an "include" list holding something that is not a field name';
+  }
+  return null;
 }
 
 // A key under `publish.overrides` that the build never reads changes nothing about the
@@ -201,7 +230,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
     // passing one along would just relocate the silent no-op into publishConfig.
     overrides: {
       fields: canonicalizeOverrideFieldKeys(
-        (publish.overrides && publish.overrides.fields) || PUBLISH_DEFAULTS.overrides.fields
+        // `??`, not `||`: an explicitly falsy `fields: false` is malformed config the
+        // validator must see and report, not something to silently swap for the default.
+        (publish.overrides && publish.overrides.fields) ?? PUBLISH_DEFAULTS.overrides.fields
       ),
     },
     section_titles: { ...PUBLISH_DEFAULTS.section_titles, ...publish.section_titles },

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -41,9 +41,13 @@ const PUBLISH_DEFAULTS = {
     max_width: 1600,
     quality: 82,
   },
+  // Per-file frontmatter overrides, keyed by vault-relative path:
+  //   fields: { "Characters/NPCs/Vex.md": { include: ["secrets"] } }
+  // `include` re-admits a field that exclude_fields strips, for that one file. `fields` is
+  // the only override the build reads — top-level `exclude`/`include` keys were declared
+  // here for years and read by nothing, so a GM who wrote one got a silent no-op. They are
+  // gone rather than implemented; loadPublishConfig warns if a config still carries one.
   overrides: {
-    exclude: [],
-    include: [],
     fields: {},
   },
   section_titles: {},
@@ -87,6 +91,20 @@ function canonicalizeOverrideFieldKeys(fields) {
   return out;
 }
 
+// A key under `publish.overrides` that the build never reads changes nothing about the
+// published site, and the GM has no way to tell that from "the override didn't match".
+// Name it, and say where the real one lives.
+function warnUnreadOverrideKeys(overrides) {
+  for (const key of Object.keys(overrides || {})) {
+    if (key === 'fields') continue;
+    console.warn(
+      `config: publish.overrides.${key} is not read by the build and has no effect. ` +
+      'The only supported override is publish.overrides.fields, keyed by vault-relative ' +
+      'path: fields: { "Characters/NPCs/Vex.md": { include: ["secrets"] } }.'
+    );
+  }
+}
+
 function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
   const configFile = path.join(vaultPath, '_meta', 'vault-config.md');
   let publish = {};
@@ -102,6 +120,8 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
       settingYear = data.setting_year;
     }
   }
+
+  warnUnreadOverrideKeys(publish.overrides);
 
   const merged = {
     mode: publish.mode || PUBLISH_DEFAULTS.mode,
@@ -155,9 +175,9 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
     // "group_by never mentioned" (fall back to the genre's pivot) apart from
     // "group_by explicitly falsy" (grouping off), and a default would erase that.
     locations: { ...jsonConfigFallback.locations, ...publish.locations },
+    // Only `fields` is carried through: nothing downstream reads any other override key, so
+    // passing one along would just relocate the silent no-op into publishConfig.
     overrides: {
-      ...PUBLISH_DEFAULTS.overrides,
-      ...publish.overrides,
       fields: canonicalizeOverrideFieldKeys(
         (publish.overrides && publish.overrides.fields) || PUBLISH_DEFAULTS.overrides.fields
       ),

--- a/tools/publish/lib/e2e-resources.js
+++ b/tools/publish/lib/e2e-resources.js
@@ -22,6 +22,17 @@
 //     can be mutated afterwards to redirect a later delete at a different
 //     id — a dry-run report can't be tampered with and then fed back in to
 //     change what a real cleanup deletes.
+//   - a record is removed from tracking *before* its delete call is issued,
+//     so a duplicate entry in `_records`, or a cleanup() re-entered from
+//     inside `runWrangler` (e.g. an adversarial test mock), can never see
+//     the same record as still deletable and delete it twice. A failed
+//     delete restores the record so a retry can still find it.
+//
+// None of this can protect against a `runWrangler` that lies about what it
+// created — provenance here means "this instance's own create call returned
+// this id," not "this id is actually safe." The guarantee is only as good
+// as the injected runner; it's real wrangler in production and a mock that
+// must never touch the network in tests.
 //
 // `_records` stays a live, writable array (rather than a defensive copy)
 // specifically so callers — including this module's own tests — can
@@ -110,15 +121,33 @@ function createE2eResources({ runWrangler, runId }) {
     if (dryRun) return toDelete;
 
     for (const record of toDelete) {
+      // Already handled earlier in this same pass — either a duplicate
+      // entry in `_records`, or a cleanup() re-entered from inside an
+      // earlier iteration's `runWrangler` call already deleted it (see
+      // the pre-call removal below).
+      if (!minted.has(record)) continue;
+
+      // Remove from tracking *before* issuing the delete call, not after,
+      // so a re-entrant cleanup() triggered synchronously from inside this
+      // very `runWrangler` call can never see this record as still valid
+      // and attempt to delete it again. Use a while-loop over indexOf
+      // (rather than a single splice) so a missing/duplicated entry can
+      // never splice the wrong element.
+      minted.delete(record);
+      let idx;
+      while ((idx = _records.indexOf(record)) !== -1) _records.splice(idx, 1);
+
       const r =
         record.type === 'kv'
           ? runWrangler(['kv', 'namespace', 'delete', '--namespace-id', record.id])
           : runWrangler(['pages', 'project', 'delete', record.name]);
+
       if (r.code !== 0) {
+        // Deletion failed — restore tracking so a retry can find it again.
+        minted.add(record);
+        _records.push(record);
         throw new Error(`Could not delete ${record.type} "${record.name}": ${(r.stderr || r.stdout || '').trim()}`);
       }
-      _records.splice(_records.indexOf(record), 1);
-      minted.delete(record);
     }
     return toDelete;
   }

--- a/tools/publish/lib/e2e-resources.js
+++ b/tools/publish/lib/e2e-resources.js
@@ -25,8 +25,11 @@
 //   - a record is removed from tracking *before* its delete call is issued,
 //     so a duplicate entry in `_records`, or a cleanup() re-entered from
 //     inside `runWrangler` (e.g. an adversarial test mock), can never see
-//     the same record as still deletable and delete it twice. A failed
-//     delete restores the record so a retry can still find it.
+//     the same record as still deletable and delete it twice. Whether the
+//     delete fails (non-zero code) or the runner throws outright, the
+//     record is put back at its original position — not the array's tail —
+//     so it's retryable and a retry still processes survivors in true
+//     reverse-creation order.
 //
 // None of this can protect against a `runWrangler` that lies about what it
 // created — provenance here means "this instance's own create call returned
@@ -130,23 +133,29 @@ function createE2eResources({ runWrangler, runId }) {
       // Remove from tracking *before* issuing the delete call, not after,
       // so a re-entrant cleanup() triggered synchronously from inside this
       // very `runWrangler` call can never see this record as still valid
-      // and attempt to delete it again. Use a while-loop over indexOf
-      // (rather than a single splice) so a missing/duplicated entry can
-      // never splice the wrong element.
+      // and attempt to delete it again. Capture its position first so a
+      // failed delete can restore it there — not at the array's tail —
+      // preserving reverse-creation order for the next retry.
+      const originalIdx = _records.indexOf(record);
       minted.delete(record);
-      let idx;
-      while ((idx = _records.indexOf(record)) !== -1) _records.splice(idx, 1);
+      while (_records.indexOf(record) !== -1) _records.splice(_records.indexOf(record), 1);
 
-      const r =
-        record.type === 'kv'
-          ? runWrangler(['kv', 'namespace', 'delete', '--namespace-id', record.id])
-          : runWrangler(['pages', 'project', 'delete', record.name]);
-
-      if (r.code !== 0) {
-        // Deletion failed — restore tracking so a retry can find it again.
+      try {
+        const r =
+          record.type === 'kv'
+            ? runWrangler(['kv', 'namespace', 'delete', '--namespace-id', record.id])
+            : runWrangler(['pages', 'project', 'delete', record.name]);
+        if (r.code !== 0) {
+          throw new Error(`Could not delete ${record.type} "${record.name}": ${(r.stderr || r.stdout || '').trim()}`);
+        }
+      } catch (err) {
+        // The delete failed, or the runner itself threw instead of
+        // returning — either way, restore tracking (at its original
+        // position) so a retry can find it again, rather than silently
+        // leaking it.
         minted.add(record);
-        _records.push(record);
-        throw new Error(`Could not delete ${record.type} "${record.name}": ${(r.stderr || r.stdout || '').trim()}`);
+        _records.splice(Math.min(originalIdx, _records.length), 0, record);
+        throw err;
       }
     }
     return toDelete;

--- a/tools/publish/lib/e2e-resources.js
+++ b/tools/publish/lib/e2e-resources.js
@@ -1,17 +1,34 @@
 // Guarded lifecycle helper for ephemeral E2E test resources (Cloudflare KV
 // namespaces, Pages projects). Built after issue #142: a session-driven
 // cleanup sweep ran ad-hoc wrangler commands and deleted the *production*
-// INBOX KV namespace. This module makes that incident inexpressible:
+// INBOX KV namespace.
+//
+// What this module actually guarantees:
 //
 //   - every resource this module creates is named `e2e-<runId>-<label>`;
 //     there is no way to construct a bare production-shaped name (e.g.
 //     "INBOX") through the factory.
-//   - cleanup() only ever deletes ids it recorded itself, in reverse
-//     creation order — there is no list-and-delete or delete-by-title API.
-//   - cleanup() independently refuses (throws) to delete any recorded
-//     resource whose name lacks the `e2e-` prefix, even if the tracked
-//     records were somehow polluted. This is a second, unconditional guard
-//     on top of the naming scheme, not a substitute for it.
+//   - cleanup() only ever considers resources it tracked itself, and for
+//     each one independently checks (a) the recorded name carries the
+//     `e2e-` prefix, and (b) the record is the *same object* this instance
+//     minted via createKvNamespace/createPagesProject — an internal Set
+//     checks identity, not just field content. A record hand-pushed onto
+//     `_records` with a spoofed `e2e-`-looking name and a real (e.g.
+//     production) id is still refused, because it was never minted here.
+//   - there is no list-and-delete or delete-by-title API: the only inputs
+//     to a deletion are records this instance itself created.
+//   - every tracked record is frozen at the moment it's created, so neither
+//     `_records` (kept exposed for inspection) nor cleanup()'s return value
+//     can be mutated afterwards to redirect a later delete at a different
+//     id — a dry-run report can't be tampered with and then fed back in to
+//     change what a real cleanup deletes.
+//
+// `_records` stays a live, writable array (rather than a defensive copy)
+// specifically so callers — including this module's own tests — can
+// exercise the identity guard above by pushing a foreign record onto it.
+// It is the guard, not read-only-ness, that makes this safe: appending to
+// the array cannot bypass the checks above, and the frozen record objects
+// already in it cannot be edited in place.
 //
 // `runWrangler` is always injected — see tools/publish/lib/setup-backend.js
 // for the same pattern. Real wrangler must never run from a test.
@@ -25,21 +42,31 @@ function trackedName(runId, label) {
 function assertPrefixed(name) {
   if (typeof name !== 'string' || !name.startsWith('e2e-')) {
     throw new Error(
-      `Refusing to delete "${name}": recorded resource name does not carry the e2e- prefix. ` +
-        'This guard exists so a polluted tracking record can never reach a real delete call.'
+      `Refusing to delete "${name}": recorded resource name does not carry the e2e- prefix.`
     );
   }
 }
 
 function createE2eResources({ runWrangler, runId }) {
   if (!runId) throw new Error('createE2eResources requires a runId');
+  if (typeof runWrangler !== 'function') throw new Error('createE2eResources requires a runWrangler function');
 
-  // Creation-ordered list of resources this instance has created. Exposed
-  // (as `_records`) only so tests can exercise the second delete guard by
-  // hand-injecting a malformed record; production code should never write
-  // to it directly — createKvNamespace/createPagesProject are the only
-  // supported way to add a tracked resource.
+  // Creation-ordered list of resources this instance has created. See the
+  // header comment for why this stays live/writable rather than a copy.
   const _records = [];
+
+  // Identity provenance: only record objects that came out of `track()`
+  // (i.e. were actually returned by createKvNamespace/createPagesProject)
+  // are ever valid deletion targets — regardless of what a record pushed
+  // directly onto `_records` claims about its own `name`/`id` fields.
+  const minted = new Set();
+
+  function track(record) {
+    Object.freeze(record);
+    _records.push(record);
+    minted.add(record);
+    return record;
+  }
 
   function createKvNamespace(label) {
     const name = trackedName(runId, label);
@@ -48,8 +75,7 @@ function createE2eResources({ runWrangler, runId }) {
     if (r.code !== 0 || !id) {
       throw new Error(`Could not create KV namespace "${name}": ${(r.stderr || r.stdout || '').trim()}`);
     }
-    _records.push({ type: 'kv', name, id });
-    return id;
+    return track({ type: 'kv', name, id }).id;
   }
 
   function createPagesProject(label) {
@@ -62,16 +88,24 @@ function createE2eResources({ runWrangler, runId }) {
     // create output doesn't reliably print one. Reuse parseCreatedId in
     // case a future version does, and fall back to the name otherwise.
     const id = parseCreatedId(r.stdout) || name;
-    _records.push({ type: 'pages', name, id });
-    return id;
+    return track({ type: 'pages', name, id }).id;
   }
 
   function cleanup({ dryRun = false } = {}) {
     const toDelete = _records.slice().reverse();
 
-    // Guard: refuse the whole cleanup if any recorded name lacks the
-    // e2e- prefix — checked before anything is deleted, dry-run or not.
-    toDelete.forEach((record) => assertPrefixed(record.name));
+    // Validate every record before deleting anything, dry-run or not: a
+    // single polluted/foreign record aborts the whole cleanup rather than
+    // being silently skipped or, worse, silently deleted.
+    toDelete.forEach((record) => {
+      assertPrefixed(record.name);
+      if (!minted.has(record)) {
+        throw new Error(
+          `Refusing to delete "${record.name}": this record was not created by this ` +
+            'createE2eResources instance (tracking looks polluted).'
+        );
+      }
+    });
 
     if (dryRun) return toDelete;
 
@@ -84,6 +118,7 @@ function createE2eResources({ runWrangler, runId }) {
         throw new Error(`Could not delete ${record.type} "${record.name}": ${(r.stderr || r.stdout || '').trim()}`);
       }
       _records.splice(_records.indexOf(record), 1);
+      minted.delete(record);
     }
     return toDelete;
   }

--- a/tools/publish/lib/e2e-resources.js
+++ b/tools/publish/lib/e2e-resources.js
@@ -141,10 +141,15 @@ function createE2eResources({ runWrangler, runId }) {
       while (_records.indexOf(record) !== -1) _records.splice(_records.indexOf(record), 1);
 
       try {
+        // Both deletes prompt interactively by default, and cleanup runs unattended
+        // (CI, a trap on exit) with nothing on stdin — the prompt would hang or read
+        // EOF as "no" and leak the resource. The two commands spell the same
+        // non-interactive answer differently: `wrangler kv namespace delete` takes
+        // `--skip-confirmation`, `wrangler pages project delete` takes `--yes`.
         const r =
           record.type === 'kv'
-            ? runWrangler(['kv', 'namespace', 'delete', '--namespace-id', record.id])
-            : runWrangler(['pages', 'project', 'delete', record.name]);
+            ? runWrangler(['kv', 'namespace', 'delete', '--namespace-id', record.id, '--skip-confirmation'])
+            : runWrangler(['pages', 'project', 'delete', record.name, '--yes']);
         if (r.code !== 0) {
           throw new Error(`Could not delete ${record.type} "${record.name}": ${(r.stderr || r.stdout || '').trim()}`);
         }

--- a/tools/publish/lib/e2e-resources.js
+++ b/tools/publish/lib/e2e-resources.js
@@ -1,0 +1,94 @@
+// Guarded lifecycle helper for ephemeral E2E test resources (Cloudflare KV
+// namespaces, Pages projects). Built after issue #142: a session-driven
+// cleanup sweep ran ad-hoc wrangler commands and deleted the *production*
+// INBOX KV namespace. This module makes that incident inexpressible:
+//
+//   - every resource this module creates is named `e2e-<runId>-<label>`;
+//     there is no way to construct a bare production-shaped name (e.g.
+//     "INBOX") through the factory.
+//   - cleanup() only ever deletes ids it recorded itself, in reverse
+//     creation order — there is no list-and-delete or delete-by-title API.
+//   - cleanup() independently refuses (throws) to delete any recorded
+//     resource whose name lacks the `e2e-` prefix, even if the tracked
+//     records were somehow polluted. This is a second, unconditional guard
+//     on top of the naming scheme, not a substitute for it.
+//
+// `runWrangler` is always injected — see tools/publish/lib/setup-backend.js
+// for the same pattern. Real wrangler must never run from a test.
+
+const { parseCreatedId } = require('./setup-backend');
+
+function trackedName(runId, label) {
+  return `e2e-${runId}-${label}`;
+}
+
+function assertPrefixed(name) {
+  if (typeof name !== 'string' || !name.startsWith('e2e-')) {
+    throw new Error(
+      `Refusing to delete "${name}": recorded resource name does not carry the e2e- prefix. ` +
+        'This guard exists so a polluted tracking record can never reach a real delete call.'
+    );
+  }
+}
+
+function createE2eResources({ runWrangler, runId }) {
+  if (!runId) throw new Error('createE2eResources requires a runId');
+
+  // Creation-ordered list of resources this instance has created. Exposed
+  // (as `_records`) only so tests can exercise the second delete guard by
+  // hand-injecting a malformed record; production code should never write
+  // to it directly — createKvNamespace/createPagesProject are the only
+  // supported way to add a tracked resource.
+  const _records = [];
+
+  function createKvNamespace(label) {
+    const name = trackedName(runId, label);
+    const r = runWrangler(['kv', 'namespace', 'create', name]);
+    const id = parseCreatedId(r.stdout);
+    if (r.code !== 0 || !id) {
+      throw new Error(`Could not create KV namespace "${name}": ${(r.stderr || r.stdout || '').trim()}`);
+    }
+    _records.push({ type: 'kv', name, id });
+    return id;
+  }
+
+  function createPagesProject(label) {
+    const name = trackedName(runId, label);
+    const r = runWrangler(['pages', 'project', 'create', name, '--production-branch=main']);
+    if (r.code !== 0) {
+      throw new Error(`Could not create Pages project "${name}": ${(r.stderr || r.stdout || '').trim()}`);
+    }
+    // Pages projects are addressed by name, not a separate id; wrangler's
+    // create output doesn't reliably print one. Reuse parseCreatedId in
+    // case a future version does, and fall back to the name otherwise.
+    const id = parseCreatedId(r.stdout) || name;
+    _records.push({ type: 'pages', name, id });
+    return id;
+  }
+
+  function cleanup({ dryRun = false } = {}) {
+    const toDelete = _records.slice().reverse();
+
+    // Guard: refuse the whole cleanup if any recorded name lacks the
+    // e2e- prefix — checked before anything is deleted, dry-run or not.
+    toDelete.forEach((record) => assertPrefixed(record.name));
+
+    if (dryRun) return toDelete;
+
+    for (const record of toDelete) {
+      const r =
+        record.type === 'kv'
+          ? runWrangler(['kv', 'namespace', 'delete', '--namespace-id', record.id])
+          : runWrangler(['pages', 'project', 'delete', record.name]);
+      if (r.code !== 0) {
+        throw new Error(`Could not delete ${record.type} "${record.name}": ${(r.stderr || r.stdout || '').trim()}`);
+      }
+      _records.splice(_records.indexOf(record), 1);
+    }
+    return toDelete;
+  }
+
+  return { createKvNamespace, createPagesProject, cleanup, _records };
+}
+
+module.exports = { createE2eResources };

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -39,8 +39,12 @@ function summarize(changes) {
 // The only two live-state systems are GURPS and CoC. Anything not GURPS routes
 // to the CoC writeback — the historical default (legacy CoC sites carry no
 // system). A PC's own frontmatter.system wins; otherwise the campaign system
-// (resolved the same way build.js does — from _meta/vault-config.md via
-// loadPublishConfig, with a vault.config.json `system` fallback) decides.
+// decides. Note flush resolves that campaign system more permissively than
+// build.js does: build reads `publishConfig.system` alone (vault-config.md
+// only), while flush falls back to a top-level `system` in vault.config.json
+// when vault-config.md doesn't set one — see runFlush below. So a legacy site
+// carrying `system` only in the JSON gets the right writeback here even though
+// the build would treat it as unset.
 function resolveSystem(frontmatter, campaignSystem) {
   const s = String((frontmatter && frontmatter.system) || campaignSystem || '').toLowerCase();
   return s.indexOf('gurps') !== -1 ? 'gurps' : 'coc';

--- a/tools/publish/lib/inbox-cli.js
+++ b/tools/publish/lib/inbox-cli.js
@@ -2,12 +2,22 @@
 // GM). Reuses Part 1's inbox-core.mjs over a wrangler-backed KV adapter.
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { runCommand } = require('./run-command.js');
 const { readNamespaceId, makeAdapter } = require('./inbox-wrangler.js');
 
-function defaultRunWrangler(args) {
-  const res = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8' });
-  return { code: res.status == null ? 1 : res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+// The change-request watcher polls `inbox pull` in a loop and writes
+// `.watcher-heartbeat` only once the poll returns. An unbounded spawn on a
+// wrangler call that never comes back stalls the heartbeat with no exit and no
+// failure line, so the loop is indistinguishable from a dead one — the exact
+// case the heartbeat exists to rule out. Bound it: a hung call becomes a failed
+// poll, which the loop's failure streak already reports. 60s rather than
+// run-command's 30s default because a cold `npx wrangler@4` may have to fetch
+// the package before it does any work.
+const WRANGLER_TIMEOUT_MS = 60000;
+
+function defaultRunWrangler(args, run = runCommand) {
+  const res = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS });
+  return { code: res.code, stdout: res.stdout || '', stderr: res.stderr || '' };
 }
 
 function defaultAdapter(cwd) {
@@ -70,4 +80,4 @@ async function runInbox(argv, deps = {}) {
   }
 }
 
-module.exports = { runInbox };
+module.exports = { runInbox, defaultRunWrangler, WRANGLER_TIMEOUT_MS };

--- a/tools/publish/lib/manifest.js
+++ b/tools/publish/lib/manifest.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
+const { canonicalNfc } = require('./unicode');
 
 // Manifest entries are vault-relative paths, optionally annotated with an inline
 // `— comment` (the Excluded section uses these throughout). Keep only the path, so an
@@ -14,15 +15,13 @@ const matter = require('gray-matter');
 // both "Six — Field Sundries.md" and "Foo.md — see Bar.md" resolve correctly.
 const ENTRY_RE = /^(.*?\.\w+)(?:\s+(?:—|–|--)\s+.*)?$/;
 
-// Normalize a vault-relative path to NFC for equality comparisons (#139). A filename
-// typed with precomposed accents ("González", NFC) and the "same" filename decomposed
-// into base letter + combining marks (NFD) are visually identical but different strings
-// byte-for-byte — different editors, OSes, and even git checkouts round-trip Unicode
-// differently. build.js compares manifest entries against scanned paths with exact-string
-// `Set.has()`, so without a shared normal form a manifest entry can silently fail to match
-// the page it names. Both sides of every such comparison must run through this helper.
+// Normalize a vault-relative path to NFC for equality comparisons (#139). build.js compares
+// manifest entries against scanned paths with exact-string `Set.has()`, so without a shared
+// normal form a manifest entry can silently fail to match the page it names. Both sides of
+// every such comparison must run through this helper. See lib/unicode.js for why the two
+// normal forms of one visible name differ, and for the other comparison boundaries.
 function canonicalPath(entry) {
-  return String(entry).normalize('NFC');
+  return canonicalNfc(entry);
 }
 
 function stripInlineComment(entry) {

--- a/tools/publish/lib/manifest.js
+++ b/tools/publish/lib/manifest.js
@@ -14,10 +14,21 @@ const matter = require('gray-matter');
 // both "Six — Field Sundries.md" and "Foo.md — see Bar.md" resolve correctly.
 const ENTRY_RE = /^(.*?\.\w+)(?:\s+(?:—|–|--)\s+.*)?$/;
 
+// Normalize a vault-relative path to NFC for equality comparisons (#139). A filename
+// typed with precomposed accents ("González", NFC) and the "same" filename decomposed
+// into base letter + combining marks (NFD) are visually identical but different strings
+// byte-for-byte — different editors, OSes, and even git checkouts round-trip Unicode
+// differently. build.js compares manifest entries against scanned paths with exact-string
+// `Set.has()`, so without a shared normal form a manifest entry can silently fail to match
+// the page it names. Both sides of every such comparison must run through this helper.
+function canonicalPath(entry) {
+  return String(entry).normalize('NFC');
+}
+
 function stripInlineComment(entry) {
   const trimmed = String(entry).trim();
   const match = ENTRY_RE.exec(trimmed);
-  return match ? match[1] : trimmed;
+  return canonicalPath(match ? match[1] : trimmed);
 }
 
 function parseManifest(markdown) {
@@ -86,4 +97,4 @@ function loadManifest(vaultPath) {
   return parseManifest(raw);
 }
 
-module.exports = { parseManifest, loadManifest, stripInlineComment };
+module.exports = { parseManifest, loadManifest, stripInlineComment, canonicalPath };

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -1,4 +1,5 @@
 const { createRenderer } = require('./markdown');
+const { canonicalNfc } = require('./unicode');
 const md = createRenderer();
 
 function escapeHtml(str) {
@@ -325,21 +326,28 @@ function resolveImageEmbeds(markdown, imageMap, currentOutputPath, usedImages, o
   // Safe because every entity template renders `portrait:` (world-domain.js was the last
   // holdout). A new template that skips the portrait must not be given a portraitBasename.
   const portrait = options.portraitBasename;
-  const dedupeBasename = portrait && imageMap[portrait] ? portrait.toLowerCase() : null;
+  // NFC throughout (#139): the `portrait:` value, the embed text, and the imageMap keys are
+  // authored in three different places and need not agree on normal form. Comparing the
+  // embed against the portrait — and registering it in usedImages, which build.js matches
+  // against imageMap's own keys when pruning in player mode — must use the canonical form,
+  // or a resolved image is dropped from the copy pass and renders as a broken <img>.
+  const portraitKey = portrait ? canonicalNfc(portrait) : null;
+  const dedupeKey = portraitKey && imageMap[portraitKey] ? portraitKey.toLowerCase() : null;
 
   // Match ![[filename.ext]] or ![[filename.ext|alt text]]
   return markdown.replace(/!\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]/g, (match, target, alt) => {
     const basename = target.trim();
     if (!IMAGE_EXT_REGEX.test(basename)) return match; // not an image, leave as-is
 
-    const entry = imageMap[basename];
+    const key = canonicalNfc(basename);
+    const entry = imageMap[key];
     if (!entry) {
       console.warn(`processor: image embed not found — "${basename}" (${currentOutputPath})`);
       return '';
     }
 
-    if (usedImages) usedImages.add(basename);
-    if (dedupeBasename && basename.toLowerCase() === dedupeBasename) return '';
+    if (usedImages) usedImages.add(key);
+    if (dedupeKey && key.toLowerCase() === dedupeKey) return '';
 
     // Output goes to docs/images/{relPath}. Compute relative path from current page.
     const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -60,7 +60,10 @@ function resolveWikiLinks(markdown, linkMap, currentOutputPath) {
     const targetPath = linkMap[target];
     if (!targetPath) return display;
     const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));
-    const relative = relativePath(currentDir, targetPath);
+    // A raw space (or other unsafe char) in the destination is not valid markdown link
+    // syntax — markdown-it falls back to literal `[text](path)` text, and the typographer
+    // then mangles a leading `../` into `…/`. Encode it into a real link destination (B7 / #145).
+    const relative = encodeHref(relativePath(currentDir, targetPath));
     return `[${display}](${relative})`;
   });
 }
@@ -280,7 +283,7 @@ function renderRelationships(frontmatter, linkMap, currentOutputPath) {
     const targetPath = linkMap[targetName];
     const escapedName = escapeHtml(targetName.replace(/_/g, ' '));
     const link = targetPath
-      ? `<a href="${relativePath(currentDir, targetPath)}" class="entity-link">${escapedName}</a>`
+      ? `<a href="${encodeHref(relativePath(currentDir, targetPath))}" class="entity-link">${escapedName}</a>`
       : escapedName;
     const typeRaw = String(r.type).replace(/_/g, ' ');
     const typeCapitalized = typeRaw.charAt(0).toUpperCase() + typeRaw.slice(1);
@@ -294,17 +297,25 @@ function renderRelationships(frontmatter, linkMap, currentOutputPath) {
 
 const IMAGE_EXT_REGEX = /\.(jpe?g|png|webp|gif|svg)$/i;
 
-// Percent-encode each path segment. A destination containing a raw space — which vault
-// attachments routinely do ("Chrome Jockey.png") — is not a valid markdown link, so
-// markdown-it emits the whole `![alt](path)` as literal text and the typographer then
-// rewrites the leading `../` into a `…/` ellipsis. Parens are encoded too: markdown-it
-// only tolerates balanced ones inside a destination.
-function encodeImageUrl(imagePath) {
-  return String(imagePath)
+// Percent-encode each path segment of an output-path-derived href/src. A destination
+// containing a raw space — which vault attachments and subfolder names routinely do
+// ("Chrome Jockey.png", "Sessions/Session 02/") — is not a valid markdown or HTML
+// destination: markdown-it emits the whole `[text](path)`/`![alt](path)` as literal text
+// and the typographer then rewrites a leading `../` into a `…/` ellipsis. Parens are
+// encoded too: markdown-it only tolerates balanced ones inside a destination.
+//
+// Generalized from the image-only `encodeImageUrl` (#145) — every hand-built href or
+// markdown-destination that interpolates a computed output path routes through this one
+// helper, so a future render path can't reintroduce the same bug in a new file.
+function encodeHref(hrefPath) {
+  return String(hrefPath)
     .split('/')
     .map(segment => encodeURIComponent(segment).replace(/\(/g, '%28').replace(/\)/g, '%29'))
     .join('/');
 }
+
+// Alias retained for the image call sites that already named it this way.
+const encodeImageUrl = encodeHref;
 
 function resolveImageEmbeds(markdown, imageMap, currentOutputPath, usedImages, options = {}) {
   // The entity's `portrait:` frontmatter. An inline embed of the same file exists so the
@@ -353,7 +364,7 @@ function renderMetaValue(raw, linkMap = {}, currentOutputPath = '') {
     const { target, label } = parseWikiRef(match[0]);
     const targetPath = linkMap[target];
     out.push(targetPath
-      ? `<a href="${relativeHref(currentOutputPath, targetPath)}" class="entity-link">${escapeHtml(label)}</a>`
+      ? `<a href="${encodeHref(relativeHref(currentOutputPath, targetPath))}" class="entity-link">${escapeHtml(label)}</a>`
       : escapeHtml(label));
     last = match.index + match[0].length;
   }
@@ -472,4 +483,4 @@ function filterFields(frontmatter, excludeFields = [], overrides = {}) {
   return filtered;
 }
 
-module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields };
+module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, encodeHref, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields };

--- a/tools/publish/lib/recency.js
+++ b/tools/publish/lib/recency.js
@@ -1,4 +1,5 @@
 const { publishedSource } = require('./processor');
+const { canonicalNfc } = require('./unicode');
 const WIKI_LINK_RE = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
 const TERMINAL_STATUSES = new Set(['dead', 'deceased', 'destroyed', 'kia', 'dissolved']);
 // A session counts as "played" once it has been run — including the post-wrap-up, pre-reconcile
@@ -9,12 +10,16 @@ const PLAYED_STATUSES = new Set(['played', 'reviewed', 'wrap-up']);
 // view (gm-only + excluded sections stripped) over its raw markdown when available (B6).
 const publishedText = publishedSource;
 
+// Mention names are NFC (#139) on the way in, and every membership test below compares them
+// against a canonicalized entity title. These are Set/Map comparisons, which `nfcLookupTable`
+// cannot wrap, so both sides are normalized at the call site: an accented NPC mentioned in the
+// latest session would otherwise never score, and never appear on the landing page.
 function extractMentions(markdown) {
   const mentions = new Set();
   let match;
   WIKI_LINK_RE.lastIndex = 0;
   while ((match = WIKI_LINK_RE.exec(markdown)) !== null) {
-    mentions.add(match[1].trim());
+    mentions.add(canonicalNfc(match[1].trim()));
   }
   return mentions;
 }
@@ -28,14 +33,14 @@ function sessionMentions(session, wrapUpByTitle) {
   if (Array.isArray(fm.participants)) {
     for (const p of fm.participants) {
       const m = String(p).match(/\[\[([^\]|]+)/);
-      if (m) names.add(m[1].trim());
+      if (m) names.add(canonicalNfc(m[1].trim()));
     }
   }
   if (fm.location) {
     const m = String(fm.location).match(/\[\[([^\]|]+)/);
-    if (m) names.add(m[1].trim());
+    if (m) names.add(canonicalNfc(m[1].trim()));
   }
-  const wu = wrapUpByTitle.get(session.title);
+  const wu = wrapUpByTitle.get(canonicalNfc(session.title));
   if (wu) {
     for (const n of extractMentions(publishedText(wu))) names.add(n);
   }
@@ -68,7 +73,8 @@ function scoreByRecency(entities, sessions, chapters, options = {}) {
   for (const w of wrapUps) {
     const ref = w.frontmatter && w.frontmatter.session;
     if (!ref) continue;
-    const target = String(ref).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim();
+    // Keyed NFC: the ref is author-typed, the `get` above uses the session's filename.
+    const target = canonicalNfc(String(ref).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim());
     if (target && !wrapUpByTitle.has(target)) wrapUpByTitle.set(target, w);
   }
 
@@ -86,7 +92,7 @@ function scoreByRecency(entities, sessions, chapters, options = {}) {
 
   const scored = entities.map(entity => {
     if (type && entity.frontmatter.type !== type) return null;
-    const names = [entity.title, ...(entity.frontmatter.aliases || [])];
+    const names = [entity.title, ...(entity.frontmatter.aliases || [])].map(canonicalNfc);
 
     // Terminal-status entities (dead, destroyed, …) are retired from "in play" — unless they
     // feature in the latest session (e.g. an NPC who died there is still current news).

--- a/tools/publish/lib/relationship-graph.js
+++ b/tools/publish/lib/relationship-graph.js
@@ -1,4 +1,5 @@
 const { escapeHtml, encodeHref } = require('./processor');
+const { canonicalNfc, nfcLookupTable } = require('./unicode');
 
 const SHAPE_MAP = {
   pc: 'circle',
@@ -17,15 +18,22 @@ function isIndexTitle(title) {
   return String(title).toLowerCase() === 'index';
 }
 
+// Node identity is the entity title, and titles reach this function from two places that
+// need not agree on Unicode normal form: the scanner (filenames) and wikilink text typed
+// inside notes. Everything entering the graph is canonicalized to NFC (#139) so one entity
+// is one node — otherwise an accented NPC is drawn twice, once resolved and once as a
+// dangling node that links nowhere.
 function buildRelationshipGraph(centerTitle, pages, backlinks) {
   if (isIndexTitle(centerTitle)) return { nodes: [], edges: [] };
-  const pageMap = {};
+  centerTitle = canonicalNfc(centerTitle);
+  const byTitle = {};
   for (const p of pages) {
-    pageMap[p.title] = p;
+    byTitle[canonicalNfc(p.title)] = p;
     if (p.frontmatter.aliases) {
-      for (const a of p.frontmatter.aliases) pageMap[a] = p;
+      for (const a of p.frontmatter.aliases) byTitle[canonicalNfc(a)] = p;
     }
   }
+  const pageMap = nfcLookupTable(byTitle);
 
   const nodes = new Map();
   const edges = [];
@@ -50,14 +58,14 @@ function buildRelationshipGraph(centerTitle, pages, backlinks) {
     const raw = page.frontmatter.relationships;
     if (Array.isArray(raw)) {
       for (const r of raw) {
-        const target = String(r.target).replace(/\[\[|\]\]/g, '').trim();
+        const target = canonicalNfc(String(r.target).replace(/\[\[|\]\]/g, '').trim());
         rels.push({ target, type: r.type });
       }
     } else if (raw && typeof raw === 'object') {
       for (const [type, targets] of Object.entries(raw)) {
         const list = Array.isArray(targets) ? targets : [targets];
         for (const t of list) {
-          const target = String(t).replace(/\[\[|\]\]/g, '').trim();
+          const target = canonicalNfc(String(t).replace(/\[\[|\]\]/g, '').trim());
           rels.push({ target, type });
         }
       }
@@ -65,8 +73,9 @@ function buildRelationshipGraph(centerTitle, pages, backlinks) {
     const bl = backlinks[title] || [];
     for (const b of bl) {
       if (isIndexTitle(b.title)) continue;
-      if (!rels.some(r => r.target === b.title)) {
-        rels.push({ target: b.title, type: 'mentioned_in' });
+      const backTitle = canonicalNfc(b.title);
+      if (!rels.some(r => r.target === backTitle)) {
+        rels.push({ target: backTitle, type: 'mentioned_in' });
       }
     }
     return rels.filter(r => !isIndexTitle(r.target));

--- a/tools/publish/lib/relationship-graph.js
+++ b/tools/publish/lib/relationship-graph.js
@@ -1,4 +1,4 @@
-const { escapeHtml } = require('./processor');
+const { escapeHtml, encodeHref } = require('./processor');
 
 const SHAPE_MAP = {
   pc: 'circle',
@@ -153,7 +153,8 @@ function renderRelationshipSVG(graph, options = {}) {
     const fill = node.hop === 0 ? 'var(--accent, #58a6ff)' : 'var(--bg-card, #232830)';
     const stroke = node.hop === 0 ? 'var(--accent, #58a6ff)' : 'var(--border, #30363d)';
 
-    const href = (node.outputPath && options.currentOutputPath) ? relPath(options.currentOutputPath, node.outputPath) : node.outputPath;
+    const rawHref = (node.outputPath && options.currentOutputPath) ? relPath(options.currentOutputPath, node.outputPath) : node.outputPath;
+    const href = rawHref ? encodeHref(rawHref) : rawHref;
     const linkOpen = href ? `<a href="${escapeHtml(href)}">` : '';
     const linkClose = href ? '</a>' : '';
 

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -162,7 +162,8 @@ function scanAttachments(config) {
   const attachmentsPath = path.join(vaultPath, attachmentsDir || '_attachments');
   const map = {};
 
-  if (!fs.existsSync(attachmentsPath)) return map;
+  // Wrapped on this path too: the returned type must not depend on whether _attachments/ exists.
+  if (!fs.existsSync(attachmentsPath)) return nfcLookupTable(map);
 
   const IMAGE_EXTS = /\.(jpe?g|png|webp|gif|svg|avif)$/i;
 

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -39,6 +39,10 @@ function scanVault(config) {
   const { vaultPath, excludeDirs, folderMap } = config;
   const pages = [];
   const warnedDirs = new Set();
+  // Output path -> the vault-relative source that first claimed it. Stripping combining
+  // marks (#139) collapses names that used to slug apart ("Renée"/"Renee" both give
+  // renee.html), and the later page silently overwrites the earlier one on disk.
+  const claimedOutputPaths = new Map();
 
   function walk(dir) {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -78,6 +82,16 @@ function scanVault(config) {
         const outputPath = outputDir
           ? outputDir + '/' + slug + '.html'
           : slug + '.html';
+
+        if (claimedOutputPaths.has(outputPath)) {
+          console.warn(
+            `scanner: page slug collision — "${outputPath}" is produced by both ` +
+            `"${claimedOutputPaths.get(outputPath)}" and "${relPath}". The latter will be used. ` +
+            `Rename one of the files so they slugify apart.`
+          );
+        } else {
+          claimedOutputPaths.set(outputPath, relPath);
+        }
 
         pages.push({
           sourcePath: fullPath,

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 const { getCanonStatus } = require('./templates/base');
+const { canonicalNfc, nfcLookupTable } = require('./unicode');
 
 function slugify(name) {
   const slug = name
@@ -111,26 +112,32 @@ function scanVault(config) {
   return pages;
 }
 
+// Titles/aliases in, output paths out. Keys are canonicalized to NFC (#139) and the table is
+// wrapped so lookups canonicalize too: the wikilink text a GM types inside a note and the
+// filename it names are authored in different apps and routinely disagree on normal form,
+// which used to render the link as plain text with no warning. Values — the output paths —
+// are stored exactly as given; nothing here rewrites an emitted path or URL.
 function buildLinkMap(pages) {
   const map = {};
 
   // Pass 1: add all canonical titles (non-superseded first so they claim their own names)
   for (const page of pages) {
     if (getCanonStatus(page.frontmatter) !== 'SUPERSEDED') {
-      map[page.title] = page.outputPath;
+      map[canonicalNfc(page.title)] = page.outputPath;
     }
   }
 
   // Pass 2: add superseded titles, redirecting to their superseded_by target if possible
   for (const page of pages) {
     if (getCanonStatus(page.frontmatter) === 'SUPERSEDED') {
-      if (page.title in map) continue;
+      const title = canonicalNfc(page.title);
+      if (title in map) continue;
       const supersededBy = page.frontmatter.superseded_by;
       if (supersededBy) {
-        const targetName = String(supersededBy).replace(/\[\[|\]\]/g, '').trim();
-        map[page.title] = map[targetName] || page.outputPath;
+        const targetName = canonicalNfc(String(supersededBy).replace(/\[\[|\]\]/g, '').trim());
+        map[title] = map[targetName] || page.outputPath;
       } else {
-        map[page.title] = page.outputPath;
+        map[title] = page.outputPath;
       }
     }
   }
@@ -139,14 +146,15 @@ function buildLinkMap(pages) {
   for (const page of pages) {
     if (Array.isArray(page.frontmatter.aliases)) {
       for (const alias of page.frontmatter.aliases) {
-        if (!(alias in map)) {
-          map[alias] = page.outputPath;
+        const key = canonicalNfc(alias);
+        if (!(key in map)) {
+          map[key] = page.outputPath;
         }
       }
     }
   }
 
-  return map;
+  return nfcLookupTable(map);
 }
 
 function scanAttachments(config) {
@@ -166,13 +174,17 @@ function scanAttachments(config) {
         walk(full);
       } else if (IMAGE_EXTS.test(entry.name)) {
         const relPath = toPosix(path.relative(attachmentsPath, full));
-        if (entry.name in map) {
+        // Key canonicalized to NFC (#139) so a `portrait:` value or `![[embed]]` typed in the
+        // other normal form still finds the file. sourcePath and relPath keep the filesystem's
+        // own bytes — they name a real file and become the copied output path.
+        const key = canonicalNfc(entry.name);
+        if (key in map) {
           console.warn(
             `scanner: attachment basename collision — "${entry.name}" found at both ` +
-            `"${map[entry.name].relPath}" and "${relPath}". The latter will be used.`
+            `"${map[key].relPath}" and "${relPath}". The latter will be used.`
           );
         }
-        map[entry.name] = {
+        map[key] = {
           sourcePath: full,
           relPath,
         };
@@ -181,7 +193,7 @@ function scanAttachments(config) {
   }
 
   walk(attachmentsPath);
-  return map;
+  return nfcLookupTable(map);
 }
 
 function pairStoryFiles(pages, vaultPath) {

--- a/tools/publish/lib/scanner.js
+++ b/tools/publish/lib/scanner.js
@@ -5,6 +5,13 @@ const { getCanonStatus } = require('./templates/base');
 
 function slugify(name) {
   const slug = name
+    // Decompose accented characters (NFD) and drop the resulting combining marks (#139)
+    // so "González" slugifies to "gonzalez" instead of falling through to the
+    // catch-all replace and turning each accent into a stray hyphen ("gonz-lez"). Also
+    // makes NFC- and NFD-typed filenames — which look identical but differ byte-for-byte
+    // — produce the same slug regardless of which normal form the source file used.
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
     .replace(/['']/g, '')
     .replace(/&/g, 'and')

--- a/tools/publish/lib/search-index.js
+++ b/tools/publish/lib/search-index.js
@@ -1,4 +1,5 @@
 const { publishedSource } = require('./processor');
+const { canonicalNfc } = require('./unicode');
 const lunr = require('lunr');
 
 function stripMarkdown(md) {
@@ -45,10 +46,12 @@ function buildSearchIndex(pages) {
       const fm = page.frontmatter;
       this.add({
         id: page.outputPath,
-        title: page.displayTitle,
-        aliases: Array.isArray(fm.aliases) ? fm.aliases.join(' ') : '',
+        title: canonicalNfc(page.displayTitle),
+        aliases: Array.isArray(fm.aliases) ? canonicalNfc(fm.aliases.join(' ')) : '',
         type: fm.type || '',
-        body: stripMarkdown(publishedText(page)).slice(0, 500),
+        // NFC before slicing (#139): the cut lands on a different character otherwise, so two
+        // spellings of one vault index different amounts of text as well as different terms.
+        body: canonicalNfc(stripMarkdown(publishedText(page))).slice(0, 500),
       });
     }
   });

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -124,4 +124,12 @@ async function runSetupBackend(feature, { configPath }, deps = {}) {
   return 0;
 }
 
-module.exports = { checkKvPermission, ensureKvNamespace, patchWranglerToml, INBOX_BLOCK, KV_PERMISSION_FIX, runSetupBackend };
+module.exports = {
+  checkKvPermission,
+  ensureKvNamespace,
+  patchWranglerToml,
+  INBOX_BLOCK,
+  KV_PERMISSION_FIX,
+  runSetupBackend,
+  parseCreatedId,
+};

--- a/tools/publish/lib/story-spine.js
+++ b/tools/publish/lib/story-spine.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { extractSections, parseWikiRef, resolveWikiLinks, publishedSource } = require('./processor');
 const { slugify } = require('./scanner');
+const { canonicalNfc } = require('./unicode');
 
 const RECAP_TITLES = ['narrative recap', 'recap'];
 
@@ -23,9 +24,14 @@ function findRecap(page, resolve) {
 
 const WRAP_UP_TYPES = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
 
+// Every `session:`/`chapter:` ref in this file is author-typed and is compared against a
+// filename-derived title through a Map key or `===`. Canonicalizing here (#139) covers the
+// write side of both indexes and the ref in chapterMatchesSession; the reads below
+// canonicalize the title they look up with. A Map is not a plain object, so nfcLookupTable
+// cannot carry this — it has to be done at the call sites.
 function refTarget(value) {
   if (!value) return '';
-  return String(value).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim();
+  return canonicalNfc(String(value).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim());
 }
 
 // Index wrap-up pages: bySession (keyed on the session ref target) and byChapter
@@ -62,9 +68,10 @@ function resolveUnitRecap(unitPage, wrapUpPage, resolve) {
 function chapterMatchesSession(chapterPage, sessionPage) {
   const ref = refTarget(sessionPage.frontmatter.chapter);
   if (!ref) return false;
-  if (ref === chapterPage.title) return true;
-  if (ref === chapterPage.title.replace(/_/g, ' ')) return true;
-  const norm = String(chapterPage.displayTitle || chapterPage.title).toLowerCase();
+  const title = canonicalNfc(chapterPage.title);
+  if (ref === title) return true;
+  if (ref === title.replace(/_/g, ' ')) return true;
+  const norm = canonicalNfc(chapterPage.displayTitle || chapterPage.title).toLowerCase();
   return norm.length > 0 && ref.toLowerCase().includes(norm);
 }
 
@@ -91,9 +98,10 @@ function chapterOwnsSession(chapter, session) {
 // exactly ONE wrap-up — in flat vaults every session shares one Sessions/ folder, and
 // a first-match grab there would hand the same wrap-up to every session.
 function wrapUpForUnit(unitPage, wrapUps, idx) {
-  const byRef = idx.bySession.get(unitPage.title)
-    || idx.byChapter.get(unitPage.title)
-    || idx.byChapter.get(unitPage.title.replace(/_/g, ' '));
+  const title = canonicalNfc(unitPage.title);
+  const byRef = idx.bySession.get(title)
+    || idx.byChapter.get(title)
+    || idx.byChapter.get(title.replace(/_/g, ' '));
   if (byRef) return byRef;
   const dir = folderOf(unitPage);
   if (dir) {

--- a/tools/publish/lib/templates/coc/party-board.js
+++ b/tools/publish/lib/templates/coc/party-board.js
@@ -1,7 +1,7 @@
 'use strict';
 const { cocRowCells } = require('../../../js/coc-party');
 const { avatarHtml } = require('../party-avatar');
-const { relativeHref, escapeHtml } = require('../../processor');
+const { relativeHref, escapeHtml, encodeHref } = require('../../processor');
 
 // Sort: DEX desc, then name asc. Missing DEX sorts last (−Infinity).
 function dexCmp(a, b) {
@@ -37,7 +37,7 @@ function renderCoCBoard(manifest, rosterOutputPath, { live = true } = {}) {
   const showRep = manifest.pcs.some((pc) => pc.rep != null);
   const rows = manifest.pcs.map((pc) => {
     const c = cocRowCells(pc, null);   // authored-default initial render
-    const href = relativeHref(rosterOutputPath, pc.outputPath);
+    const href = encodeHref(relativeHref(rosterOutputPath, pc.outputPath));
     const repTd = showRep ? `\n  <td data-gl-party-field="rep">${c.rep}</td>` : '';
     return `<tr class="gl-party-row ${c.rowClass}" data-gl-party="${escapeHtml(pc.pcSlug)}">
   <td class="gl-pc"><a href="${escapeHtml(href)}">${avatarHtml(pc, rosterOutputPath)}<span class="gl-pc-txt"><span class="gl-pc-name">${escapeHtml(pc.name)}</span><span class="gl-pc-sub">${c.player}</span></span></a></td>

--- a/tools/publish/lib/templates/context-sidebar.js
+++ b/tools/publish/lib/templates/context-sidebar.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath } = require('../processor');
+const { escapeHtml, relativePath, encodeHref } = require('../processor');
 
 function normalizeRelationships(raw, linkMap) {
   if (!raw) return [];
@@ -29,7 +29,7 @@ function renderContextSidebar({ backlinks, relationships, parentEntity, events, 
   const currentDir = currentOutputPath.substring(0, currentOutputPath.lastIndexOf('/'));
 
   if (parentEntity) {
-    const href = parentEntity.path ? relativePath(currentDir, parentEntity.path) : null;
+    const href = parentEntity.path ? encodeHref(relativePath(currentDir, parentEntity.path)) : null;
     const link = href
       ? `<a href="${href}">${escapeHtml(parentEntity.name)}</a>`
       : escapeHtml(parentEntity.name);
@@ -38,7 +38,7 @@ function renderContextSidebar({ backlinks, relationships, parentEntity, events, 
 
   if (relationships && relationships.length > 0) {
     const items = relationships.map(r => {
-      const href = r.targetPath ? relativePath(currentDir, r.targetPath) : null;
+      const href = r.targetPath ? encodeHref(relativePath(currentDir, r.targetPath)) : null;
       const name = escapeHtml(r.target.replace(/_/g, ' '));
       const link = href ? `<a href="${href}">${name}</a>` : name;
       const type = escapeHtml(r.type.replace(/_/g, ' '));
@@ -49,7 +49,7 @@ function renderContextSidebar({ backlinks, relationships, parentEntity, events, 
 
   if (backlinks && backlinks.length > 0) {
     const items = backlinks.map(b => {
-      const href = relativePath(currentDir, b.outputPath);
+      const href = encodeHref(relativePath(currentDir, b.outputPath));
       return `<li><a href="${href}">${escapeHtml(b.displayTitle)}</a> <span class="sidebar-badge">${escapeHtml(b.type)}</span></li>`;
     });
     sections.push(`<h3>Mentioned In</h3>\n<ul>${items.join('\n')}</ul>`);
@@ -57,7 +57,7 @@ function renderContextSidebar({ backlinks, relationships, parentEntity, events, 
 
   if (events && events.length > 0) {
     const items = events.map(e => {
-      const href = relativePath(currentDir, e.outputPath);
+      const href = encodeHref(relativePath(currentDir, e.outputPath));
       return `<li><a href="${href}">${escapeHtml(e.displayTitle)}</a></li>`;
     });
     sections.push(`<h3>Events</h3>\n<ul>${items.join('\n')}</ul>`);

--- a/tools/publish/lib/templates/event.js
+++ b/tools/publish/lib/templates/event.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath, humanizeName } = require('../processor');
+const { escapeHtml, relativePath, humanizeName, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge, portraitImg } = require('./base');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
@@ -48,7 +48,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
     const locDisplay = locMatch && locMatch[2] ? locMatch[2].trim() : humanizeName(locTarget);
     const locPath = linkMap?.[locTarget];
     if (locPath) {
-      const href = relativePath(currentDir, locPath);
+      const href = encodeHref(relativePath(currentDir, locPath));
       metaItems.push(`<span><span class="label">Location</span> <a href="${href}">${escapeHtml(locDisplay)}</a></span>`);
     } else {
       metaItems.push(`<span><span class="label">Location</span> ${escapeHtml(locDisplay)}</span>`);
@@ -79,7 +79,7 @@ function eventTemplate(page, processedContent, navFor, config, imageMap, linkMap
       if (p.isLink) {
         const resolved = linkMap?.[p.target];
         if (resolved) {
-          const href = relativePath(currentDir, resolved);
+          const href = encodeHref(relativePath(currentDir, resolved));
           nameHtml = `<a href="${href}">${escapeHtml(p.display)}</a>`;
         } else {
           nameHtml = escapeHtml(p.display);

--- a/tools/publish/lib/templates/faction.js
+++ b/tools/publish/lib/templates/faction.js
@@ -2,6 +2,7 @@ const { escapeHtml, relativePath, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge, portraitImg } = require('./base');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
+const { canonicalNfc } = require('../unicode');
 
 function factionTemplate(page, processedContent, navFor, config, imageMap, linkMap, allPages, context) {
   const fm = page.frontmatter;
@@ -52,12 +53,14 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
   }
 
   // Member rollup: find entities with member_of or assigned_to relationships pointing to this faction
-  const factionTitle = page.title;
+  // NFC on both sides (#139): the relationship target is author-typed, the faction title is
+  // the filename. A mismatch empties the members rollup on an accented faction page.
+  const factionTitle = canonicalNfc(page.title);
   const members = (allPages || []).filter(p => {
     const rels = p.frontmatter.relationships;
     if (!rels || !Array.isArray(rels)) return false;
     return rels.some(r => {
-      const target = String(r.target || '').replace(/\[\[|\]\]/g, '').trim();
+      const target = canonicalNfc(String(r.target || '').replace(/\[\[|\]\]/g, '').trim());
       return target === factionTitle && (r.type === 'member_of' || r.type === 'assigned_to');
     });
   });

--- a/tools/publish/lib/templates/faction.js
+++ b/tools/publish/lib/templates/faction.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath } = require('../processor');
+const { escapeHtml, relativePath, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge, portraitImg } = require('./base');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
@@ -30,7 +30,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
     const leaderPath = linkMap?.[leaderName];
     const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
     if (leaderPath) {
-      const href = relativePath(currentDir, leaderPath);
+      const href = encodeHref(relativePath(currentDir, leaderPath));
       leadershipHtml = `<p class="faction-leadership"><strong>Leadership:</strong> <a href="${href}">${escapeHtml(leaderName)}</a></p>`;
     } else {
       leadershipHtml = `<p class="faction-leadership"><strong>Leadership:</strong> ${escapeHtml(leaderName)}</p>`;
@@ -44,7 +44,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
     const territoryPath = linkMap?.[territoryName];
     const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
     if (territoryPath) {
-      const href = relativePath(currentDir, territoryPath);
+      const href = encodeHref(relativePath(currentDir, territoryPath));
       territoryHtml = `<p class="faction-territory"><strong>Territory:</strong> <a href="${href}">${escapeHtml(territoryName)}</a></p>`;
     } else {
       territoryHtml = `<p class="faction-territory"><strong>Territory:</strong> ${escapeHtml(territoryName)}</p>`;
@@ -66,7 +66,7 @@ function factionTemplate(page, processedContent, navFor, config, imageMap, linkM
   if (members.length > 0) {
     const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
     const memberLinks = members.map(m => {
-      const href = relativePath(currentDir, m.outputPath);
+      const href = encodeHref(relativePath(currentDir, m.outputPath));
       return `<li><a href="${href}">${escapeHtml(m.displayTitle)}</a></li>`;
     }).join('\n');
     membersHtml = `<div class="members"><h3>Members</h3><ul>${memberLinks}</ul></div>`;

--- a/tools/publish/lib/templates/gurps/party-board.js
+++ b/tools/publish/lib/templates/gurps/party-board.js
@@ -1,7 +1,7 @@
 'use strict';
 const { deriveLive } = require('../../../js/gurps-live');
 const { rowCells } = require('../../../js/gurps-party');
-const { relativeHref, escapeHtml } = require('../../processor');
+const { relativeHref, escapeHtml, encodeHref } = require('../../processor');
 const { avatarHtml } = require('../party-avatar');
 
 function renderPartyBoard(manifest, rosterOutputPath, { live = true } = {}) {
@@ -11,7 +11,7 @@ function renderPartyBoard(manifest, rosterOutputPath, { live = true } = {}) {
   const rows = manifest.pcs.map((pc) => {
     const view = deriveLive(pc, null);           // authored-default initial render
     const c = rowCells(view);
-    const href = relativeHref(rosterOutputPath, pc.outputPath);
+    const href = encodeHref(relativeHref(rosterOutputPath, pc.outputPath));
     const speed = pc.basicSpeed != null ? Number(pc.basicSpeed).toFixed(2) : '—';
     return `<tr class="gl-party-row ${c.rowClass}" data-gl-party="${escapeHtml(pc.pcSlug)}">
   <td class="gl-pc"><a href="${escapeHtml(href)}">${avatarHtml(pc, rosterOutputPath)}<span class="gl-pc-txt"><span class="gl-pc-name">${escapeHtml(pc.name)}</span><span class="gl-pc-sub" data-gl-party-field="enc">${c.enc}</span></span></a></td>

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -374,7 +374,10 @@ function renderChapterList(pages, indexDir) {
   function sessionsForChapter(chapter) {
     // The third copy of the chapter matcher (story-spine.js and build.js hold the others).
     // Author-typed ref vs filename-derived title on both substring tests, so both sides are
-    // canonicalized to NFC (#139) or an accented chapter lists none of its sessions.
+    // canonicalized to NFC (#139) — but the two ref clauses are UNREACHABLE TODAY: this
+    // function only ever sees the pages of a single output dir, so the folder-prefix clause
+    // below is true for every session it is given and always decides first. Kept in the same
+    // normal form as its two live siblings so the three cannot drift.
     const chTitle = canonicalNfc(chapter.displayTitle).toLowerCase();
     const chFrontTitle = chapter.frontmatter.title ? canonicalNfc(chapter.frontmatter.title).toLowerCase() : '___';
     const chFolder = chapter.outputPath.split('/').slice(0, -1).join('/');

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -1,6 +1,6 @@
 const { createRenderer } = require('../markdown');
 const mdRenderer = createRenderer();
-const { escapeHtml, relativePath, resolveWikiLinks, renderMetaValue, plainMetaValue } = require('../processor');
+const { escapeHtml, relativePath, resolveWikiLinks, renderMetaValue, plainMetaValue, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg, getCanonStatus } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
@@ -42,8 +42,8 @@ function sectionTitle(key, publishConfig) {
 function relHref(page, indexDir) {
   const out = page.outputPath;
   const prefix = indexDir + '/';
-  if (out.startsWith(prefix)) return out.substring(prefix.length);
-  return out.split('/').pop();
+  const rel = out.startsWith(prefix) ? out.substring(prefix.length) : out.split('/').pop();
+  return encodeHref(rel);
 }
 
 function buildPillFilters(pages, dir) {

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -4,6 +4,7 @@ const { escapeHtml, relativePath, resolveWikiLinks, renderMetaValue, plainMetaVa
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg, getCanonStatus } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
+const { canonicalNfc, nfcLookupTable } = require('../unicode');
 
 const GENRE_SECTION_TITLES = {
   military: {
@@ -70,11 +71,16 @@ function buildPillFilters(pages, dir) {
 
 function buildLocationTree(pages) {
   const nodes = pages.map(p => ({ page: p, children: [] }));
-  const lookup = {};
-  for (const n of nodes) lookup[n.page.title] = n;
+  // Keyed NFC and wrapped (#139): the parent_location ref read below is author-typed while
+  // these keys come from filenames, so a mismatch silently renders the child as a root
+  // sibling instead of nesting it.
+  const byTitle = {};
+  for (const n of nodes) byTitle[canonicalNfc(n.page.title)] = n;
   for (const n of nodes) {
-    if (!(n.page.displayTitle in lookup)) lookup[n.page.displayTitle] = n;
+    const display = canonicalNfc(n.page.displayTitle);
+    if (!(display in byTitle)) byTitle[display] = n;
   }
+  const lookup = nfcLookupTable(byTitle);
   const roots = [];
   for (const n of nodes) {
     const parentRef = n.page.frontmatter.parent_location;
@@ -298,8 +304,10 @@ function renderLocationsPage(pages, indexDir, imageMap = {}, publishConfig = nul
     const p = node.page;
     const parentRef = p.frontmatter.parent_location;
     const locType = String(p.frontmatter.location_type || '').trim();
+    // NFC (#139): this is a grouping key built from an author-typed ref, so two spellings of
+    // one parent name would otherwise render as two separate regions with the same heading.
     const region = parentRef
-      ? String(parentRef).replace(/\[\[|\]\]/g, '').trim()
+      ? canonicalNfc(String(parentRef).replace(/\[\[|\]\]/g, '').trim())
       : (locType || 'Other');
     if (!byRegion[region]) byRegion[region] = [];
     byRegion[region].push(node);
@@ -364,12 +372,16 @@ function renderChapterList(pages, indexDir) {
   if (chapters.length === 0 && sessions.length === 0) return '';
 
   function sessionsForChapter(chapter) {
-    const chTitle = chapter.displayTitle.toLowerCase();
+    // The third copy of the chapter matcher (story-spine.js and build.js hold the others).
+    // Author-typed ref vs filename-derived title on both substring tests, so both sides are
+    // canonicalized to NFC (#139) or an accented chapter lists none of its sessions.
+    const chTitle = canonicalNfc(chapter.displayTitle).toLowerCase();
+    const chFrontTitle = chapter.frontmatter.title ? canonicalNfc(chapter.frontmatter.title).toLowerCase() : '___';
     const chFolder = chapter.outputPath.split('/').slice(0, -1).join('/');
     return sessions.filter(s => {
-      const ref = String(s.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '').toLowerCase();
+      const ref = canonicalNfc(String(s.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '')).toLowerCase();
       if (ref && chTitle.includes(ref.replace(/^chapter \d+\s*[-–—]\s*/i, '').trim().toLowerCase())) return true;
-      if (ref && ref.includes(chapter.frontmatter.title ? chapter.frontmatter.title.toLowerCase() : '___')) return true;
+      if (ref && ref.includes(chFrontTitle)) return true;
       if (s.outputPath.startsWith(chFolder + '/')) return true;
       return false;
     });

--- a/tools/publish/lib/templates/item.js
+++ b/tools/publish/lib/templates/item.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath, parseWikiRef } = require('../processor');
+const { escapeHtml, relativePath, parseWikiRef, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge, portraitImg } = require('./base');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
@@ -39,7 +39,7 @@ function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap,
     const holderPath = linkMap?.[holderName];
     const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
     if (holderPath) {
-      const href = relativePath(currentDir, holderPath);
+      const href = encodeHref(relativePath(currentDir, holderPath));
       holderHtml = `<p class="item-holder"><strong>Current Holder:</strong> <a href="${href}">${escapeHtml(holderLabel)}</a></p>`;
     } else {
       holderHtml = `<p class="item-holder"><strong>Current Holder:</strong> ${escapeHtml(holderLabel)}</p>`;
@@ -53,7 +53,7 @@ function itemTemplate(page, processedContent, navFor, config, imageMap, linkMap,
     const originPath = linkMap?.[originName];
     const currentDir = page.outputPath.substring(0, page.outputPath.lastIndexOf('/'));
     if (originPath) {
-      const href = relativePath(currentDir, originPath);
+      const href = encodeHref(relativePath(currentDir, originPath));
       originHtml = `<p class="item-origin"><strong>Origin:</strong> <a href="${href}">${escapeHtml(originLabel)}</a></p>`;
     } else {
       originHtml = `<p class="item-origin"><strong>Origin:</strong> ${escapeHtml(originLabel)}</p>`;

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -1,3 +1,5 @@
+const { canonicalNfc } = require('../unicode');
+
 function getLatestSession(pages) {
   const played = pages.filter(
     p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')
@@ -233,10 +235,12 @@ function getLatestWrapUp(pages, session) {
       if (wu.frontmatter.session_number === num) return wu;
     }
   }
-  const sessionTitle = session.title || '';
+  // NFC both sides (#139): the wrap-up's session ref is author-typed, the session title is a
+  // filename. A mismatch drops the landing page's narrative recap back to the session body.
+  const sessionTitle = canonicalNfc(session.title || '');
   if (sessionTitle) {
     for (const wu of wrapUps) {
-      const ref = String(wu.frontmatter.session || wu.title || '');
+      const ref = canonicalNfc(String(wu.frontmatter.session || wu.title || ''));
       if (ref === sessionTitle || ref.includes(sessionTitle)) return wu;
     }
   }

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -1,4 +1,5 @@
 const { canonicalNfc } = require('../unicode');
+const { parseWikiRef } = require('../processor');
 
 function getLatestSession(pages) {
   const played = pages.filter(
@@ -211,6 +212,16 @@ function getRecentEvents(pages, max) {
     .slice(0, max || 4);
 }
 
+// Does `ref` name `title` as a whole title, rather than as the prefix of a longer one?
+// "Session 1" is a substring of "Session 10", so a bare `includes` picks the wrong
+// wrap-up; require the character after the match not to continue the word.
+function refMentions(ref, title) {
+  const at = ref.indexOf(title);
+  if (at === -1) return false;
+  const after = ref.charAt(at + title.length);
+  return after === '' || !/[0-9A-Za-z]/.test(after);
+}
+
 function getLatestWrapUp(pages, session) {
   if (!session) return null;
   const wrapTypes = new Set(['session-wrap-up', 'session_wrap', 'session-wrapup']);
@@ -229,19 +240,33 @@ function getLatestWrapUp(pages, session) {
     }
   }
 
+  // NFC both sides (#139): the wrap-up's session ref is author-typed, the session title is a
+  // filename. A mismatch drops the landing page's narrative recap back to the session body.
+  const sessionTitle = canonicalNfc(session.title || '');
+  const refOf = (wu) =>
+    canonicalNfc(parseWikiRef(wu.frontmatter.session || wu.title || '').target);
+
+  // An explicit `session:` ref names one session, so it outranks session_number, which
+  // chapters make ambiguous by restarting the count.
+  if (sessionTitle) {
+    for (const wu of wrapUps) {
+      if (refOf(wu) === sessionTitle) return wu;
+    }
+  }
+
   const num = session.frontmatter.session_number;
   if (num != null) {
     for (const wu of wrapUps) {
       if (wu.frontmatter.session_number === num) return wu;
     }
   }
-  // NFC both sides (#139): the wrap-up's session ref is author-typed, the session title is a
-  // filename. A mismatch drops the landing page's narrative recap back to the session body.
-  const sessionTitle = canonicalNfc(session.title || '');
+
+  // Last resort: a ref that mentions the session inside longer prose ("Recap for
+  // Session 05 extras"). Guarded against the digit run-on that made "Session 1" match
+  // "[[Session 10]]" and put the wrong recap on the landing page.
   if (sessionTitle) {
     for (const wu of wrapUps) {
-      const ref = canonicalNfc(String(wu.frontmatter.session || wu.title || ''));
-      if (ref === sessionTitle || ref.includes(sessionTitle)) return wu;
+      if (refMentions(refOf(wu), sessionTitle)) return wu;
     }
   }
   return null;

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -4,6 +4,7 @@ const {
   getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs,
   getRecentEvents, getExploreDescriptions,
 } = require('./landing-data');
+const { canonicalNfc } = require('../unicode');
 
 function formatDate(dateStr) {
   if (!dateStr) return null;
@@ -32,9 +33,11 @@ function statusLabel(status) {
 // page's source filename (page.title). Returns null when no matching session page is present.
 function resolveSessionLink(link, pages) {
   if (!link) return null;
-  const target = String(link).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim();
+  // NFC both sides (#139). A miss here is masked by the getLatestSession fallback, so the
+  // landing quietly features a DIFFERENT session than the overview names — worse than blank.
+  const target = canonicalNfc(String(link).replace(/^\[\[/, '').replace(/\]\]$/, '').split('|')[0].trim());
   if (!target) return null;
-  return pages.find(p => p.frontmatter.type === 'session' && p.title === target) || null;
+  return pages.find(p => p.frontmatter.type === 'session' && canonicalNfc(p.title) === target) || null;
 }
 
 function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus) {

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -1,4 +1,4 @@
-const { escapeHtml, plainMetaValue } = require('../processor');
+const { escapeHtml, plainMetaValue, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, DIR_LABELS, portraitImg, canonStatusBadge, clientScripts } = require('./base');
 const {
   getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs,
@@ -88,7 +88,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
     const dateStr = formatDate(overviewFm.last_play_date || latestSession.frontmatter.play_date || latestSession.frontmatter.actual_date);
     const dateBadge = dateStr ? ` <span style="opacity:0.7;font-size:0.85rem"> — ${escapeHtml(dateStr)}</span>` : '';
     const linkTarget = latestWrapUp || latestSession;
-    const recapLink = `<a class="recap-link" href="${escapeHtml(linkTarget.outputPath)}">Read full session &rarr;</a>`;
+    const recapLink = `<a class="recap-link" href="${escapeHtml(encodeHref(linkTarget.outputPath))}">Read full session &rarr;</a>`;
     recapZone = `<div class="dashboard-section">
   <h2>Latest Session${dateBadge}</h2>
   <div class="recap">${recap ? escapeHtml(recap) : '<em>No recap available.</em>'}
@@ -115,7 +115,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
       const traits = fm.key_traits
         ? `<div class="pc-traits">${escapeHtml(Array.isArray(fm.key_traits) ? fm.key_traits.join(', ') : String(fm.key_traits))}</div>`
         : '';
-      return `<a class="pc-card" href="${escapeHtml(pc.outputPath)}">
+      return `<a class="pc-card" href="${escapeHtml(encodeHref(pc.outputPath))}">
   ${portraitHtml}
   <h3>${escapeHtml(pc.displayTitle)}</h3>
   ${occupation}${traits}
@@ -134,7 +134,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
       const status = statusLabel(pc.frontmatter.status);
       const context = pc.frontmatter.death_context || pc.frontmatter.retirement_context || '';
       const contextHtml = context ? ` <span class="memorial-context">${escapeHtml(context)}</span>` : '';
-      return `<a href="${escapeHtml(pc.outputPath)}">${escapeHtml(pc.displayTitle)} (${escapeHtml(status)})</a>${contextHtml}`;
+      return `<a href="${escapeHtml(encodeHref(pc.outputPath))}">${escapeHtml(pc.displayTitle)} (${escapeHtml(status)})</a>${contextHtml}`;
     }).join('\n');
     memoriamZone = `<div class="dashboard-section">
   <h2>In Memoriam</h2>
@@ -155,7 +155,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
         ? `<div class="npc-icon">${portraitTag}</div>`
         : `<div class="npc-icon">${escapeHtml(initials)}</div>`;
       const role = fm.occupation ? `<div class="npc-role">${escapeHtml(plainMetaValue(fm.occupation))}</div>` : '';
-      return `<a class="npc-card" href="${escapeHtml(page.outputPath)}">
+      return `<a class="npc-card" href="${escapeHtml(encodeHref(page.outputPath))}">
   ${iconHtml}
   <div><h4>${escapeHtml(page.displayTitle)}</h4>${role}</div>
 </a>`;
@@ -174,7 +174,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
     const locCards = recentLocations.map(({ page }) => {
       const fm = page.frontmatter;
       const subtitle = fm.location_type || '';
-      return `<a class="entity-card" href="${escapeHtml(page.outputPath)}">
+      return `<a class="entity-card" href="${escapeHtml(encodeHref(page.outputPath))}">
   <h4>${escapeHtml(page.displayTitle)}</h4>
   ${subtitle ? `<div class="card-subtitle">${escapeHtml(subtitle)}</div>` : ''}
 </a>`;
@@ -194,7 +194,7 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
       const date = formatDate(fm.date) || '';
       const location = fm.location ? String(fm.location).replace(/\[\[|\]\]/g, '').replace(/_/g, ' ') : '';
       const outcome = fm.outcome || '';
-      return `<a class="entity-card" href="${escapeHtml(page.outputPath)}">
+      return `<a class="entity-card" href="${escapeHtml(encodeHref(page.outputPath))}">
   <h4>${escapeHtml(page.displayTitle)}</h4>
   ${date ? `<div class="card-subtitle">${escapeHtml(date)}${location ? ' — ' + escapeHtml(location) : ''}</div>` : ''}
   ${outcome ? `<div class="card-excerpt">${escapeHtml(outcome)}</div>` : ''}

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativeHref, parseWikiRef, publishedSource } = require('../processor');
+const { escapeHtml, relativeHref, parseWikiRef, publishedSource, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, canonStatusBadge, portraitImg, clientScripts } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
@@ -25,7 +25,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
     parentLocation: parent.label,
     // Breadcrumb hrefs are relative to the current page; linkMap holds the root-relative
     // output path, so make it relative or it resolves under the current dir and 404s.
-    parentLocationHref: parentTarget ? relativeHref(page.outputPath, parentTarget) : null,
+    parentLocationHref: parentTarget ? encodeHref(relativeHref(page.outputPath, parentTarget)) : null,
   } : {});
   const breadcrumbsHtml = renderBreadcrumbs(crumbs);
 
@@ -69,7 +69,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   let subLocationsHtml = '';
   if (childLocations.length > 0) {
     const cards = childLocations.map(child => {
-      const href = relativeHref(page.outputPath, child.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, child.outputPath));
       const excerpt = excerptFromMarkdown(publishedSource(child),
         { excludeSections: (publishConfig && publishConfig.exclude_sections) || [] });
       return `<a class="entity-card" href="${href}">
@@ -91,7 +91,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   let whosHereHtml = '';
   if (locNPCs.length > 0) {
     const npcCards = locNPCs.map(npc => {
-      const href = relativeHref(page.outputPath, npc.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, npc.outputPath));
       const initials = getInitials(npc.displayTitle);
       const role = npc.frontmatter.occupation || '';
       return `<a class="npc-card" href="${href}">
@@ -116,7 +116,7 @@ function locationTemplate(page, processedContent, navFor, config, imageMap, cont
   let timelineHtml = '';
   if (locEvents.length > 0) {
     const nodes = locEvents.map(ev => {
-      const href = relativeHref(page.outputPath, ev.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, ev.outputPath));
       const date = ev.frontmatter.in_game_date || ev.frontmatter.date || '';
       const outcome = ev.frontmatter.outcome || '';
       return `<div class="timeline-node">

--- a/tools/publish/lib/templates/location.js
+++ b/tools/publish/lib/templates/location.js
@@ -4,11 +4,15 @@ const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { getInitials } = require('./landing-data');
 const { excerptFromMarkdown } = require('../excerpt');
+const { canonicalNfc } = require('../unicode');
 
+// The ref is author-typed, the title comes from a filename: canonicalize both to NFC (#139)
+// or "Places Within", "Known Figures" and "What Happened Here" all vanish from an accented
+// location page. Bare `===`, so no lookup-table wrapper can cover this.
 function matchesRef(refValue, title) {
   if (!refValue) return false;
-  const cleaned = String(refValue).replace(/\[\[|\]\]/g, '').split('|')[0].replace(/_/g, ' ').trim();
-  const normalTitle = String(title || '').replace(/_/g, ' ').trim();
+  const cleaned = canonicalNfc(String(refValue).replace(/\[\[|\]\]/g, '').split('|')[0].replace(/_/g, ' ').trim());
+  const normalTitle = canonicalNfc(String(title || '').replace(/_/g, ' ').trim());
   return cleaned === normalTitle;
 }
 

--- a/tools/publish/lib/templates/nav.js
+++ b/tools/publish/lib/templates/nav.js
@@ -1,4 +1,4 @@
-const { relativePath, escapeHtml } = require('../processor');
+const { relativePath, escapeHtml, encodeHref } = require('../processor');
 const { DIR_LABELS } = require('./base');
 
 const NAV_GROUPS = [
@@ -64,16 +64,16 @@ function renderTopNav(pages, currentOutputPath, config, options = {}) {
 
   const hasStoryGroup = groups.some(g => g.name === 'Story');
   const standaloneStory = options.hasStory && !hasStoryGroup;
-  const storyHref = relativePath(currentDir, 'story.html');
+  const storyHref = encodeHref(relativePath(currentDir, 'story.html'));
 
   const desktopGroupsHtml = groups.map(group => {
     const linksHtml = group.links.map(link => {
-      const href = relativePath(currentDir, link.href);
+      const href = encodeHref(relativePath(currentDir, link.href));
       return `        <a href="${href}">${escapeHtml(link.label)}</a>`;
     }).join('\n');
 
     const toggle = options.hasStory && group.name === 'Story'
-      ? `<a class="nav-group-toggle" href="${relativePath(currentDir, 'story.html')}">${escapeHtml(group.name)}</a>`
+      ? `<a class="nav-group-toggle" href="${encodeHref(relativePath(currentDir, 'story.html'))}">${escapeHtml(group.name)}</a>`
       : `<button class="nav-group-toggle">${escapeHtml(group.name)}</button>`;
 
     return `      <div class="nav-group">
@@ -92,11 +92,11 @@ ${linksHtml}
     ? [standaloneDesktop, desktopGroupsHtml].filter(Boolean).join('\n')
     : desktopGroupsHtml;
 
-  const rootHref = relativePath(currentDir, 'index.html') || './index.html';
+  const rootHref = encodeHref(relativePath(currentDir, 'index.html')) || './index.html';
 
   const mobileGroupsHtml = groups.map(group => {
     const links = group.links.map(link => {
-      const href = relativePath(currentDir, link.href);
+      const href = encodeHref(relativePath(currentDir, link.href));
       return `    <li><a href="${href}">${escapeHtml(link.label)}</a></li>`;
     }).join('\n');
     // Mirror the desktop behavior: when a Story section exists, the Story heading links to

--- a/tools/publish/lib/templates/npc.js
+++ b/tools/publish/lib/templates/npc.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativeHref, renderMetaValue, publishedSource } = require('../processor');
+const { escapeHtml, relativeHref, renderMetaValue, publishedSource, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, canonStatusBadge, portraitImg, clientScripts } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
@@ -62,7 +62,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
     const locDisplay = locTitle.replace(/_/g, ' ');
     const locPath = linkMap ? linkMap[locTitle] : null;
     if (locPath) {
-      const href = relativeHref(page.outputPath, locPath);
+      const href = encodeHref(relativeHref(page.outputPath, locPath));
       locationCardHtml = `<a class="npc-location-card" href="${href}">
   <div><span class="loc-label">Location</span><br><strong>${escapeHtml(locDisplay)}</strong></div>
 </a>`;
@@ -82,7 +82,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
       const display = target.replace(/_/g, ' ');
       const relType = (r.type || '').replace(/_/g, ' ');
       const targetPath = linkMap ? linkMap[target] : null;
-      const href = targetPath ? relativeHref(page.outputPath, targetPath) : null;
+      const href = targetPath ? encodeHref(relativeHref(page.outputPath, targetPath)) : null;
       const tag = href ? 'a' : 'div';
       const hrefAttr = href ? ` href="${href}"` : '';
       return `<${tag} class="rel-card"${hrefAttr}>
@@ -107,7 +107,7 @@ function npcTemplate(page, processedContent, navFor, config, imageMap, context) 
   let arcTimelineHtml = '';
   if (sessionBacklinks.length > 0) {
     const nodes = sessionBacklinks.map(b => {
-      const href = relativeHref(page.outputPath, b.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, b.outputPath));
       return `<div class="timeline-node">
   <a href="${href}">${escapeHtml(b.displayTitle)}</a>
 </div>`;

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativePath, relativeHref, publishedSource } = require('../processor');
+const { escapeHtml, relativePath, relativeHref, publishedSource, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
@@ -343,7 +343,7 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
   // --- Story Tab ---
   const opts = context || {};
   const storyContent = opts.storyHref
-    ? `<a class="story-read-link" href="${relativeHref(page.outputPath, opts.storyHref)}">Read ${escapeHtml(page.displayTitle)}'s story &rarr;</a>`
+    ? `<a class="story-read-link" href="${encodeHref(relativeHref(page.outputPath, opts.storyHref))}">Read ${escapeHtml(page.displayTitle)}'s story &rarr;</a>`
     : (storyHtml || '<p class="text-muted">No story content available.</p>');
 
   // --- Journey Tab ---

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -1,4 +1,5 @@
 const { escapeHtml, relativePath, relativeHref, publishedSource, encodeHref } = require('../processor');
+const { canonicalNfc } = require('../unicode');
 const { baseShell, cssPath, rootPath, clientScripts, portraitImg } = require('./base');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
 const { getInitials } = require('./landing-data');
@@ -163,7 +164,9 @@ function buildRouteMap(page, pages) {
   for (const session of storyPages) {
     const loc = session.frontmatter.location;
     if (loc) {
-      const locTitle = String(loc).replace(/\[\[|\]\]/g, '').split('|')[0].trim();
+      // NFC (#139): a Set keyed on an author-typed ref, so two spellings of one location
+      // would list it twice in the route map instead of deduping.
+      const locTitle = canonicalNfc(String(loc).replace(/\[\[|\]\]/g, '').split('|')[0].trim());
       if (!seen.has(locTitle) || locations[locations.length - 1] !== locTitle) {
         locations.push(locTitle);
         seen.add(locTitle);

--- a/tools/publish/lib/templates/story-landing.js
+++ b/tools/publish/lib/templates/story-landing.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativeHref } = require('../processor');
+const { escapeHtml, relativeHref, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts } = require('./base');
 
 const OUT = 'story.html';
@@ -7,8 +7,8 @@ const GROUP_LABELS = { current: 'Current', retired: 'Retired', fallen: 'Fallen' 
 function storyLanding(spine, characterStories, config, publishConfig, navFor) {
   let saga = '';
   if (spine.length) {
-    const begin = relativeHref(OUT, spine[0].outputPath);
-    const items = spine.map(u => `<li><a href="${relativeHref(OUT, u.outputPath)}">${escapeHtml(u.title)}</a></li>`).join('');
+    const begin = encodeHref(relativeHref(OUT, spine[0].outputPath));
+    const items = spine.map(u => `<li><a href="${encodeHref(relativeHref(OUT, u.outputPath))}">${escapeHtml(u.title)}</a></li>`).join('');
     saga = `<section class="story-branch"><h2>The Campaign Saga</h2>
       <p><a class="story-begin" href="${begin}">Begin reading &rarr;</a></p><ol class="story-toc">${items}</ol></section>`;
   }
@@ -17,7 +17,7 @@ function storyLanding(spine, characterStories, config, publishConfig, navFor) {
     const groups = ['current', 'retired', 'fallen'].map(g => {
       const inG = characterStories.filter(c => c.group === g);
       if (!inG.length) return '';
-      const links = inG.map(c => `<li><a href="${relativeHref(OUT, c.outputPath)}">${escapeHtml(c.title)}</a></li>`).join('');
+      const links = inG.map(c => `<li><a href="${encodeHref(relativeHref(OUT, c.outputPath))}">${escapeHtml(c.title)}</a></li>`).join('');
       return `<h3>${GROUP_LABELS[g]}</h3><ul>${links}</ul>`;
     }).join('');
     chars = `<section class="story-branch"><h2>Character Stories</h2>${groups}</section>`;

--- a/tools/publish/lib/templates/story.js
+++ b/tools/publish/lib/templates/story.js
@@ -1,11 +1,11 @@
-const { escapeHtml, relativeHref } = require('../processor');
+const { escapeHtml, relativeHref, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts } = require('./base');
 
 function storyNav(unit) {
   const prev = unit.prevHref
-    ? `<a href="${relativeHref(unit.outputPath, unit.prevHref)}">&larr; Previous</a>` : '<span></span>';
+    ? `<a href="${encodeHref(relativeHref(unit.outputPath, unit.prevHref))}">&larr; Previous</a>` : '<span></span>';
   const next = unit.nextHref
-    ? `<a href="${relativeHref(unit.outputPath, unit.nextHref)}">Next &rarr;</a>` : '<span></span>';
+    ? `<a href="${encodeHref(relativeHref(unit.outputPath, unit.nextHref))}">Next &rarr;</a>` : '<span></span>';
   return `<div class="story-nav">${prev}${next}</div>`;
 }
 
@@ -37,7 +37,7 @@ function storyPage(unit, config, publishConfig, navFor) {
 
 function characterStoryPage(story, config, publishConfig, navFor) {
   const sheetLink = story.sheetOutputPath
-    ? `<p class="story-sheet-link"><a href="${relativeHref(story.outputPath, story.sheetOutputPath)}">View character sheet &rarr;</a></p>` : '';
+    ? `<p class="story-sheet-link"><a href="${encodeHref(relativeHref(story.outputPath, story.sheetOutputPath))}">View character sheet &rarr;</a></p>` : '';
   const content = `
     <article class="story-prose">
       <h1 class="page-title">${escapeHtml(story.title)}</h1>

--- a/tools/publish/lib/templates/wiki.js
+++ b/tools/publish/lib/templates/wiki.js
@@ -1,4 +1,4 @@
-const { escapeHtml, relativeHref } = require('../processor');
+const { escapeHtml, relativeHref, encodeHref } = require('../processor');
 const { baseShell, cssPath, rootPath, clientScripts, canonStatusBadge, metadataBadgesFor, portraitImg } = require('./base');
 const { renderContextSidebar, normalizeRelationships } = require('./context-sidebar');
 const { generateBreadcrumbs, renderBreadcrumbs } = require('../breadcrumbs');
@@ -24,7 +24,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
 
   if (extraSidebar.mentionedNPCs && extraSidebar.mentionedNPCs.length > 0) {
     const npcItems = extraSidebar.mentionedNPCs.map(n => {
-      const href = relativeHref(page.outputPath, n.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, n.outputPath));
       return `<li><a href="${href}">${escapeHtml(n.displayTitle)}</a></li>`;
     });
     extraSections.push(`<h3>NPCs Appearing</h3>\n<ul>${npcItems.join('\n')}</ul>`);
@@ -32,7 +32,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
 
   if (extraSidebar.events && extraSidebar.events.length > 0) {
     const eventItems = extraSidebar.events.map(e => {
-      const href = relativeHref(page.outputPath, e.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, e.outputPath));
       return `<li><a href="${href}">${escapeHtml(e.displayTitle)}</a></li>`;
     });
     extraSections.push(`<h3>Events</h3>\n<ul>${eventItems.join('\n')}</ul>`);
@@ -40,7 +40,7 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
 
   if (extraSidebar.constituentSessions && extraSidebar.constituentSessions.length > 0) {
     const sessionItems = extraSidebar.constituentSessions.map(s => {
-      const href = relativeHref(page.outputPath, s.outputPath);
+      const href = encodeHref(relativeHref(page.outputPath, s.outputPath));
       return `<li><a href="${href}">${escapeHtml(s.displayTitle)}</a></li>`;
     });
     extraSections.push(`<h3>Sessions</h3>\n<ul>${sessionItems.join('\n')}</ul>`);
@@ -74,8 +74,8 @@ function wikiTemplate(page, processedContent, navFor, config, imageMap, context)
     const idx = sameType.findIndex(p => p.title === page.title);
     const prev = idx > 0 ? sameType[idx - 1] : null;
     const next = idx < sameType.length - 1 ? sameType[idx + 1] : null;
-    const prevLink = prev ? `<a href="${relativeHref(page.outputPath, prev.outputPath)}">&larr; ${escapeHtml(prev.displayTitle)}</a>` : '<span></span>';
-    const nextLink = next ? `<a href="${relativeHref(page.outputPath, next.outputPath)}">${escapeHtml(next.displayTitle)} &rarr;</a>` : '<span></span>';
+    const prevLink = prev ? `<a href="${encodeHref(relativeHref(page.outputPath, prev.outputPath))}">&larr; ${escapeHtml(prev.displayTitle)}</a>` : '<span></span>';
+    const nextLink = next ? `<a href="${encodeHref(relativeHref(page.outputPath, next.outputPath))}">${escapeHtml(next.displayTitle)} &rarr;</a>` : '<span></span>';
     storyNav = `<div class="story-nav">${prevLink}${nextLink}</div>`;
   }
 

--- a/tools/publish/lib/timeline.js
+++ b/tools/publish/lib/timeline.js
@@ -1,4 +1,4 @@
-const { escapeHtml } = require('./processor');
+const { escapeHtml, encodeHref } = require('./processor');
 
 const MONTHS = { january:0, february:1, march:2, april:3, may:4, june:5,
   july:6, august:7, september:8, october:9, november:10, december:11 };
@@ -116,7 +116,7 @@ function renderTimelineHTML(data) {
   </div>
   <div class="tl-detail-col">
     <span class="tl-type">${escapeHtml(badge)}</span>
-    <h3><a href="${escapeHtml(evt.outputPath)}">${escapeHtml(evt.title)}</a></h3>
+    <h3><a href="${escapeHtml(encodeHref(evt.outputPath))}">${escapeHtml(evt.title)}</a></h3>
     ${details.length ? `<p>${escapeHtml(details.join(' — '))}</p>` : ''}
   </div>
 </div>`;
@@ -143,7 +143,7 @@ function renderTimelineStrip(data, options) {
     <div class="tl-dot"></div>
   </div>
   <div class="tl-detail-col">
-    <h3><a href="${escapeHtml(evt.outputPath)}">${escapeHtml(evt.title)}</a></h3>
+    <h3><a href="${escapeHtml(encodeHref(evt.outputPath))}">${escapeHtml(evt.title)}</a></h3>
   </div>
 </div>`;
   }).join('\n');

--- a/tools/publish/lib/unicode.js
+++ b/tools/publish/lib/unicode.js
@@ -1,0 +1,49 @@
+// Unicode normal form is the hidden variable behind every string comparison this tool
+// makes (#139). A name typed with precomposed accents ("González", NFC) and the same
+// visible name decomposed into base letter + combining marks (NFD) are identical on
+// screen and different byte-for-byte — and which form a given string arrives in depends
+// on the editor, the OS, and the filesystem that round-tripped it. Both sides of a
+// comparison must therefore be put into one normal form first, or the match silently
+// misses and the failure surfaces as "the link didn't render" rather than as an error.
+//
+// NFC is the canonical form throughout: it is what the web, git, and most editors emit.
+function canonicalNfc(value) {
+  return String(value).normalize('NFC');
+}
+
+// Wrap a lookup table so that reads canonicalize their key.
+//
+// The two big tables — linkMap (page titles and aliases) and imageMap (attachment
+// basenames) — are indexed from build.js, processor.js, and a dozen entity templates,
+// and the query string is always author-typed text: the words inside a `[[wikilink]]`,
+// a `portrait:` value, a relationship target, a `parent`/`holder`/`leader` name. The keys
+// come from filenames and frontmatter. Key and query are typed on different keyboards in
+// different apps, so they routinely disagree on normal form.
+//
+// Normalizing at the table rather than at each call site is deliberate: the guarantee then
+// holds by construction for every present and future lookup, instead of depending on some
+// forty call sites each remembering to normalize — the failure this codebase keeps
+// rediscovering, where one call site is fixed and its siblings are left behind.
+// Keys are stored already canonicalized, so enumeration (Object.keys /
+// entries / values) is unchanged, and the stored VALUES — output paths, attachment
+// relPaths — are never touched. That is what keeps #139's normalization orthogonal to
+// #145's percent-encoding: only comparison keys are canonicalized, never emitted paths.
+function nfcLookupTable(map) {
+  return new Proxy(map, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string') {
+        const key = canonicalNfc(prop);
+        if (Object.prototype.hasOwnProperty.call(target, key)) return target[key];
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+    has(target, prop) {
+      if (typeof prop === 'string' && Object.prototype.hasOwnProperty.call(target, canonicalNfc(prop))) {
+        return true;
+      }
+      return Reflect.has(target, prop);
+    },
+  });
+}
+
+module.exports = { canonicalNfc, nfcLookupTable };

--- a/tools/publish/lib/unicode.js
+++ b/tools/publish/lib/unicode.js
@@ -28,6 +28,20 @@ function canonicalNfc(value) {
 // entries / values) is unchanged, and the stored VALUES — output paths, attachment
 // relPaths — are never touched. That is what keeps #139's normalization orthogonal to
 // #145's percent-encoding: only comparison keys are canonicalized, never emitted paths.
+//
+// What this does NOT cover — read before relying on it:
+//   * `set` and `delete` are untrapped. Writing through the wrapper with a non-canonical key
+//     stores that key verbatim, creating a duplicate entry that reads can never reach.
+//     Build tables fully as a plain object, canonicalizing keys yourself, then wrap once.
+//   * `Object.prototype.hasOwnProperty.call(map, k)` and `Object.keys(map).includes(k)`
+//     bypass the traps and see only the stored keys; `k in map` and `map[k]` go through them.
+//     Prefer the latter two.
+//   * A copy loses the guarantee. Spread, `Object.assign({}, map)`, and a JSON round-trip all
+//     produce a plain object again; re-wrap if the copy is going to be looked up.
+//   * `Map` and `Set` cannot be wrapped at all — their lookups are method calls, not property
+//     access. Every `Map`/`Set` keyed on author-typed text is therefore call-site-dependent
+//     and must canonicalize at both the write and the read. `recency.js`, `story-spine.js`,
+//     and the chapter matcher in `build.js` are the ones that exist today.
 function nfcLookupTable(map) {
   return new Proxy(map, {
     get(target, prop, receiver) {

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.21",
+  "version": "1.11.22",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/templates-scaffold/vault.config.json.tmpl
+++ b/tools/publish/templates-scaffold/vault.config.json.tmpl
@@ -22,7 +22,7 @@
     "Heritages": "heritages"
   },
   "excludeDirs": ["_meta", "_Templates", "_resources"],
-  "excludeSections": ["GM Notes", "DM Notes", "Player Notes", "Source References"],
+  "excludeSections": ["GM Notes", "DM Notes", "Player Notes", "Source References", "Reconciliation Context", "Handoff to Reconcile"],
   "excludeCallouts": true,
   "backend": { "statusBar": false, "inbox": false }
 }

--- a/tools/publish/test/fixtures/html-comment-leak/Chapters/Chapter 1 - Test/Chapter 1 Overview.md
+++ b/tools/publish/test/fixtures/html-comment-leak/Chapters/Chapter 1 - Test/Chapter 1 Overview.md
@@ -1,0 +1,7 @@
+---
+type: chapter
+title: Chapter 1 — Test
+sort_order: 1
+---
+## Overview
+Structural overview.

--- a/tools/publish/test/fixtures/html-comment-leak/Chapters/Chapter 1 - Test/Session 1.md
+++ b/tools/publish/test/fixtures/html-comment-leak/Chapters/Chapter 1 - Test/Session 1.md
@@ -1,0 +1,13 @@
+---
+type: session
+status: played
+chapter: "[[Chapter 1 Overview]]"
+session_number: 1
+play_date: "2024-01-01"
+---
+## Narrative Recap
+<!-- authoring note: verify with GM before publishing -->
+The investigators discovered the hidden passage behind the bookshelf.
+
+## Discoveries
+A dusty ledger.

--- a/tools/publish/test/fixtures/html-comment-leak/_meta/vault-config.md
+++ b/tools/publish/test/fixtures/html-comment-leak/_meta/vault-config.md
@@ -1,0 +1,4 @@
+---
+publish:
+  mode: full
+---

--- a/tools/publish/test/inbox-cli.test.js
+++ b/tools/publish/test/inbox-cli.test.js
@@ -1,6 +1,6 @@
 const { test, before } = require('node:test');
 const assert = require('node:assert');
-const { runInbox } = require('../lib/inbox-cli.js');
+const { runInbox, defaultRunWrangler, WRANGLER_TIMEOUT_MS } = require('../lib/inbox-cli.js');
 
 let inbox;
 before(async () => { inbox = await import('../templates-scaffold/functions/api/inbox-core.mjs'); });
@@ -84,4 +84,28 @@ test('reply rejects an unknown kind', async () => {
   const rc = await runInbox(['reply', 'a', 'bogus', 'x'], { adapter: kv, out: c.out });
   assert.equal(rc, 1);
   assert.match(c.lines.join('\n'), /applied\|rejected\|advice/);
+});
+
+test('the wrangler call the watcher polls through is bounded by a timeout', () => {
+  // The watcher's poll loop writes .watcher-heartbeat only after `inbox pull`
+  // returns. An unbounded spawn on a hung wrangler stalls the heartbeat with no
+  // exit and no failure line, so the loop looks dead and the GM cannot tell.
+  const seen = [];
+  const res = defaultRunWrangler(['kv', 'key', 'list'], (cmd, args, opts) => {
+    seen.push({ cmd, args, opts });
+    return { code: 0, stdout: '[]', stderr: '' };
+  });
+  assert.equal(res.code, 0);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].cmd, 'npx');
+  assert.deepEqual(seen[0].args, ['wrangler@4', 'kv', 'key', 'list']);
+  assert.ok(Number.isFinite(seen[0].opts.timeoutMs) && seen[0].opts.timeoutMs > 0,
+    `expected a finite positive timeoutMs, got ${JSON.stringify(seen[0].opts)}`);
+  assert.equal(seen[0].opts.timeoutMs, WRANGLER_TIMEOUT_MS);
+});
+
+test('a timed-out wrangler call reports failure instead of hanging', () => {
+  const res = defaultRunWrangler(['kv', 'key', 'list'],
+    () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }));
+  assert.equal(res.code, 1);
 });

--- a/tools/publish/test/integration/build-unicode-refs.test.js
+++ b/tools/publish/test/integration/build-unicode-refs.test.js
@@ -14,6 +14,12 @@ const { build } = require('../../lib/build');
 // that replaces that method. It covers boundaries no lookup-table wrapper can reach (Map,
 // Set, bare ===) and any new one a future template introduces.
 //
+// What it does NOT cover: filenames are pinned to NFC in every variant, so the mirror
+// direction — NFC refs against NFD *filenames* — is out of scope here and is guarded instead
+// by test/unit/unicode-lookup.test.js. Reverting buildLinkMap (scanner.js), recency.js's
+// entity names, or story-spine.js's unit-title reads leaves this file green, so "byte-
+// identical across three variants" means the ref-vs-title class is closed, not all of #139.
+//
 // Every name is written with precomposed \u escapes, never a literal accented character, so
 // the constants are NFC by construction and no editor can silently re-normalize this file.
 const NPC = 'Alena Gonz\u00e1lez';

--- a/tools/publish/test/integration/build-unicode-refs.test.js
+++ b/tools/publish/test/integration/build-unicode-refs.test.js
@@ -1,0 +1,326 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { build } = require('../../lib/build');
+
+// Differential build for #139. The same vault is built twice: once with every author-typed
+// reference decomposed (NFD), once with every reference precomposed (NFC). Filenames are NFC
+// in both. If any comparison between a ref and a filename-derived title is normalization-
+// naive, the two sites diverge — a rollup empties, a tree flattens, a recap swaps.
+//
+// Reading the code has now missed sites three times over; this test is the mechanical guard
+// that replaces that method. It covers boundaries no lookup-table wrapper can reach (Map,
+// Set, bare ===) and any new one a future template introduces.
+//
+// Every name is written with precomposed \u escapes, never a literal accented character, so
+// the constants are NFC by construction and no editor can silently re-normalize this file.
+const NPC = 'Alena Gonz\u00e1lez';
+const LOC = 'Caf\u00e9 Ub\u00edquito';
+const SUB = 'Caf\u00e9 Ub\u00edquito Anexo';
+const FAC = 'Sociedad Ib\u00e9rica';
+const ITEM = 'Reliquia \u00c1mbar';
+const EVT = 'La Desaparici\u00f3n';
+const CRE = 'Bestia \u00d1u';
+const HER = 'Linaje \u00d3seo';
+const SESS = 'Sesi\u00f3n Ren\u00e9e';
+const SESS2 = 'Sesi\u00f3n Posterior';
+const CHAP = 'Cap\u00edtulo Ren\u00e9e';
+const CHAP2 = 'Cap\u00edtulo Segundo';
+const SESS3 = 'Sesi\u00f3n Anexa';
+const OLD = 'Nombre Antig\u00fco';
+const DOC = 'Carta An\u00f3nima';
+// Named by two districts but never published as a page: the locations index then buckets
+// those districts under this raw ref rather than a resolved node.
+const REGION = 'Regi\u00f3n Perdida';
+const BARRIO_N = 'Barrio Norte';
+const BARRIO_S = 'Barrio Sur';
+const DOMAIN = 'Dominio \u00c1rtico';
+const CLUE = 'Pista \u00d3rfica';
+const PC = 'Rook';
+const PORTRAIT = `${NPC}.png`;
+
+function writeVault(root, refForm) {
+  // R() decomposes every author-typed reference in the NFD variant. Filenames never change.
+  // In MIXED, the form flips per file: a grouping key or dedupe Set built from a raw ref
+  // splits one entity into two, which a uniform build can never reveal.
+  let fileIndex = 0;
+  let decompose = false;
+  const R = s => (decompose ? s.normalize('NFD') : s.normalize('NFC'));
+  const f = (rel, body) => {
+    decompose = refForm === 'NFD' || (refForm === 'MIXED' && fileIndex++ % 2 === 1);
+    // Filenames pinned to NFC: were they ever NFD, the "control" build would mismatch too and
+    // the whole-tree comparison would pass while proving nothing.
+    const p = path.join(root, rel.normalize('NFC'));
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, body);
+  };
+
+  f(`_attachments/${PORTRAIT}`, 'fake-png-bytes');
+
+  f('_Campaign/Campaign Overview.md', [
+    '---', 'type: campaign_overview', 'title: "Diff Campaign"',
+    'current_game_date: "1923-04-01"', 'sessions_played: 2',
+    // Deliberately the EARLIER session: a failed ref match then falls back to the
+    // date-latest session, which is a visible swap rather than an empty slot.
+    `last_session: "[[${R(SESS)}]]"`, 'last_play_date: "2026-01-02"',
+    '---', '', `The saga of [[${R(NPC)}]] at [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Chapters/${CHAP}.md`, [
+    '---', 'type: chapter', `title: "${CHAP}"`, 'sort_order: 1', 'status: active',
+    '---', '', '## Narrative Recap', '', `The chapter opens on [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Sessions/${SESS}.md`, [
+    '---', 'type: session', 'session_number: 1', 'status: played',
+    'play_date: "2026-01-02"', 'in_game_date: "1923-04-01"',
+    `chapter: "[[${R(CHAP)}]]"`, `location: "[[${R(LOC)}]]"`,
+    'participants:', `  - "[[${R(NPC)}]]"`, `  - "[[${R(PC)}]]"`,
+    '---', '', `The party met [[${R(NPC)}]] and fought [[${R(CRE)}]].`, '',
+    `They carried [[${R(ITEM)}]].`, '',
+  ].join('\n'));
+
+  f(`Sessions/${SESS2}.md`, [
+    '---', 'type: session', 'session_number: 2', 'status: played',
+    'play_date: "2026-02-09"', 'in_game_date: "1923-05-01"',
+    `chapter: "[[${R(CHAP)}]]"`, `location: "[[${R(LOC)}]]"`,
+    '---', '', 'A later, duller session with no recap heading.', '',
+  ].join('\n'));
+
+  // Outside the session folder on purpose: wrap-up pairing has a same-folder fallback in
+  // three separate modules, and colocating the two would mask the ref match under test.
+  f(`Chapters/${CHAP2}.md`, [
+    '---', 'type: chapter', `title: "${CHAP2}"`, 'sort_order: 2', 'status: active',
+    '---', '', 'A second chapter, in the same folder as its session.', '',
+  ].join('\n'));
+
+  f(`Chapters/${SESS3}.md`, [
+    '---', 'type: session', 'session_number: 1', 'status: played',
+    'play_date: "2026-01-05"', 'in_game_date: "1923-04-15"',
+    `chapter: "[[${R(CHAP2)}]]"`,
+    '---', '', 'A session filed beside its chapter.', '',
+  ].join('\n'));
+
+  f(`Wrapups/${SESS} Wrap.md`, [
+    '---', 'type: session_wrap', `session: "[[${R(SESS)}]]"`,
+    '---', '', '## Narrative Recap', '',
+    `The wrap-up recounts [[${R(NPC)}]] escaping [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Characters/NPCs/${NPC}.md`, [
+    '---', 'type: npc', `portrait: "${R(PORTRAIT)}"`,
+    `location: "[[${R(LOC)}]]"`, `occupation: "Agent of [[${R(FAC)}]]"`,
+    `faction: "[[${R(FAC)}]]"`, `first_appearance: "[[${R(SESS)}]]"`,
+    `summary: "Seen last at [[${R(LOC)}]]"`,
+    'aliases:', '  - "La Se\u00f1ora"',
+    'relationships:',
+    `  - target: "[[${R(FAC)}]]"`, '    type: member_of',
+    `  - target: "[[${R(PC)}]]"`, '    type: ally',
+    '---', '', `She keeps rooms above [[${R(LOC)}]].`, '', `![[${R(PORTRAIT)}]]`, '',
+  ].join('\n'));
+
+  f(`Characters/NPCs/${OLD}.md`, [
+    '---', 'type: npc', 'canon_status: SUPERSEDED', `superseded_by: "[[${R(NPC)}]]"`,
+    '---', '', 'An earlier name for the same woman.', '',
+  ].join('\n'));
+
+  f(`Characters/PCs/${PC}.md`, [
+    '---', 'type: pc', 'player_name: "Ant"',
+    'relationships:', `  - target: "[[${R(NPC)}]]"`, '    type: ally',
+    `  - target: "[[${R(FAC)}]]"`, '    type: member_of',
+    '---', '', `Rook trusts [[${R(NPC)}]].`, '',
+  ].join('\n'));
+
+  f(`Locations/${LOC}.md`, [
+    '---', 'type: location', 'location_type: cafe',
+    '---', '', `A smoky room. [[${R(NPC)}]] holds court here.`, '',
+  ].join('\n'));
+
+  f(`Locations/${SUB}.md`, [
+    '---', 'type: location', 'location_type: room', `parent_location: "[[${R(LOC)}]]"`,
+    '---', '', 'A back room.', '',
+  ].join('\n'));
+
+  f(`Locations/${BARRIO_N}.md`, [
+    '---', 'type: location', 'location_type: district',
+    `parent_location: "[[${R(REGION)}]]"`,
+    '---', '', 'North of the river.', '',
+  ].join('\n'));
+
+  f(`Locations/${BARRIO_S}.md`, [
+    '---', 'type: location', 'location_type: district',
+    `parent_location: "[[${R(REGION)}]]"`,
+    '---', '', 'South of the river.', '',
+  ].join('\n'));
+
+  f(`Factions/${FAC}.md`, [
+    '---', 'type: faction', 'faction_type: society',
+    `leadership: "[[${R(NPC)}]]"`, `territory: "[[${R(LOC)}]]"`,
+    '---', '', `They meet at [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Items/${ITEM}.md`, [
+    '---', 'type: item', 'item_type: relic',
+    `current_holder: "[[${R(NPC)}]]"`, `origin: "[[${R(LOC)}]]"`,
+    '---', '', `Taken from [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Events/${EVT}.md`, [
+    '---', 'type: event', 'event_type: disappearance', 'in_game_date: "1923-03-30"',
+    `location: "[[${R(LOC)}]]"`, 'participants:', `  - "[[${R(NPC)}]]"`,
+    '---', '', `Everyone at [[${R(LOC)}]] saw it.`, '',
+  ].join('\n'));
+
+  f(`Creatures/${CRE}.md`, [
+    '---', 'type: creature', 'creature_type: beast', `location: "[[${R(LOC)}]]"`,
+    'relationships:', `  - target: "[[${R(NPC)}]]"`, '    type: hunted_by',
+    '---', '', `It stalks [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Heritages/${HER}.md`, [
+    '---', 'type: heritage',
+    'relationships:', `  - target: "[[${R(NPC)}]]"`, '    type: ancestor_of',
+    '---', '', `Bloodline of [[${R(NPC)}]].`, '',
+  ].join('\n'));
+
+  f(`World/${DOMAIN}.md`, [
+    '---', 'type: world_domain', `summary: "Beyond [[${R(LOC)}]]"`,
+    'relationships:', `  - target: "[[${R(NPC)}]]"`, '    type: known_to',
+    '---', '', `Ice fields north of [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Clues/${CLUE}.md`, [
+    '---', 'type: clue', `location: "[[${R(LOC)}]]"`,
+    'relationships:', `  - target: "[[${R(NPC)}]]"`, '    type: points_to',
+    '---', '', `Found at [[${R(LOC)}]], in the hand of [[${R(NPC)}]].`, '',
+  ].join('\n'));
+
+  f(`Characters/PCs/${PC}_Story.md`, [
+    '---', 'type: character-story',
+    '---', '', `Rook's tale begins with [[${R(NPC)}]] at [[${R(LOC)}]].`, '',
+  ].join('\n'));
+
+  f(`Documents/${DOC}.md`, [
+    '---', 'type: document',
+    '---', '', `Addressed to [[${R(NPC)}]] care of [[${R(LOC)}]].`, '',
+  ].join('\n'));
+}
+
+function buildVariant(refForm) {
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), `unicode-refs-${refForm}-`));
+  const vault = path.join(work, 'vault');
+  const docs = path.join(work, 'docs');
+  writeVault(vault, refForm);
+  const configPath = path.join(work, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({
+    vaultPath: vault, outputDir: docs, attachmentsDir: '_attachments',
+    siteTitle: 'Diff Campaign', siteUrl: 'https://example.github.io/diff',
+    excludeDirs: ['_meta', '_Templates'],
+    folderMap: {
+      _Campaign: 'campaign', Chapters: 'chapters', Sessions: 'sessions', Wrapups: 'wrapups',
+      'Characters/PCs': 'characters/pcs', 'Characters/NPCs': 'characters/npcs',
+      Locations: 'locations', Factions: 'factions', Items: 'items',
+      Events: 'events', Creatures: 'creatures', Heritages: 'heritages', Documents: 'documents',
+      World: 'world', Clues: 'clues',
+    },
+  }));
+  const origLog = console.log, origWarn = console.warn;
+  console.log = () => {};
+  console.warn = () => {};
+  try { build({ configPath }); } finally { console.log = origLog; console.warn = origWarn; }
+  return { work, docs };
+}
+
+function readTree(dir) {
+  const out = new Map();
+  (function walk(d, base) {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, e.name);
+      const rel = path.posix.join(base, e.name);
+      if (e.isDirectory()) walk(full, rel);
+      // Content is compared NFC-normalized: a page that merely echoes the raw ref text is
+      // not a defect, so only structural and content divergence survives the comparison.
+      else if (/\.(html|json)$/.test(e.name)) {
+        out.set(rel.normalize('NFC'), fs.readFileSync(full, 'utf8').normalize('NFC'));
+      }
+    }
+  })(dir, '');
+  return out;
+}
+
+describe('build with NFD refs against NFC filenames (#139)', () => {
+  let nfd, nfc, mixed, treeNfd, treeNfc, treeMixed;
+  const read = rel => treeNfd.get(rel);
+
+  before(() => {
+    nfd = buildVariant('NFD');
+    nfc = buildVariant('NFC');
+    mixed = buildVariant('MIXED');
+    treeNfd = readTree(nfd.docs);
+    treeNfc = readTree(nfc.docs);
+    treeMixed = readTree(mixed.docs);
+  });
+
+  after(() => {
+    for (const v of [nfd, nfc, mixed]) fs.rmSync(v.work, { recursive: true, force: true });
+  });
+
+  function diffAgainstControl(tree) {
+    const keys = [...new Set([...tree.keys(), ...treeNfc.keys()])].sort();
+    return keys.filter(k => tree.get(k) !== treeNfc.get(k));
+  }
+
+  it('produces a byte-identical site whichever normal form every ref uses', () => {
+    const differing = diffAgainstControl(treeNfd);
+    assert.deepStrictEqual(differing, [], `these outputs depend on the refs' normal form: ${differing.join(', ')}`);
+  });
+
+  it('produces a byte-identical site when the two forms are mixed within one vault', () => {
+    const differing = diffAgainstControl(treeMixed);
+    assert.deepStrictEqual(differing, [], `these outputs split one entity in two when forms are mixed: ${differing.join(', ')}`);
+  });
+
+  it('renders the shared parent region once, not once per spelling', () => {
+    const html = read('locations/index.html');
+    const headings = (treeMixed.get('locations/index.html').match(/loc-region-title/g) || []).length;
+    const control = (html.match(/loc-region-title/g) || []).length;
+    assert.strictEqual(headings, control, 'mixed-form vault produced a different number of region headings');
+  });
+
+  // Per-page assertions on the NFD build. The whole-tree check above proves "no divergence";
+  // these name the feature that breaks, so a failure points at the site rather than the page.
+  it('lists sub-locations under their parent ("Places Within")', () => {
+    assert.match(read('locations/cafe-ubiquito.html'), /Places Within/);
+  });
+
+  it('lists NPCs at their location ("Known Figures")', () => {
+    assert.match(read('locations/cafe-ubiquito.html'), /Known Figures/);
+  });
+
+  it('lists events at their location ("What Happened Here")', () => {
+    assert.match(read('locations/cafe-ubiquito.html'), /What Happened Here/);
+  });
+
+  it('rolls up faction members from relationship targets', () => {
+    assert.match(read('factions/sociedad-iberica.html'), /<h3>Members<\/h3>/);
+  });
+
+  it('nests a child location under its parent in the locations index', () => {
+    assert.match(read('locations/index.html'), /loc-children/);
+  });
+
+  it('features the session the overview names, not the date-latest one', () => {
+    const html = read('index.html');
+    assert.match(html, /The wrap-up recounts/, 'landing recap did not come from the named session\'s wrap-up');
+    assert.doesNotMatch(html, /duller session/, 'landing fell back to a different session entirely');
+  });
+
+  it('groups sessions under their chapter on the chapters index', () => {
+    const html = read('chapters/index.html');
+    const grouped = /<ol class="chapter-sessions">[\s\S]*?sesion-anexa\.html[\s\S]*?<\/ol>/.test(html);
+    assert.ok(grouped, 'session was not listed inside its chapter card');
+    assert.doesNotMatch(html, /Other Sessions/, 'session fell through to the ungrouped list');
+  });
+});

--- a/tools/publish/test/search.test.js
+++ b/tools/publish/test/search.test.js
@@ -1,0 +1,27 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+// No `document` global in this Node environment, so js/search.js takes its
+// early-return branch and exports the pure helpers instead of bootstrapping
+// the DOM search overlay.
+const search = require('../js/search.js');
+
+test('encodeHref: percent-encodes a space in a path segment', () => {
+  assert.strictEqual(search.encodeHref('chronicle/Sessions/Session 02/x.html'), 'chronicle/Sessions/Session%2002/x.html');
+});
+
+test('encodeHref: percent-encodes # and ? (URL-active chars a raw space merely looked wrong for)', () => {
+  assert.strictEqual(search.encodeHref('notes/Q&A #3.html'), 'notes/Q%26A%20%233.html');
+  assert.strictEqual(search.encodeHref('notes/what now?.html'), 'notes/what%20now%3F.html');
+});
+
+test('encodeHref: percent-encodes parens', () => {
+  assert.strictEqual(search.encodeHref('items/Widget (Mk2).html'), 'items/Widget%20%28Mk2%29.html');
+});
+
+test('encodeHref: is a no-op on an already-safe path', () => {
+  assert.strictEqual(search.encodeHref('characters/pcs/john-doe.html'), 'characters/pcs/john-doe.html');
+});
+
+test('esc: still escapes HTML entities for the attribute (unchanged behavior)', () => {
+  assert.strictEqual(search.esc('<a>&"'), '&lt;a&gt;&amp;&quot;');
+});

--- a/tools/publish/test/search.test.js
+++ b/tools/publish/test/search.test.js
@@ -25,3 +25,44 @@ test('encodeHref: is a no-op on an already-safe path', () => {
 test('esc: still escapes HTML entities for the attribute (unchanged behavior)', () => {
   assert.strictEqual(search.esc('<a>&"'), '&lt;a&gt;&amp;&quot;');
 });
+
+// Both halves of the #139 search fix. The index half is exercised by the differential build,
+// but the client half ships as a static asset the build never inspects — deleting the
+// normalization leaves the whole server-side suite green while accented search silently stops
+// working in the browser. These two assertions are the only thing standing under it.
+//
+// Escapes, not literal accented characters, so no editor can re-normalize this file.
+const Q_NFC = 'Gonz\u00e1lez';
+const Q_NFD = 'Gonza\u0301lez';
+
+test('normalizeQuery: folds a decomposed query into the index normal form (#139)', () => {
+  assert.notStrictEqual(Q_NFC, Q_NFD); // sanity: the two really do differ byte-for-byte
+  assert.strictEqual(search.normalizeQuery(Q_NFD), Q_NFC);
+  assert.strictEqual(search.normalizeQuery(Q_NFC), Q_NFC);
+});
+
+test('normalizeQuery: leaves ASCII and empty input alone', () => {
+  assert.strictEqual(search.normalizeQuery('john doe'), 'john doe');
+  assert.strictEqual(search.normalizeQuery(''), '');
+  assert.strictEqual(search.normalizeQuery(null), '');
+  assert.strictEqual(search.normalizeQuery(undefined), '');
+});
+
+test('buildSearchIndex: an NFD-authored page is findable by the folded (NFC) query', () => {
+  // The other half of the pair: normalizeQuery only helps if the index it queries is in that
+  // same form. Asserted through a real lunr search rather than by inspecting the index blob,
+  // because matching is the behaviour that matters.
+  const lunr = require('lunr');
+  const { buildSearchIndex } = require('../lib/search-index');
+  const { index } = buildSearchIndex([{
+    outputPath: 'characters/npcs/gonzalez.html',
+    displayTitle: Q_NFD,
+    title: Q_NFD,
+    frontmatter: { type: 'npc' },
+    markdown: `Notes about ${Q_NFD}.`,
+  }]);
+  const idx = lunr.Index.load(index);
+  const hits = idx.search(search.normalizeQuery(Q_NFD));
+  assert.strictEqual(hits.length, 1, 'folded query found nothing in an NFD-authored index');
+  assert.strictEqual(hits[0].ref, 'characters/npcs/gonzalez.html');
+});

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -421,3 +421,56 @@ describe('overrides.fields unicode normalization (#139)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe('overrides surface (dead top-level keys)', () => {
+  // `overrides.fields` is the only override the build reads: build.js takes
+  // `publishConfig.overrides.fields[vaultRelPath]` and hands that per-file object to
+  // filterFields, which reads `.include` off it. A top-level `overrides.exclude` or
+  // `overrides.include` was declared in the defaults but never read anywhere, so a GM who
+  // wrote one got a silent no-op.
+  function writeConfig(tmpDir, yamlBody) {
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir, { recursive: true });
+    fs.writeFileSync(path.join(metaDir, 'vault-config.md'), `---\n${yamlBody}---\n`);
+  }
+
+  function captureWarns(fn) {
+    const warns = [];
+    const orig = console.warn;
+    console.warn = (...args) => warns.push(args.join(' '));
+    try { return { result: fn(), warns }; } finally { console.warn = orig; }
+  }
+
+  it('declares only the override the build actually reads', () => {
+    assert.deepStrictEqual(Object.keys(PUBLISH_DEFAULTS.overrides), ['fields']);
+  });
+
+  it('warns instead of silently ignoring an unread top-level override key', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    try {
+      writeConfig(tmpDir, 'publish:\n  overrides:\n    exclude:\n      - "Notes/Secret.md"\n');
+      const { warns } = captureWarns(() => loadPublishConfig(tmpDir));
+      const hits = warns.filter(w => w.includes('overrides.exclude'));
+      assert.strictEqual(hits.length, 1, `expected one warning, got: ${warns.join(' | ')}`);
+      assert.match(hits[0], /overrides\.fields/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stays quiet for the supported overrides.fields block', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    try {
+      writeConfig(tmpDir, 'publish:\n  overrides:\n    fields:\n      "Characters/NPCs/Vex.md":\n        include:\n          - secrets\n');
+      const { result, warns } = captureWarns(() => loadPublishConfig(tmpDir));
+      assert.deepStrictEqual(warns.filter(w => w.includes('overrides')), []);
+      assert.deepStrictEqual(result.overrides.fields['Characters/NPCs/Vex.md'].include, ['secrets']);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves overrides.fields as the only key when nothing is configured', () => {
+    assert.deepStrictEqual(loadPublishConfig('/nonexistent/path').overrides, { fields: {} });
+  });
+});

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -297,3 +297,52 @@ describe('sheet_crest', () => {
     assert.strictEqual(result.sheet_crest, null);
   });
 });
+
+describe('overrides.fields unicode normalization (#139)', () => {
+  const { canonicalPath } = require('../../lib/manifest');
+
+  // Built with explicit \u escapes (never a literal accented character) so the test
+  // file itself cannot be silently re-normalized by an editor or formatter. NFC types
+  // the accent as one precomposed codepoint; NFD types the same visible character as
+  // base letter + a separate combining acute accent codepoint. build.js looks up
+  // overrides via fieldOverrides[vaultRelPathOf(page)], and vaultRelPathOf() now
+  // canonicalizes the scanned page path to NFC (#139) — so an overrides.fields key
+  // must land in the same NFC form at config-load time, or it silently stops matching
+  // whenever the config author's normal form differs from the page's.
+  const NFC_PATH = 'Characters/PCs/Alena Gonz\u00e1lez.md';
+  const NFD_PATH = 'Characters/PCs/Alena Gonza\u0301lez.md';
+
+  function writeVaultConfig(tmpDir, fieldKey) {
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    const yaml = [
+      '---',
+      'publish:',
+      '  overrides:',
+      '    fields:',
+      `      "${fieldKey}":`,
+      '        some_field: "override value"',
+      '---',
+    ].join('\n');
+    fs.writeFileSync(path.join(metaDir, 'vault-config.md'), yaml);
+  }
+
+  it('canonicalizes an NFD-keyed overrides.fields entry to NFC, matching an NFC page path', () => {
+    assert.notStrictEqual(NFC_PATH, NFD_PATH); // sanity: the two source strings really do differ byte-for-byte
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    writeVaultConfig(tmpDir, NFD_PATH);
+    const result = loadPublishConfig(tmpDir);
+    assert.deepStrictEqual(Object.keys(result.overrides.fields), [NFC_PATH]);
+    assert.strictEqual(result.overrides.fields[canonicalPath(NFC_PATH)].some_field, 'override value');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('canonicalizes an NFC-keyed overrides.fields entry, matching an NFD page path (vice versa)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    writeVaultConfig(tmpDir, NFC_PATH);
+    const result = loadPublishConfig(tmpDir);
+    assert.deepStrictEqual(Object.keys(result.overrides.fields), [NFC_PATH]);
+    assert.strictEqual(result.overrides.fields[canonicalPath(NFD_PATH)].some_field, 'override value');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -24,6 +24,51 @@ describe('PUBLISH_DEFAULTS', () => {
   });
 });
 
+describe('exclude_sections default (issue #144)', () => {
+  // Reconcile / session-wrapup write '## Reconciliation Context' and
+  // '## Handoff to Reconcile' straight into vault files — GM plot state that
+  // must never reach a published player-mode site. The built-in default and
+  // the scaffold template (templates-scaffold/vault.config.json.tmpl) had
+  // drifted apart; this guards both independently, plus a sync check so they
+  // can't drift again.
+  const EXPECTED = [
+    'GM Notes',
+    'DM Notes',
+    'Player Notes',
+    'Source References',
+    'Reconciliation Context',
+    'Handoff to Reconcile',
+  ];
+
+  it('includes the six reconcile-bookkeeping sections by default', () => {
+    assert.deepStrictEqual(PUBLISH_DEFAULTS.exclude_sections, EXPECTED);
+  });
+
+  it('loadPublishConfig uses the six-item default when no vault config is present', () => {
+    const config = loadPublishConfig('/nonexistent/path');
+    assert.deepStrictEqual(config.exclude_sections, EXPECTED);
+  });
+
+  it('a vault-config.md exclude_sections list fully replaces the default (no default leakage)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(
+      path.join(metaDir, 'vault-config.md'),
+      '---\npublish:\n  exclude_sections:\n    - "Custom Section"\n---\n',
+    );
+    const result = loadPublishConfig(tmpDir);
+    assert.deepStrictEqual(result.exclude_sections, ['Custom Section']);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('scaffold template excludeSections stays in sync with PUBLISH_DEFAULTS.exclude_sections', () => {
+    const tmplPath = path.join(__dirname, '../../templates-scaffold/vault.config.json.tmpl');
+    const parsed = JSON.parse(fs.readFileSync(tmplPath, 'utf8'));
+    assert.deepStrictEqual(parsed.excludeSections, PUBLISH_DEFAULTS.exclude_sections);
+  });
+});
+
 describe('exclude_drafts', () => {
   it('defaults to false', () => {
     const config = loadPublishConfig('/nonexistent/path');

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -62,6 +62,36 @@ describe('exclude_sections default (issue #144)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it('unions vault-config.md with a stale vault.config.json excludeSections list, with no default injection', () => {
+    // Regression for the exact upgrade scenario #144 leaves unfixed: a site
+    // scaffolded before this change has a stale 4-item excludeSections in
+    // vault.config.json. Adding a vault-config.md list must union with that
+    // stale list (neither shadows the other, per the existing union
+    // semantics), and the six-item built-in default must not sneak in on
+    // top of either explicit source.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(
+      path.join(metaDir, 'vault-config.md'),
+      '---\npublish:\n  exclude_sections:\n    - "Custom Section"\n---\n',
+    );
+    const staleFallback = {
+      excludeSections: ['GM Notes', 'DM Notes', 'Player Notes', 'Source References'],
+    };
+    const result = loadPublishConfig(tmpDir, staleFallback);
+    assert.deepStrictEqual(result.exclude_sections, [
+      'Custom Section',
+      'GM Notes',
+      'DM Notes',
+      'Player Notes',
+      'Source References',
+    ]);
+    assert.ok(!result.exclude_sections.includes('Reconciliation Context'));
+    assert.ok(!result.exclude_sections.includes('Handoff to Reconcile'));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   it('scaffold template excludeSections stays in sync with PUBLISH_DEFAULTS.exclude_sections', () => {
     const tmplPath = path.join(__dirname, '../../templates-scaffold/vault.config.json.tmpl');
     const parsed = JSON.parse(fs.readFileSync(tmplPath, 'utf8'));

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -517,4 +517,55 @@ describe('malformed publish.overrides blocks', () => {
     assert.deepStrictEqual(result.overrides.fields, {});
     assert.ok(warns.some(w => w.includes('overrides.fields')), `no warning in: ${warns.join(' | ')}`);
   });
+
+  it('reaches the validator for an explicitly falsy fields value', () => {
+    // `||` swapped `false` for the default before it could be reported, so a
+    // GM who wrote `fields: false` got silence and no overrides.
+    const { result, warns } = loadWithWarns('publish:\n  overrides:\n    fields: false\n');
+    assert.deepStrictEqual(result.overrides.fields, {});
+    assert.ok(warns.some(w => w.includes('overrides.fields') && w.includes('boolean')),
+      `no boolean warning in: ${warns.join(' | ')}`);
+  });
+
+  it('drops a per-file override whose include is a string, not a list', () => {
+    // filterFields does `overrides.include.includes(field)`; on a string that is
+    // substring matching, so `include: sec` would re-admit `secrets`.
+    const { result, warns } = loadWithWarns(
+      'publish:\n  overrides:\n    fields:\n      "Characters/NPCs/Vex.md":\n        include: sec\n');
+    assert.deepStrictEqual(result.overrides.fields, {});
+    assert.ok(warns.some(w => w.includes('Characters/NPCs/Vex.md') && w.includes('include')),
+      `no include warning in: ${warns.join(' | ')}`);
+  });
+
+  it('drops a per-file override that is not a map at all', () => {
+    // A truthy non-array `include` (or a scalar override) makes filterFields throw.
+    const { result, warns } = loadWithWarns(
+      'publish:\n  overrides:\n    fields:\n      "Characters/NPCs/Vex.md": secrets\n');
+    assert.deepStrictEqual(result.overrides.fields, {});
+    assert.ok(warns.some(w => w.includes('Characters/NPCs/Vex.md')),
+      `no per-file warning in: ${warns.join(' | ')}`);
+  });
+
+  it('drops a per-file override whose include list holds a non-string', () => {
+    const { result, warns } = loadWithWarns(
+      'publish:\n  overrides:\n    fields:\n      "Characters/NPCs/Vex.md":\n        include:\n          - 7\n');
+    assert.deepStrictEqual(result.overrides.fields, {});
+    assert.ok(warns.some(w => w.includes('Characters/NPCs/Vex.md')),
+      `no per-file warning in: ${warns.join(' | ')}`);
+  });
+
+  it('keeps a well-formed per-file override untouched', () => {
+    const { result, warns } = loadWithWarns(
+      'publish:\n  overrides:\n    fields:\n      "Characters/NPCs/Vex.md":\n        include:\n          - secrets\n');
+    assert.deepStrictEqual(result.overrides.fields['Characters/NPCs/Vex.md'], { include: ['secrets'] });
+    assert.deepStrictEqual(warns.filter(w => w.includes('overrides')), []);
+  });
+
+  it('keeps a per-file override with no include key', () => {
+    // `{}` is a legal entry — it just re-admits nothing. Warning here would be noise.
+    const { result, warns } = loadWithWarns(
+      'publish:\n  overrides:\n    fields:\n      "Characters/NPCs/Vex.md": {}\n');
+    assert.deepStrictEqual(result.overrides.fields['Characters/NPCs/Vex.md'], {});
+    assert.deepStrictEqual(warns.filter(w => w.includes('overrides')), []);
+  });
 });

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -474,3 +474,47 @@ describe('overrides surface (dead top-level keys)', () => {
     assert.deepStrictEqual(loadPublishConfig('/nonexistent/path').overrides, { fields: {} });
   });
 });
+
+describe('malformed publish.overrides blocks', () => {
+  function writeConfig(tmpDir, yamlBody) {
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir, { recursive: true });
+    fs.writeFileSync(path.join(metaDir, 'vault-config.md'), `---\n${yamlBody}---\n`);
+  }
+
+  function loadWithWarns(yamlBody) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-test-'));
+    const warns = [];
+    const orig = console.warn;
+    console.warn = (...args) => warns.push(args.join(' '));
+    try {
+      writeConfig(tmpDir, yamlBody);
+      return { result: loadPublishConfig(tmpDir), warns };
+    } finally {
+      console.warn = orig;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  it('warns once, not per character index, when overrides is a bare string', () => {
+    // Object.keys('fields') is ['0'..'5'], which would invent six override keys.
+    const { result, warns } = loadWithWarns('publish:\n  overrides: fields\n');
+    const hits = warns.filter(w => w.includes('publish.overrides'));
+    assert.strictEqual(hits.length, 1, `expected one warning, got: ${warns.join(' | ')}`);
+    assert.match(hits[0], /must be a map/);
+    assert.deepStrictEqual(result.overrides, { fields: {} });
+  });
+
+  it('warns once when overrides is a list', () => {
+    const { warns } = loadWithWarns('publish:\n  overrides:\n    - fields\n');
+    const hits = warns.filter(w => w.includes('publish.overrides'));
+    assert.strictEqual(hits.length, 1, `expected one warning, got: ${warns.join(' | ')}`);
+    assert.match(hits[0], /a list/);
+  });
+
+  it('ignores a non-map overrides.fields instead of inventing per-character keys', () => {
+    const { result, warns } = loadWithWarns('publish:\n  overrides:\n    fields: secrets\n');
+    assert.deepStrictEqual(result.overrides.fields, {});
+    assert.ok(warns.some(w => w.includes('overrides.fields')), `no warning in: ${warns.join(' | ')}`);
+  });
+});

--- a/tools/publish/test/unit/e2e-resources.test.js
+++ b/tools/publish/test/unit/e2e-resources.test.js
@@ -1,0 +1,113 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { createE2eResources } = require('../../lib/e2e-resources');
+
+function fakeRunWrangler(script) {
+  // script: array of { code, stdout, stderr } consumed in call order
+  const calls = [];
+  let i = 0;
+  const runWrangler = (args) => {
+    calls.push(args);
+    const next = script[i] || { code: 0, stdout: '', stderr: '' };
+    i++;
+    return next;
+  };
+  return { runWrangler, calls };
+}
+
+test('create then cleanup deletes exactly the created ids, in reverse creation order', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' },      // createKvNamespace
+    { code: 0, stdout: 'id = "kvid2"', stderr: '' },      // createKvNamespace (2nd)
+    { code: 0, stdout: '', stderr: '' },                  // cleanup delete #2
+    { code: 0, stdout: '', stderr: '' },                  // cleanup delete #1
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+
+  const id1 = resources.createKvNamespace('inbox');
+  const id2 = resources.createKvNamespace('status-bar');
+  assert.strictEqual(id1, 'kvid1');
+  assert.strictEqual(id2, 'kvid2');
+
+  const result = resources.cleanup({ dryRun: false });
+
+  assert.strictEqual(result.length, 2);
+  assert.strictEqual(result[0].id, 'kvid2');
+  assert.strictEqual(result[1].id, 'kvid1');
+
+  // Only the two create calls plus two delete calls happened, in reverse order.
+  assert.strictEqual(calls.length, 4);
+  assert.deepStrictEqual(calls[2], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid2']);
+  assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+});
+
+test('dry-run cleanup deletes nothing and reports the pending deletion list', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' },
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  resources.createKvNamespace('inbox');
+
+  const report = resources.cleanup({ dryRun: true });
+
+  assert.strictEqual(report.length, 1);
+  assert.strictEqual(report[0].id, 'kvid1');
+  assert.strictEqual(report[0].name, 'e2e-run1-inbox');
+  // Only the create call happened — no delete call was made.
+  assert.strictEqual(calls.length, 1);
+});
+
+test('cleanup refuses to delete a hand-injected record whose name lacks the e2e- prefix', () => {
+  const { runWrangler, calls } = fakeRunWrangler([]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+
+  // Simulate polluted tracking: a record that did not come through createKvNamespace.
+  resources._records.push({ type: 'kv', name: 'INBOX', id: 'prod-namespace-id' });
+
+  assert.throws(() => resources.cleanup({ dryRun: false }), /e2e-/);
+  // The guard must fire before any wrangler call is made.
+  assert.strictEqual(calls.length, 0);
+});
+
+test('production-shaped names are impossible to construct via the factory', () => {
+  const { runWrangler } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' },
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+
+  resources.createKvNamespace('INBOX');
+
+  // Even asking for the label "INBOX" cannot produce the bare production name.
+  assert.strictEqual(resources._records[0].name, 'e2e-run1-INBOX');
+  assert.notStrictEqual(resources._records[0].name, 'INBOX');
+  assert.match(resources._records[0].name, /^e2e-/);
+});
+
+test('createKvNamespace throws when wrangler fails or prints no id', () => {
+  const { runWrangler } = fakeRunWrangler([
+    { code: 1, stdout: '', stderr: 'boom' },
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  assert.throws(() => resources.createKvNamespace('inbox'), /boom/);
+});
+
+test('createPagesProject names and tracks the project, falling back to the name as id', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: "Successfully created the 'e2e-run1-site' project.", stderr: '' },
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+
+  const id = resources.createPagesProject('site');
+
+  assert.strictEqual(id, 'e2e-run1-site');
+  assert.deepStrictEqual(calls[0], ['pages', 'project', 'create', 'e2e-run1-site', '--production-branch=main']);
+  assert.strictEqual(resources._records[0].name, 'e2e-run1-site');
+});
+
+test('createE2eResources exposes no list-based or title-based deletion API', () => {
+  const { runWrangler } = fakeRunWrangler([]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  const keys = Object.keys(resources);
+  assert.ok(!keys.some((k) => /list/i.test(k)));
+  assert.ok(!keys.some((k) => /delete.*title|title.*delete/i.test(k)));
+});

--- a/tools/publish/test/unit/e2e-resources.test.js
+++ b/tools/publish/test/unit/e2e-resources.test.js
@@ -37,8 +37,8 @@ test('create then cleanup deletes exactly the created ids, in reverse creation o
 
   // Only the two create calls plus two delete calls happened, in reverse order.
   assert.strictEqual(calls.length, 4);
-  assert.deepStrictEqual(calls[2], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid2']);
-  assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+  assert.deepStrictEqual(calls[2], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid2', '--skip-confirmation']);
+  assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1', '--skip-confirmation']);
 });
 
 test('cleanup deletes a Pages project by name, reverse-ordered alongside a KV namespace', () => {
@@ -55,8 +55,8 @@ test('cleanup deletes a Pages project by name, reverse-ordered alongside a KV na
 
   resources.cleanup({ dryRun: false });
 
-  assert.deepStrictEqual(calls[2], ['pages', 'project', 'delete', 'e2e-run1-site']);
-  assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+  assert.deepStrictEqual(calls[2], ['pages', 'project', 'delete', 'e2e-run1-site', '--yes']);
+  assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1', '--skip-confirmation']);
 });
 
 test('dry-run cleanup deletes nothing and reports the pending deletion list', () => {
@@ -94,7 +94,7 @@ test('mutating a dry-run report cannot redirect a later real cleanup (records ar
 
   resources.cleanup({ dryRun: false });
 
-  assert.deepStrictEqual(calls[1], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+  assert.deepStrictEqual(calls[1], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1', '--skip-confirmation']);
 });
 
 test('cleanup refuses to delete a hand-injected record whose name lacks the e2e- prefix', () => {
@@ -140,7 +140,7 @@ test('cleanup deletes a duplicated record only once, not twice', () => {
 
   const deleteCalls = calls.filter((a) => a[2] === 'delete');
   assert.strictEqual(deleteCalls.length, 1, 'exactly one delete call, despite the duplicate entry');
-  assert.deepStrictEqual(deleteCalls[0], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+  assert.deepStrictEqual(deleteCalls[0], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1', '--skip-confirmation']);
   assert.strictEqual(resources._records.length, 0, 'tracking left clean, no stray leftover entry');
 });
 
@@ -176,8 +176,8 @@ test('a cleanup() call re-entered from inside runWrangler does not double-delete
   resources.cleanup({ dryRun: false });
 
   const deleteArgv = calls.filter((a) => a[2] === 'delete').map((a) => a.join(' '));
-  const deleteA = `kv namespace delete --namespace-id ${idA}`;
-  const deleteB = `kv namespace delete --namespace-id ${idB}`;
+  const deleteA = `kv namespace delete --namespace-id ${idA} --skip-confirmation`;
+  const deleteB = `kv namespace delete --namespace-id ${idB} --skip-confirmation`;
 
   assert.strictEqual(deleteArgv.filter((s) => s === deleteA).length, 1, 'A deleted exactly once');
   assert.strictEqual(deleteArgv.filter((s) => s === deleteB).length, 1, 'B deleted exactly once');

--- a/tools/publish/test/unit/e2e-resources.test.js
+++ b/tools/publish/test/unit/e2e-resources.test.js
@@ -41,6 +41,24 @@ test('create then cleanup deletes exactly the created ids, in reverse creation o
   assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
 });
 
+test('cleanup deletes a Pages project by name, reverse-ordered alongside a KV namespace', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' },                                       // createKvNamespace
+    { code: 0, stdout: "Successfully created the 'e2e-run1-site' project.", stderr: '' },   // createPagesProject
+    { code: 0, stdout: '', stderr: '' },                                                    // delete pages (created last)
+    { code: 0, stdout: '', stderr: '' },                                                    // delete kv
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+
+  resources.createKvNamespace('inbox');
+  resources.createPagesProject('site');
+
+  resources.cleanup({ dryRun: false });
+
+  assert.deepStrictEqual(calls[2], ['pages', 'project', 'delete', 'e2e-run1-site']);
+  assert.deepStrictEqual(calls[3], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+});
+
 test('dry-run cleanup deletes nothing and reports the pending deletion list', () => {
   const { runWrangler, calls } = fakeRunWrangler([
     { code: 0, stdout: 'id = "kvid1"', stderr: '' },
@@ -57,6 +75,28 @@ test('dry-run cleanup deletes nothing and reports the pending deletion list', ()
   assert.strictEqual(calls.length, 1);
 });
 
+test('mutating a dry-run report cannot redirect a later real cleanup (records are frozen)', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' }, // create
+    { code: 0, stdout: '', stderr: '' },              // real delete
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  resources.createKvNamespace('inbox');
+
+  const dryReport = resources.cleanup({ dryRun: true });
+  assert.strictEqual(calls.length, 1);
+
+  // Attempt to redirect the eventual deletion by mutating the dry-run report.
+  dryReport[0].id = 'production-namespace-id';
+  dryReport[0].name = 'INBOX';
+  assert.strictEqual(dryReport[0].id, 'kvid1', 'record object is frozen — mutation is a no-op');
+  assert.strictEqual(dryReport[0].name, 'e2e-run1-inbox');
+
+  resources.cleanup({ dryRun: false });
+
+  assert.deepStrictEqual(calls[1], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+});
+
 test('cleanup refuses to delete a hand-injected record whose name lacks the e2e- prefix', () => {
   const { runWrangler, calls } = fakeRunWrangler([]);
   const resources = createE2eResources({ runWrangler, runId: 'run1' });
@@ -66,6 +106,20 @@ test('cleanup refuses to delete a hand-injected record whose name lacks the e2e-
 
   assert.throws(() => resources.cleanup({ dryRun: false }), /e2e-/);
   // The guard must fire before any wrangler call is made.
+  assert.strictEqual(calls.length, 0);
+});
+
+test('cleanup refuses to delete a hand-injected record even with a spoofed e2e- name (identity guard)', () => {
+  const { runWrangler, calls } = fakeRunWrangler([]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+
+  // #142's incident, expressed through this module: a name that passes the
+  // prefix check but points at a real (e.g. production) id, injected
+  // without going through createKvNamespace. The prefix alone must not be
+  // enough to authorize a delete.
+  resources._records.push({ type: 'kv', name: 'e2e-anything', id: 'production-inbox-id' });
+
+  assert.throws(() => resources.cleanup({ dryRun: false }), /not created by this/);
   assert.strictEqual(calls.length, 0);
 });
 
@@ -81,14 +135,31 @@ test('production-shaped names are impossible to construct via the factory', () =
   assert.strictEqual(resources._records[0].name, 'e2e-run1-INBOX');
   assert.notStrictEqual(resources._records[0].name, 'INBOX');
   assert.match(resources._records[0].name, /^e2e-/);
+  assert.ok(Object.isFrozen(resources._records[0]));
 });
 
-test('createKvNamespace throws when wrangler fails or prints no id', () => {
+test('createKvNamespace throws when wrangler exits non-zero', () => {
   const { runWrangler } = fakeRunWrangler([
     { code: 1, stdout: '', stderr: 'boom' },
   ]);
   const resources = createE2eResources({ runWrangler, runId: 'run1' });
   assert.throws(() => resources.createKvNamespace('inbox'), /boom/);
+});
+
+test('createKvNamespace throws when wrangler exits zero but prints no parseable id', () => {
+  const { runWrangler } = fakeRunWrangler([
+    { code: 0, stdout: 'created!', stderr: '' },
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  assert.throws(() => resources.createKvNamespace('inbox'), /Could not create KV namespace/);
+});
+
+test('createPagesProject throws when wrangler exits non-zero', () => {
+  const { runWrangler } = fakeRunWrangler([
+    { code: 1, stdout: '', stderr: 'nope' },
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  assert.throws(() => resources.createPagesProject('site'), /nope/);
 });
 
 test('createPagesProject names and tracks the project, falling back to the name as id', () => {
@@ -104,10 +175,20 @@ test('createPagesProject names and tracks the project, falling back to the name 
   assert.strictEqual(resources._records[0].name, 'e2e-run1-site');
 });
 
-test('createE2eResources exposes no list-based or title-based deletion API', () => {
+test('createE2eResources requires a runId', () => {
+  const { runWrangler } = fakeRunWrangler([]);
+  assert.throws(() => createE2eResources({ runWrangler }), /runId/);
+});
+
+test('createE2eResources requires a runWrangler function', () => {
+  assert.throws(() => createE2eResources({ runId: 'run1' }), /runWrangler/);
+});
+
+test('createE2eResources exposes exactly the intended surface — no list or delete-by-title API', () => {
   const { runWrangler } = fakeRunWrangler([]);
   const resources = createE2eResources({ runWrangler, runId: 'run1' });
-  const keys = Object.keys(resources);
-  assert.ok(!keys.some((k) => /list/i.test(k)));
-  assert.ok(!keys.some((k) => /delete.*title|title.*delete/i.test(k)));
+  assert.deepStrictEqual(
+    Object.keys(resources).sort(),
+    ['_records', 'cleanup', 'createKvNamespace', 'createPagesProject'].sort()
+  );
 });

--- a/tools/publish/test/unit/e2e-resources.test.js
+++ b/tools/publish/test/unit/e2e-resources.test.js
@@ -202,6 +202,63 @@ test('a failed delete restores tracking so a retry can find the record again', (
   assert.strictEqual(calls.length, 3);
 });
 
+test('a runWrangler that throws instead of returning still leaves the record tracked and retryable', () => {
+  const calls = [];
+  let shouldThrow = true;
+  const runWrangler = (args) => {
+    calls.push(args);
+    if (args[2] === 'create') return { code: 0, stdout: 'id = "kvid1"', stderr: '' };
+    if (args[2] === 'delete' && shouldThrow) throw new Error('spawn ENOENT');
+    return { code: 0, stdout: '', stderr: '' };
+  };
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  resources.createKvNamespace('inbox');
+
+  assert.throws(() => resources.cleanup({ dryRun: false }), /spawn ENOENT/);
+  assert.strictEqual(resources._records.length, 1, 'record restored for a retry, not leaked');
+  assert.strictEqual(resources._records[0].id, 'kvid1');
+
+  // A retry finds it and can succeed once the runner stops throwing —
+  // it must not have been silently forgotten as "already handled."
+  shouldThrow = false;
+  resources.cleanup({ dryRun: false });
+  assert.strictEqual(resources._records.length, 0);
+  assert.strictEqual(calls.filter((a) => a[2] === 'delete').length, 2, 'first attempt (threw) + retry (succeeded)');
+});
+
+test('a resource created during cleanup, followed by a failed delete, retries in true reverse creation order', () => {
+  let createdD = false;
+  let resources;
+  const runWrangler = (args) => {
+    if (args[2] === 'create') {
+      const label = args[3].split('-').pop();
+      return { code: 0, stdout: `id = "id-${label}"`, stderr: '' };
+    }
+    if (args[2] === 'delete') {
+      const id = args[4];
+      if (id === 'id-b' && !createdD) {
+        createdD = true;
+        resources.createKvNamespace('d'); // a resource created mid-cleanup, as a side effect
+        return { code: 0, stdout: '', stderr: '' }; // b's own delete still succeeds
+      }
+      if (id === 'id-a') return { code: 1, stdout: '', stderr: 'a delete fails' };
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  };
+
+  resources = createE2eResources({ runWrangler, runId: 'run1' });
+  resources.createKvNamespace('a');
+  resources.createKvNamespace('b');
+
+  assert.throws(() => resources.cleanup({ dryRun: false }), /a delete fails/);
+
+  // b succeeded (gone); a failed (restored); d was created mid-run. True
+  // reverse-creation order among the survivors (a created 1st, d created
+  // 3rd) deletes the newer one, d, before the older one, a.
+  const retryOrder = resources.cleanup({ dryRun: true }).map((r) => r.id);
+  assert.deepStrictEqual(retryOrder, ['id-d', 'id-a']);
+});
+
 test('production-shaped names are impossible to construct via the factory', () => {
   const { runWrangler } = fakeRunWrangler([
     { code: 0, stdout: 'id = "kvid1"', stderr: '' },

--- a/tools/publish/test/unit/e2e-resources.test.js
+++ b/tools/publish/test/unit/e2e-resources.test.js
@@ -123,6 +123,85 @@ test('cleanup refuses to delete a hand-injected record even with a spoofed e2e- 
   assert.strictEqual(calls.length, 0);
 });
 
+test('cleanup deletes a duplicated record only once, not twice', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' }, // create
+    { code: 0, stdout: '', stderr: '' },              // the single real delete
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  resources.createKvNamespace('inbox');
+
+  // Polluted tracking: the same minted record object pushed onto _records
+  // a second time (e.g. accidental double-tracking, not a foreign object).
+  resources._records.push(resources._records[0]);
+  assert.strictEqual(resources._records.length, 2);
+
+  resources.cleanup({ dryRun: false });
+
+  const deleteCalls = calls.filter((a) => a[2] === 'delete');
+  assert.strictEqual(deleteCalls.length, 1, 'exactly one delete call, despite the duplicate entry');
+  assert.deepStrictEqual(deleteCalls[0], ['kv', 'namespace', 'delete', '--namespace-id', 'kvid1']);
+  assert.strictEqual(resources._records.length, 0, 'tracking left clean, no stray leftover entry');
+});
+
+test('a cleanup() call re-entered from inside runWrangler does not double-delete or corrupt tracking', () => {
+  // Simulates a buggy/adversarial session or test mock that calls
+  // cleanup() again while a delete call from an earlier cleanup() is still
+  // in flight — not something real wrangler would ever do, but exactly the
+  // "caller mutated our tracking mid-run" class this module defends
+  // against. Provenance removal happens *before* the delete call is made,
+  // so the nested cleanup() can never see a record the outer call already
+  // committed to deleting.
+  const calls = [];
+  let reentered = false;
+  let resources;
+
+  const runWrangler = (args) => {
+    calls.push(args);
+    if (args[2] === 'create') {
+      const label = args[3].split('-').pop();
+      return { code: 0, stdout: `id = "id-${label}"`, stderr: '' };
+    }
+    if (args[2] === 'delete' && !reentered) {
+      reentered = true;
+      resources.cleanup({ dryRun: false }); // re-entrant, mid-delete
+    }
+    return { code: 0, stdout: '', stderr: '' };
+  };
+
+  resources = createE2eResources({ runWrangler, runId: 'run1' });
+  const idA = resources.createKvNamespace('a');
+  const idB = resources.createKvNamespace('b');
+
+  resources.cleanup({ dryRun: false });
+
+  const deleteArgv = calls.filter((a) => a[2] === 'delete').map((a) => a.join(' '));
+  const deleteA = `kv namespace delete --namespace-id ${idA}`;
+  const deleteB = `kv namespace delete --namespace-id ${idB}`;
+
+  assert.strictEqual(deleteArgv.filter((s) => s === deleteA).length, 1, 'A deleted exactly once');
+  assert.strictEqual(deleteArgv.filter((s) => s === deleteB).length, 1, 'B deleted exactly once');
+  assert.strictEqual(resources._records.length, 0, 'tracking left clean, no stray entries');
+});
+
+test('a failed delete restores tracking so a retry can find the record again', () => {
+  const { runWrangler, calls } = fakeRunWrangler([
+    { code: 0, stdout: 'id = "kvid1"', stderr: '' },        // create
+    { code: 1, stdout: '', stderr: 'first attempt fails' }, // delete attempt 1: fails
+    { code: 0, stdout: '', stderr: '' },                     // delete attempt 2 (retry): succeeds
+  ]);
+  const resources = createE2eResources({ runWrangler, runId: 'run1' });
+  resources.createKvNamespace('inbox');
+
+  assert.throws(() => resources.cleanup({ dryRun: false }), /first attempt fails/);
+  assert.strictEqual(resources._records.length, 1, 'record restored for a retry, not lost');
+
+  resources.cleanup({ dryRun: false }); // retry succeeds
+
+  assert.strictEqual(resources._records.length, 0);
+  assert.strictEqual(calls.length, 3);
+});
+
 test('production-shaped names are impossible to construct via the factory', () => {
   const { runWrangler } = fakeRunWrangler([
     { code: 0, stdout: 'id = "kvid1"', stderr: '' },

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -105,6 +105,55 @@ describe('getLatestWrapUp', () => {
     assert.strictEqual(result.title, 'Session_05_Wrap_Up');
   });
 
+  it('does not let Session 1 match the Session 10 wrap-up', () => {
+    // Regression: `ref.includes(sessionTitle)` matched "[[Session 10]]" for
+    // "Session 1", so the landing page ran the wrong session's recap.
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session: '[[Session 10]]' }, title: 'Session_10_Wrap_Up' },
+      { frontmatter: { type: 'session_wrap', session: '[[Session 1]]' }, title: 'Session_01_Wrap_Up' },
+    ];
+    const s1 = { title: 'Session 1', frontmatter: { type: 'session' } };
+    assert.strictEqual(getLatestWrapUp(pages, s1).title, 'Session_01_Wrap_Up');
+  });
+
+  it('returns null rather than a longer-numbered wrap-up', () => {
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session: '[[Session 10]]' }, title: 'Session_10_Wrap_Up' },
+    ];
+    const s1 = { title: 'Session 1', frontmatter: { type: 'session' } };
+    assert.strictEqual(getLatestWrapUp(pages, s1), null);
+  });
+
+  it('parses the wiki-link target, alias and all', () => {
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session: '[[Session 05|the Vienna night]]' }, title: 'WU' },
+    ];
+    const s5 = { title: 'Session 05', frontmatter: { type: 'session' } };
+    assert.strictEqual(getLatestWrapUp(pages, s5).title, 'WU');
+  });
+
+  it('prefers an exact session ref over a colliding session_number', () => {
+    // Chapters restart numbering, so `session_number: 4` alone is ambiguous.
+    // An explicit ref names one session and must win.
+    const pages = [
+      { frontmatter: { type: 'session_wrap', session_number: 4 }, title: 'Vienna_S4_Wrap_Up' },
+      { frontmatter: { type: 'session_wrap', session: '[[Session 04 - Calcutta]]', session_number: 4 }, title: 'Calcutta_S4_Wrap_Up' },
+    ];
+    const session = { title: 'Session 04 - Calcutta', frontmatter: { type: 'session', session_number: 4 } };
+    assert.strictEqual(getLatestWrapUp(pages, session).title, 'Calcutta_S4_Wrap_Up');
+  });
+
+  it('still matches an NFD-typed session ref against an NFC title', () => {
+    // #139: the ref is author-typed, the title comes from a filename. Exact
+    // equality must stay normalization-insensitive.
+    const nfc = '[[Session 05 - Caf\u00e9 Central]]';
+    const nfd = nfc.normalize('NFD');
+    assert.notStrictEqual(nfd, nfc, 'fixture must actually differ by normal form');
+    const pages = [{ frontmatter: { type: 'session_wrap', session: nfd }, title: 'WU' }];
+    const session = { title: 'Session 05 - Caf\u00e9 Central', frontmatter: { type: 'session' } };
+    assert.strictEqual(getLatestWrapUp(pages, session).title, 'WU');
+  });
+
   it('recognizes all wrap-up type variants', () => {
     const variants = ['session-wrap-up', 'session_wrap', 'session-wrapup'];
     for (const type of variants) {

--- a/tools/publish/test/unit/manifest.test.js
+++ b/tools/publish/test/unit/manifest.test.js
@@ -225,3 +225,38 @@ describe('parseManifest does not truncate dashed filenames (review regression)',
     assert.strictEqual(stripInlineComment('NoExtension'), 'NoExtension');
   });
 });
+
+describe('unicode normalization (#139)', () => {
+  const { canonicalPath, stripInlineComment } = require('../../lib/manifest');
+
+  // Built with explicit \u escapes (never a literal accented character) so the test
+  // file itself cannot be silently re-normalized by an editor or formatter. NFC types
+  // the accent as one precomposed codepoint; NFD types the same visible character as
+  // base letter + a separate combining acute accent codepoint.
+  const NFC = 'Alena Gonz\u00e1lez.md';
+  const NFD = 'Alena Gonza\u0301lez.md';
+
+  it('canonicalPath maps both normal forms of the same name to the same string', () => {
+    assert.notStrictEqual(NFC, NFD); // sanity: the two source strings really do differ byte-for-byte
+    assert.strictEqual(canonicalPath(NFC), canonicalPath(NFD));
+  });
+
+  it('canonicalPath returns NFC', () => {
+    assert.strictEqual(canonicalPath(NFD), NFC);
+    assert.strictEqual(canonicalPath(NFD).normalize('NFC'), canonicalPath(NFD));
+  });
+
+  it('a manifest entry typed in NFD is parsed out already normalized to NFC', () => {
+    const md = [
+      '## Publishing (1 files)',
+      '',
+      `- [x] ${NFD}`,
+    ].join('\n');
+    const result = parseManifest(md);
+    assert.strictEqual(result.publishing[0], NFC);
+  });
+
+  it('stripInlineComment normalizes an NFD path with a trailing comment', () => {
+    assert.strictEqual(stripInlineComment(`${NFD} — some note`), NFC);
+  });
+});

--- a/tools/publish/test/unit/processor-links.test.js
+++ b/tools/publish/test/unit/processor-links.test.js
@@ -1,0 +1,71 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { resolveWikiLinks, renderRelationships, renderMetaValue, encodeHref, encodeImageUrl } = require('../../lib/processor');
+const { createRenderer } = require('../../lib/markdown');
+
+// Mirrors the options createRenderer() actually uses in lib/markdown.js — a mismatch here
+// would let this test pass against different (safer) markdown-it behavior than production.
+const md = createRenderer();
+
+describe('resolveWikiLinks percent-encodes link destinations (#145)', () => {
+  it('encodes a space in the resolved path and renders as a real <a>, not literal text', () => {
+    const linkMap = { 'Session 02': 'chronicle/Sessions/Session 02/x.html' };
+    // One directory deep so the relative path starts with "../" — the exact shape that
+    // markdown-it's typographer mangles into "…/" when the destination is left unescaped.
+    const result = resolveWikiLinks('See [[Session 02]]', linkMap, 'chronicle/other/y.html');
+    assert.strictEqual(result, 'See [Session 02](../Sessions/Session%2002/x.html)');
+
+    const html = md.render(result);
+    assert.match(html, /<a href="\.\.\/Sessions\/Session%2002\/x\.html">Session 02<\/a>/);
+    assert.ok(!html.includes('…'), 'typographer must not mangle the encoded destination into an ellipsis');
+    assert.ok(!html.includes('[Session 02]'), 'destination must parse as a real link, not literal bracket text');
+  });
+
+  it('leaves a no-space target unchanged', () => {
+    const linkMap = { 'John Doe': 'characters/pcs/john-doe.html' };
+    const result = resolveWikiLinks('See [[John Doe]]', linkMap, 'index.html');
+    assert.strictEqual(result, 'See [John Doe](characters/pcs/john-doe.html)');
+  });
+
+  it('encodes parens in a path segment', () => {
+    const linkMap = { Widget: 'items/Widget (Mk2).html' };
+    const result = resolveWikiLinks('See [[Widget]]', linkMap, 'index.html');
+    assert.strictEqual(result, 'See [Widget](items/Widget%20%28Mk2%29.html)');
+  });
+});
+
+describe('renderRelationships percent-encodes the target href (#145)', () => {
+  it('encodes a space in the target output path', () => {
+    const frontmatter = { relationships: [{ target: 'Session 02', type: 'ally' }] };
+    const linkMap = { Session_02: 'chronicle/Sessions/Session 02/x.html' };
+    frontmatter.relationships[0].target = 'Session_02';
+    const html = renderRelationships(frontmatter, linkMap, 'chronicle/other/y.html');
+    assert.match(html, /href="\.\.\/Sessions\/Session%2002\/x\.html"/);
+  });
+});
+
+describe('renderMetaValue percent-encodes wikilink hrefs (#145)', () => {
+  it('encodes a space in the resolved output path', () => {
+    const linkMap = { 'Session 02': 'chronicle/Sessions/Session 02/x.html' };
+    const html = renderMetaValue('[[Session 02]]', linkMap, 'chronicle/other/y.html');
+    assert.match(html, /href="\.\.\/Sessions\/Session%2002\/x\.html"/);
+  });
+});
+
+describe('encodeHref', () => {
+  it('percent-encodes a space in a path segment', () => {
+    assert.strictEqual(encodeHref('a b/c.html'), 'a%20b/c.html');
+  });
+
+  it('percent-encodes parens', () => {
+    assert.strictEqual(encodeHref('a (b).html'), 'a%20%28b%29.html');
+  });
+
+  it('is a no-op on an already-safe path', () => {
+    assert.strictEqual(encodeHref('characters/pcs/john-doe.html'), 'characters/pcs/john-doe.html');
+  });
+
+  it('is the same function as encodeImageUrl (generalized, not duplicated)', () => {
+    assert.strictEqual(encodeHref, encodeImageUrl);
+  });
+});

--- a/tools/publish/test/unit/published-markdown.test.js
+++ b/tools/publish/test/unit/published-markdown.test.js
@@ -1,0 +1,65 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { build } = require('../../lib/build');
+
+const walk = d => fs.readdirSync(d, { withFileTypes: true })
+  .flatMap(e => e.isDirectory() ? walk(path.join(d, e.name)) : [path.join(d, e.name)]);
+
+// Regression coverage for issue #149: the publishedMarkdown chain in build.js
+// (stripGmOnly -> stripSpoiler -> stripCallouts -> filterSections) never called
+// stripHtmlComments, so a bare HTML comment written before real prose in a session's
+// Narrative Recap section survived into two surfaces that read page.publishedMarkdown
+// directly: the homepage "Latest Session" teaser (landing-data.js extractRecap) and
+// every story-spine page body (story-spine.js publishedOf). processContent (the
+// entity/wrap-up page path) already stripped comments, which is why only these two
+// surfaces leaked (#85 -> #87 -> #149).
+describe('publishedMarkdown strips HTML comments (issue #149)', () => {
+  let out, docs;
+  const fixtures = path.join(__dirname, '..', 'fixtures', 'html-comment-leak');
+
+  before(() => {
+    out = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-html-comment-'));
+    const configPath = path.join(out, 'config.json');
+    docs = path.join(out, 'docs');
+    fs.writeFileSync(configPath, JSON.stringify({
+      vaultPath: fixtures,
+      outputDir: docs,
+      attachmentsDir: '_attachments',
+      siteTitle: 'Comment Leak Test',
+      siteUrl: 'https://example.github.io/comment-leak',
+      excludeDirs: ['_meta'],
+      excludeSections: [],
+      folderMap: { Chapters: 'chapters' },
+    }));
+    build({ configPath });
+  });
+
+  after(() => fs.rmSync(out, { recursive: true, force: true }));
+
+  it('strips the comment from the homepage "Latest Session" teaser', () => {
+    const html = fs.readFileSync(path.join(docs, 'index.html'), 'utf8');
+    assert.ok(html.includes('hidden passage'), 'expected recap prose to render on the homepage');
+    assert.ok(!html.includes('<!--') && !html.includes('&lt;!--'), 'index.html leaked an HTML comment');
+    assert.ok(!html.includes('authoring note'), 'index.html leaked the comment text');
+  });
+
+  it('strips the comment from the story-spine chronicle page', () => {
+    const storyHtml = fs.readFileSync(path.join(docs, 'story', 'chapter-1-test-session-1.html'), 'utf8');
+    assert.ok(storyHtml.includes('hidden passage'), 'expected recap prose to render on the story page');
+    assert.ok(!storyHtml.includes('<!--') && !storyHtml.includes('&lt;!--'), 'story page leaked an HTML comment');
+    assert.ok(!storyHtml.includes('authoring note'), 'story page leaked the comment text');
+  });
+
+  it('regression: no generated HTML file contains a raw or escaped HTML comment (#85 -> #87 -> #149)', () => {
+    const files = walk(docs).filter(f => f.endsWith('.html'));
+    assert.ok(files.length > 0, 'expected the build to produce html files');
+    for (const f of files) {
+      const html = fs.readFileSync(f, 'utf8');
+      assert.ok(!html.includes('<!--'), `${f} contains a raw HTML comment`);
+      assert.ok(!html.includes('&lt;!--'), `${f} contains an escaped HTML comment`);
+    }
+  });
+});

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -31,6 +31,28 @@ describe('slugify', () => {
   });
 });
 
+describe('slugify unicode normalization (#139)', () => {
+  // Built with explicit \u escapes (never a literal accented character) so the test
+  // file itself cannot be silently re-normalized by an editor or formatter. NFC types
+  // the accent as one precomposed codepoint; NFD types the same visible character as
+  // base letter + a separate combining acute accent codepoint.
+  const NFC = 'Gonz\u00e1lez';
+  const NFD = 'Gonza\u0301lez';
+
+  it('strips combining marks rather than hyphenating them, for NFC input', () => {
+    assert.strictEqual(slugify(NFC), 'gonzalez');
+  });
+
+  it('strips combining marks rather than hyphenating them, for NFD input', () => {
+    assert.strictEqual(slugify(NFD), 'gonzalez');
+  });
+
+  it('produces the same slug for two names differing only in normal form', () => {
+    assert.notStrictEqual(NFC, NFD); // sanity: the two source strings really do differ byte-for-byte
+    assert.strictEqual(slugify(NFC), slugify(NFD));
+  });
+});
+
 describe('mapFolder', () => {
   const folderMap = {
     'Characters/PCs': 'characters/pcs',

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -339,7 +339,7 @@ describe('scanVault page slug collision warning (#139)', () => {
   });
 
   it('still returns both colliding pages so the caller decides what to do', () => {
-    const tmpDir = makeVault(['Renée', 'Renee']);
+    const tmpDir = makeVault([ACCENTED, 'Renee']);
     try {
       const { result: pages } = captureWarns(() => scanVault(config(tmpDir)));
       assert.strictEqual(pages.length, 2);

--- a/tools/publish/test/unit/scanner.test.js
+++ b/tools/publish/test/unit/scanner.test.js
@@ -2,6 +2,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const { slugify, mapFolder, buildLinkMap, scanVault, pairStoryFiles } = require('../../lib/scanner');
 const { getCanonStatus } = require('../../lib/templates/base');
 
@@ -278,5 +279,72 @@ describe('scanVault unmapped-directory warning', () => {
     };
     const warns = captureWarns(() => scanVault(config));
     assert.strictEqual(warns.filter(w => w.includes('folderMap')).length, 0);
+  });
+});
+
+describe('scanVault page slug collision warning (#139)', () => {
+  // Stripping combining marks makes "Renée" and "Renee" in one folder slug to the
+  // same renee.html, where the old naive slugify kept them apart ("ren-e"/"renee").
+  // The second page silently overwrites the first on disk, so the scan has to say so.
+  function captureWarns(fn) {
+    const warns = [];
+    const orig = console.warn;
+    console.warn = (...args) => warns.push(args.join(' '));
+    try { return { result: fn(), warns }; } finally { console.warn = orig; }
+  }
+
+  function makeVault(fileNames) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scanner-collision-'));
+    const npcDir = path.join(tmpDir, 'Characters', 'NPCs');
+    fs.mkdirSync(npcDir, { recursive: true });
+    for (const name of fileNames) {
+      fs.writeFileSync(path.join(npcDir, name + '.md'), '---\ntype: npc\n---\n\nBody.\n');
+    }
+    return tmpDir;
+  }
+
+  const config = (vaultPath) => ({
+    vaultPath,
+    excludeDirs: ['_meta', '_Templates'],
+    folderMap: { 'Characters/NPCs': 'characters/npcs' },
+  });
+
+  // é written as an escape so no editor can silently re-normalize this source file.
+  const ACCENTED = 'Ren\u00e9e';
+
+  it('warns when two pages in the same folder produce the same output path', () => {
+    const tmpDir = makeVault([ACCENTED, 'Renee']);
+    try {
+      const { warns } = captureWarns(() => scanVault(config(tmpDir)));
+      const collisionWarns = warns.filter(w => w.includes('page slug collision'));
+      assert.strictEqual(collisionWarns.length, 1, `expected one collision warning, got: ${warns.join(' | ')}`);
+      // Normalized before matching: the filesystem may hand readdir back either normal form.
+      const warning = collisionWarns[0].normalize('NFC');
+      assert.ok(warning.includes('characters/npcs/renee.html'), warning);
+      assert.ok(warning.includes(ACCENTED + '.md'), warning);
+      assert.ok(warning.includes('Renee.md'), warning);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not warn when slugs are distinct', () => {
+    const tmpDir = makeVault([ACCENTED, 'Bjorn']);
+    try {
+      const { warns } = captureWarns(() => scanVault(config(tmpDir)));
+      assert.strictEqual(warns.filter(w => w.includes('page slug collision')).length, 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still returns both colliding pages so the caller decides what to do', () => {
+    const tmpDir = makeVault(['Renée', 'Renee']);
+    try {
+      const { result: pages } = captureWarns(() => scanVault(config(tmpDir)));
+      assert.strictEqual(pages.length, 2);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tools/publish/test/unit/unicode-lookup.test.js
+++ b/tools/publish/test/unit/unicode-lookup.test.js
@@ -1,0 +1,224 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { buildLinkMap, scanAttachments } = require('../../lib/scanner');
+const { resolveWikiLinks, renderRelationships, renderMetaValue, resolveImageEmbeds } = require('../../lib/processor');
+const { portraitImg } = require('../../lib/templates/base');
+
+// The two lookup tables the whole renderer indexes into — linkMap (keyed by page title
+// and alias) and imageMap (keyed by attachment basename) — are queried with author-typed
+// text: the words inside a `[[wikilink]]`, a `portrait:` value, a relationship target.
+// The key and the query therefore come from two different keyboards, editors, and OSes,
+// which round-trip Unicode differently: "Gonzalez" typed with a precomposed accent (NFC) and
+// the same visible name typed as e + combining acute (NFD) are different strings
+// byte-for-byte. Exact-string lookup silently misses, and the link renders as plain text
+// or the portrait silently vanishes — the same #139 defect as the manifest boundary.
+//
+// Every constant below is written with explicit \u escapes, never a literal accented
+// character, so no editor or formatter can silently re-normalize this file and quietly
+// turn these tests into tautologies.
+const NFC = 'Alena Gonz\u00e1lez';
+const NFD = 'Alena Gonza\u0301lez';
+const NFC_PNG = 'Alena Gonz\u00e1lez.png';
+const NFD_PNG = 'Alena Gonza\u0301lez.png';
+
+// Sanity: the pairs really do differ byte-for-byte, or every assertion below is vacuous.
+assert.notStrictEqual(NFC, NFD);
+assert.notStrictEqual(NFC_PNG, NFD_PNG);
+
+const OUT = 'characters/npcs/alena-gonzalez.html';
+
+function pageNamed(title, frontmatter = {}, outputPath = OUT) {
+  return { title, outputPath, frontmatter };
+}
+
+describe('linkMap lookups across unicode normal forms (#139)', () => {
+  it('resolves an NFC-typed lookup against an NFD-named page', () => {
+    const map = buildLinkMap([pageNamed(NFD)]);
+    assert.strictEqual(map[NFC], OUT);
+  });
+
+  it('resolves an NFD-typed lookup against an NFC-named page', () => {
+    const map = buildLinkMap([pageNamed(NFC)]);
+    assert.strictEqual(map[NFD], OUT);
+  });
+
+  it('reports membership for either normal form', () => {
+    const map = buildLinkMap([pageNamed(NFC)]);
+    assert.ok(NFD in map);
+    assert.ok(NFC in map);
+    assert.ok(!('Someone Else' in map));
+  });
+
+  it('resolves an alias typed in the other normal form', () => {
+    const map = buildLinkMap([pageNamed('Alena', { aliases: [NFD] })]);
+    assert.strictEqual(map[NFC], OUT);
+  });
+
+  it('redirects a superseded page whose superseded_by target differs only in normal form', () => {
+    const map = buildLinkMap([
+      pageNamed(NFC, {}, 'characters/npcs/new.html'),
+      pageNamed('Old Name', { canon_status: 'SUPERSEDED', superseded_by: `[[${NFD}]]` }, 'characters/npcs/old.html'),
+    ]);
+    assert.strictEqual(map['Old Name'], 'characters/npcs/new.html');
+  });
+
+  it('renders a body wikilink typed in the other normal form as a real link', () => {
+    const map = buildLinkMap([pageNamed(NFD)]);
+    const out = resolveWikiLinks(`Met [[${NFC}]] at the docks.`, map, 'sessions/session-01.html');
+    assert.strictEqual(out, `Met [${NFC}](../${OUT}) at the docks.`);
+  });
+
+  it('links a relationship target typed in the other normal form', () => {
+    const map = buildLinkMap([pageNamed(NFD)]);
+    const html = renderRelationships({ relationships: [{ target: NFC, type: 'ally' }] }, map, 'characters/pcs/rook.html');
+    assert.ok(html.includes(`href="../npcs/alena-gonzalez.html"`), html);
+  });
+
+  it('links a frontmatter wikilink typed in the other normal form', () => {
+    const map = buildLinkMap([pageNamed(NFD)]);
+    const html = renderMetaValue(`Works for [[${NFC}]]`, map, 'characters/pcs/rook.html');
+    assert.ok(html.includes(`href="../npcs/alena-gonzalez.html"`), html);
+  });
+
+  it('stores the output path byte-for-byte, without canonicalizing it', () => {
+    // #139 normalization and #145 percent-encoding stay orthogonal: only the lookup KEY is
+    // canonicalized, never the emitted path. A page whose output path carries NFD bytes must
+    // keep them — the file on disk is named with those bytes, so an NFC-rewritten href 404s.
+    const nfdOut = `characters/npcs/${NFD}.html`;
+    const map = buildLinkMap([pageNamed(NFC, {}, nfdOut)]);
+    assert.strictEqual(map[NFC], nfdOut);
+    assert.strictEqual(map[NFD], nfdOut);
+    assert.deepStrictEqual(Object.values(map), [nfdOut]);
+
+    const out = resolveWikiLinks(`[[${NFC}]]`, map, 'sessions/session-01.html');
+    const href = out.slice(out.lastIndexOf('(') + 1, -1);
+    assert.strictEqual(decodeURIComponent(href), `../characters/npcs/${NFD}.html`);
+  });
+});
+
+describe('imageMap lookups across unicode normal forms (#139)', () => {
+  function attachmentVault(fileName) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unicode-attach-'));
+    fs.mkdirSync(path.join(tmpDir, '_attachments'));
+    fs.writeFileSync(path.join(tmpDir, '_attachments', fileName), 'not-really-a-png');
+    return tmpDir;
+  }
+
+  function withVault(fileName, fn) {
+    const tmpDir = attachmentVault(fileName);
+    try {
+      fn(scanAttachments({ vaultPath: tmpDir, attachmentsDir: '_attachments' }));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  // Both on-disk spellings are exercised: the filesystem itself may hand readdir back
+  // either normal form regardless of which one created the file, so pinning only one
+  // direction would pass or fail by accident of the host filesystem.
+  for (const [label, onDisk] of [['NFC', NFC_PNG], ['NFD', NFD_PNG]]) {
+    it(`resolves a ${label}-named attachment from either normal form`, () => {
+      withVault(onDisk, (map) => {
+        assert.ok(map[NFC_PNG], 'NFC lookup missed');
+        assert.ok(map[NFD_PNG], 'NFD lookup missed');
+        assert.strictEqual(map[NFC_PNG], map[NFD_PNG]);
+      });
+    });
+
+    it(`renders a portrait: value against a ${label}-named attachment in either normal form`, () => {
+      withVault(onDisk, (map) => {
+        for (const portrait of [NFC_PNG, NFD_PNG, `_attachments/${NFD_PNG}`]) {
+          const html = portraitImg({ portrait }, 'characters/npcs/alena.html', map);
+          assert.match(html, /^<img src="/, `portrait "${portrait}" did not resolve`);
+        }
+      });
+    });
+
+    it(`resolves an image embed against a ${label}-named attachment in either normal form`, () => {
+      withVault(onDisk, (map) => {
+        for (const typed of [NFC_PNG, NFD_PNG]) {
+          const out = resolveImageEmbeds(`![[${typed}]]`, map, 'characters/npcs/alena.html');
+          assert.match(out, /^!\[/, `embed "${typed}" did not resolve`);
+        }
+      });
+    });
+  }
+
+  it('records a used image under the imageMap key, so player-mode pruning keeps it', () => {
+    // build.js prunes with `usedImages.has(basename)` over Object.entries(imageMap). An
+    // embed typed in the other normal form must register the map's own key, or the image
+    // resolves in the HTML and is then left out of the copy pass — a broken <img> in
+    // player mode only.
+    withVault(NFC_PNG, (map) => {
+      const used = new Set();
+      resolveImageEmbeds(`![[${NFD_PNG}]]`, map, 'characters/npcs/alena.html', used);
+      const key = Object.keys(map)[0];
+      assert.ok(used.has(key), `usedImages ${[...used]} does not contain map key ${key}`);
+    });
+  });
+
+  it('dedupes an embed that repeats the portrait in the other normal form', () => {
+    withVault(NFC_PNG, (map) => {
+      const out = resolveImageEmbeds(`![[${NFD_PNG}]]`, map, 'characters/npcs/alena.html', null, {
+        portraitBasename: NFC_PNG,
+      });
+      assert.strictEqual(out, '');
+    });
+  });
+
+  it('emits the src from the scanned relPath, without canonicalizing it', () => {
+    // Same orthogonality guarantee as linkMap: the bytes in the URL are the bytes the
+    // scanner recorded (and copyImages writes), never a re-normalized spelling.
+    withVault(NFD_PNG, (map) => {
+      const entry = map[NFC_PNG];
+      const html = portraitImg({ portrait: NFC_PNG }, 'characters/npcs/alena.html', map);
+      const src = html.match(/src="([^"]+)"/)[1];
+      assert.strictEqual(decodeURIComponent(src), `../../images/${entry.relPath}`);
+    });
+  });
+});
+
+describe('derived title tables across unicode normal forms (#139)', () => {
+  // Same defect class as linkMap, found auditing every table keyed by author-typed text:
+  // buildBacklinks keys off the words inside a `[[wikilink]]` but is read back with the
+  // scanned page title, and the relationship graph resolves wikilink targets against page
+  // titles. A mismatch drops the "Mentioned in" sidebar entry, or draws the entity twice —
+  // once as a resolved node, once as a dangling one.
+  const { buildBacklinks } = require('../../lib/backlinks');
+  const { buildRelationshipGraph } = require('../../lib/relationship-graph');
+
+  it('backlinks a mention typed in the other normal form', () => {
+    const bl = buildBacklinks([
+      { title: 'Session_1', displayTitle: 'Session 1', outputPath: 'sessions/session-1.html', frontmatter: { type: 'session' }, markdown: `Met [[${NFD}]].` },
+      { title: NFC, displayTitle: NFC, outputPath: OUT, frontmatter: { type: 'npc' }, markdown: '' },
+    ]);
+    assert.ok(bl[NFC], 'lookup by the page title should find the mention');
+    assert.strictEqual(bl[NFC][0].outputPath, 'sessions/session-1.html');
+  });
+
+  it('resolves a graph relationship target typed in the other normal form', () => {
+    const pages = [
+      { title: 'Rook', displayTitle: 'Rook', outputPath: 'characters/pcs/rook.html', frontmatter: { type: 'pc', relationships: [{ target: `[[${NFD}]]`, type: 'ally' }] } },
+      { title: NFC, displayTitle: NFC, outputPath: OUT, frontmatter: { type: 'npc' } },
+    ];
+    const graph = buildRelationshipGraph('Rook', pages, {});
+    const node = graph.nodes.find(n => n.type === 'npc');
+    assert.ok(node, `no npc node in ${JSON.stringify(graph.nodes)}`);
+    assert.strictEqual(node.outputPath, OUT);
+  });
+
+  it('draws the mutual relationship as one resolved pair, not a dangling twin', () => {
+    const pages = [
+      { title: 'Rook', displayTitle: 'Rook', outputPath: 'characters/pcs/rook.html', frontmatter: { type: 'pc', relationships: [{ target: `[[${NFD}]]`, type: 'ally' }] } },
+      { title: NFC, displayTitle: NFC, outputPath: OUT, frontmatter: { type: 'npc', relationships: [{ target: '[[Rook]]', type: 'ally' }] } },
+    ];
+    const graph = buildRelationshipGraph('Rook', pages, {});
+    assert.strictEqual(graph.nodes.length, 2, JSON.stringify(graph.nodes.map(n => n.id)));
+    // Every node must resolve to a page: a node with a null outputPath is the dangling
+    // twin the mismatch produces — drawn in the graph but linking nowhere.
+    assert.ok(graph.nodes.every(n => n.outputPath), JSON.stringify(graph.nodes));
+  });
+});

--- a/tools/publish/test/unit/unicode-lookup.test.js
+++ b/tools/publish/test/unit/unicode-lookup.test.js
@@ -222,3 +222,123 @@ describe('derived title tables across unicode normal forms (#139)', () => {
     assert.ok(graph.nodes.every(n => n.outputPath), JSON.stringify(graph.nodes));
   });
 });
+
+// Map/Set boundaries. nfcLookupTable only guarantees plain-object tables; these four sites
+// compare author-typed text against filenames through `Map.get`, `Set.has`, or bare `===`,
+// so each one needs canonicalization at both the write and the read.
+describe('Map/Set title boundaries across unicode normal forms (#139)', () => {
+  const { scoreByRecency } = require('../../lib/recency');
+  const { buildStorySpine } = require('../../lib/story-spine');
+
+  const SESSION_NFC = 'Session Ren\u00e9e';
+  const SESSION_NFD = 'Session Rene\u0301e';
+  const CHAPTER_NFC = 'Chapter Ren\u00e9e';
+  const CHAPTER_NFD = 'Chapter Rene\u0301e';
+  assert.notStrictEqual(SESSION_NFC, SESSION_NFD);
+  assert.notStrictEqual(CHAPTER_NFC, CHAPTER_NFD);
+
+  const npcPage = () => ({ title: NFC, displayTitle: NFC, outputPath: OUT, frontmatter: { type: 'npc' } });
+
+  it('scores an entity mentioned in the latest session under the other normal form', () => {
+    const session = {
+      title: 'Session_1', displayTitle: 'Session 1', outputPath: 'sessions/session-1.html',
+      frontmatter: { type: 'session', status: 'played', play_date: '2026-01-02', session_number: 1 },
+      markdown: `The party met [[${NFD}]] at the docks.`,
+    };
+    const scored = scoreByRecency([npcPage()], [session], [], { type: 'npc' });
+    assert.strictEqual(scored.length, 1, 'accented NPC never scores, so it never reaches the landing page');
+  });
+
+  it('scores an entity named only in a frontmatter participant ref in the other normal form', () => {
+    const session = {
+      title: 'Session_1', displayTitle: 'Session 1', outputPath: 'sessions/session-1.html',
+      frontmatter: {
+        type: 'session', status: 'played', play_date: '2026-01-02', session_number: 1,
+        participants: [`[[${NFD}]]`],
+      },
+      markdown: 'No wiki-links in the body.',
+    };
+    assert.strictEqual(scoreByRecency([npcPage()], [session], [], { type: 'npc' }).length, 1);
+  });
+
+  it('counts wrap-up mentions when the wrap-up session ref differs in normal form', () => {
+    const session = {
+      title: SESSION_NFC, displayTitle: SESSION_NFC, outputPath: 'sessions/session-renee.html',
+      frontmatter: { type: 'session', status: 'played', play_date: '2026-01-02', session_number: 1 },
+      markdown: 'The session stub carries no mentions.',
+    };
+    const wrapUp = {
+      title: 'Session_Wrap', displayTitle: 'Session Wrap', outputPath: 'sessions/wrap.html',
+      frontmatter: { type: 'session_wrap', session: `[[${SESSION_NFD}]]` },
+      markdown: `The recap names [[${NFC}]] throughout.`,
+    };
+    const scored = scoreByRecency([npcPage()], [session], [], { type: 'npc', wrapUps: [wrapUp] });
+    assert.strictEqual(scored.length, 1, 'wrap-up never pairs with its session, so its mentions are lost');
+  });
+
+  it('pairs a session with a wrap-up whose session ref differs in normal form', () => {
+    // The wrap-up lives outside the session's folder, so the same-folder fallback cannot
+    // rescue the pairing and only the ref match is under test.
+    const pages = [
+      { title: 'Chapter_1', displayTitle: 'Chapter 1', sourcePath: '/v/Chapters/Chapter_1.md', frontmatter: { type: 'chapter', sort_order: 1 }, markdown: '' },
+      { title: SESSION_NFC, displayTitle: SESSION_NFC, sourcePath: '/v/Chapters/Chapter_1/S1.md', frontmatter: { type: 'session', session_number: 1 }, markdown: '' },
+      { title: 'S1_Wrap', displayTitle: 'S1 Wrap', sourcePath: '/v/Wrapups/S1_Wrap.md', frontmatter: { type: 'session_wrap', session: `[[${SESSION_NFD}]]` }, markdown: '## Narrative Recap\n\nThe vault burned.\n' },
+    ];
+    const units = buildStorySpine(pages);
+    assert.ok(
+      units.some(u => u.kind === 'session' && u.recapHtml.includes('vault burned')),
+      `session recap missing from story spine: ${JSON.stringify(units.map(u => u.kind))}`,
+    );
+  });
+
+  it('groups a flat-vault session under a chapter whose ref differs in normal form', () => {
+    // Separate folders, so chapterOwnsSession falls through to the title/ref match.
+    const pages = [
+      { title: CHAPTER_NFC, displayTitle: CHAPTER_NFC, sourcePath: '/v/Chapters/Chapter.md', frontmatter: { type: 'chapter', sort_order: 1 }, markdown: '' },
+      { title: 'S1', displayTitle: 'S1', sourcePath: '/v/Sessions/S1.md', frontmatter: { type: 'session', session_number: 1, chapter: `[[${CHAPTER_NFD}]]` }, markdown: '## Narrative Recap\n\nThe bridge fell.\n' },
+    ];
+    const units = buildStorySpine(pages);
+    assert.ok(
+      units.some(u => u.kind === 'session' && u.chapterTitle === CHAPTER_NFC),
+      `session not grouped under its chapter: ${JSON.stringify(units.map(u => [u.kind, u.chapterTitle]))}`,
+    );
+  });
+});
+
+describe('chapter page constituent sessions across unicode normal forms (#139)', () => {
+  const { build } = require('../../lib/build');
+  const CHAPTER_NFC = 'Chapter Ren\u00e9e';
+  const CHAPTER_NFD = 'Chapter Rene\u0301e';
+
+  it('lists a session whose chapter ref differs in normal form from the chapter filename', () => {
+    const work = fs.mkdtempSync(path.join(os.tmpdir(), 'unicode-chapter-'));
+    try {
+      const vault = path.join(work, 'vault');
+      fs.mkdirSync(path.join(vault, 'Chapters'), { recursive: true });
+      fs.mkdirSync(path.join(vault, 'Sessions'), { recursive: true });
+      fs.writeFileSync(
+        path.join(vault, 'Chapters', `${CHAPTER_NFC}.md`),
+        `---\ntype: chapter\ntitle: "${CHAPTER_NFC}"\nsort_order: 1\n---\n\nChapter body.\n`,
+      );
+      fs.writeFileSync(
+        path.join(vault, 'Sessions', 'Session 1.md'),
+        `---\ntype: session\nchapter: "[[${CHAPTER_NFD}]]"\nsession_number: 1\nstatus: played\n---\n\nSession body.\n`,
+      );
+
+      const docs = path.join(work, 'docs');
+      const configPath = path.join(work, 'config.json');
+      fs.writeFileSync(configPath, JSON.stringify({
+        vaultPath: vault, outputDir: docs, attachmentsDir: '_attachments',
+        siteTitle: 'Unicode Chapters', siteUrl: 'https://example.github.io/unicode',
+        excludeDirs: ['_meta', '_Templates'],
+        folderMap: { Chapters: 'chapters', Sessions: 'sessions' },
+      }));
+      build({ configPath });
+
+      const html = fs.readFileSync(path.join(docs, 'chapters', 'chapter-renee.html'), 'utf8');
+      assert.match(html, /sessions\/session-1\.html/, 'chapter page lists no constituent sessions');
+    } finally {
+      fs.rmSync(work, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes the eight remaining publish-site and validation issues blocking the release.

Closes #149
Closes #145
Closes #139
Closes #144
Closes #130
Closes #142
Closes #143
Closes #136

## What was wrong

| Issue | Defect |
|---|---|
| #149 | `publishedMarkdown` never stripped HTML comments, so authoring notes rendered as visible text in the homepage "Latest Session" excerpt and every story-spine page body. Third recurrence of the #85/#87 class — fixed at the one chain both surfaces read from, with a site-wide regression test that walks every emitted `.html`. |
| #145 | Hand-built link destinations were not percent-encoded, so any target path containing a space rendered as literal markdown text (and the typographer mangled `..` into `…`). `encodeHref` now covers every href emitter found by a full audit, including search results. |
| #139 | Manifest matching and slug generation ignored unicode normalization, so NFC manifest entries never matched macOS NFD filenames and accented pages never rendered. Canonicalized at the comparison boundaries; combining marks stripped in `slugify`. **Scope grew substantially during review — see below.** |
| #144 | `## Reconciliation Context` and `## Handoff to Reconcile` — written automatically by reconcile and session-wrapup — published GM plot state to the player site. The built-in default had also drifted from the scaffold template; both now carry the same six entries. |
| #130 | Nothing validated relationship predicates, so invented off-vocabulary predicates silently degraded the knowledge graph. New `vault_check.py relationships` (also in `all`) plus a matching check in `scripts/validate_schema.py`, both reading the authoritative vocabulary from `gm-apprentice-ontology.json` and reporting nearest matches. |
| #142 | Ephemeral test resources had no safe lifecycle, and an ad-hoc cleanup sweep deleted the production INBOX KV namespace. New `lib/e2e-resources.js` deletes only records it minted itself, checked by object identity; there is no list-and-delete or delete-by-title API to reach for. |
| #143 | The change-request watcher could be silently reaped mid-session, and a dead watcher looks exactly like a quiet table. Guidance now prefers a persistent monitor primitive, documents the shell loop as fallback, and adds a heartbeat the GM can check in seconds. |
| #136 | The manifest-format spec was reachable only via a two-hop cross-reference. Pointers added at the top of the capabilities that need it. |

## #139 turned out to be much wider than the issue described

The issue reported manifest matching and slugs. Those were fixed first, but review kept finding the same root cause elsewhere: any place author-typed text (a `[[wikilink]]`, a `session:`/`chapter:`/`parent_location:` ref, a `portrait:` value) is compared by exact equality against a filename-derived value. Twenty such comparisons were found in total; seven were silently breaking rendered pages.

What was actually broken, beyond the reported symptom:

- The landing page's narrative recap vanished for a session with an accented name.
- A session's recap vanished from the Story page.
- Location pages lost "Places Within", "Known Figures" and "What Happened Here".
- Faction pages lost their members rollup.
- The locations index rendered a child as a root sibling instead of nesting it.
- An accented NPC never scored as "recently seen" and never appeared on the landing page.
- A chapter page's constituent-sessions sidebar came up empty.
- With both encodings mixed in one vault, a region heading rendered twice and a route-map location listed twice.

Three sweeps missed sites because they were done by reading code. What finally closed it was a differential build (`test/integration/build-unicode-refs.test.js`): the same fixture vault renders three ways — all-NFD, all-NFC, and with the encoding flipped per file — asserting byte-identical output. The mixed variant is what catches the last two, which are structurally invisible to any single-encoding build. Every fix is revert-proved against it.

Two properties are worth knowing for future work. Normalization is applied only at comparison boundaries and never to an emitted path or URL, which keeps it orthogonal to #145's percent-encoding; that property has its own pinning test. And the differential build cannot vary the *filename* side, so it does not guard the mirror direction — the test header says so, and `test/unit/unicode-lookup.test.js` covers it.

## Upgrade notes for existing sites

- **#144 does not apply itself to sites that already set an explicit exclude list.** Config lists union across `_meta/vault-config.md` and `vault.config.json` rather than one shadowing the other, so add `Reconciliation Context` and `Handoff to Reconcile` to either file. Sites with no explicit list anywhere also newly pick up `DM Notes`, `Player Notes` and `Source References`.
- **#139 changes URLs.** Pages with accented characters that decompose (é, ó, ë) get new slugs — previously-broken ones start rendering, previously-working ones move (`gonz-lez.html` → `gonzalez.html`), so existing links and bookmarks to them break. Characters without a decomposition (ø, ł, đ, ß) are unaffected.
- **#130 surfaces existing data on first run.** Plan notes scaffolded from the older template carry a blank relationship type and will report as errors the first time the check runs. The shipped template is fixed; existing notes need a one-time pass.
- After #139 lands, the five NFD entries in the Dead End vault's `_meta/publish-manifest.md` should be reverted to NFC.

## Deviation from plan worth a look

The plan mandated verbatim wording for #136 stating that the H2 section "not the checkbox state" determines inclusion. That is false — `manifest.js` collects only checked entries under `## Publishing`, so an unchecked entry there silently does not publish. Shipping the mandated wording would have hard-coded the exact misunderstanding #136 was filed to correct, so the documentation states the real rule instead: the heading decides the bucket, a checked box is required within `## Publishing`, and the manifest is enforced as an inclusion filter only in `mode: player`.

## Versions and testing

Plugin 1.8.48 → 1.8.49; publish tool 1.11.21 → 1.11.22.

Publish-tool suite 1412 passing, plus every Python validator the CI workflow runs — including `test_vault_check.py`, which was never wired into CI before this branch. Markdownlint clean; skill-creator validation run over `publish-site` and `campaign-qa`, which has no CI backstop.

Client-side search now normalizes its query to match the index. Existing all-ASCII sites are unaffected: NFC is the identity on every ASCII code point, so tokens, stems and result ordering are byte-identical to before.

Known and deliberately left for separate issues: dead code in `landing-data.js` carrying the same comparison bug with no callers; two unreachable ref clauses in `sessionsForChapter`; and two pre-existing cosmetic artifacts under NFD input (initials rendering "BN" rather than "BÑ", and a relationship-graph label truncating one character early).

**Merge before the mobrpg branch** (1.9.0), or the version number walks backwards.
