### PR TITLE
Publish-site follow-ups: unicode boundaries, wrangler timeouts, chapter grouping

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.49",
+  "version": "1.8.50",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,18 +25,26 @@ review, closed as one pass.
   `runCommand` on the same 60s bound the inbox poll received in 1.8.49, and
   the constant moved to `run-command.js` instead of being copied a third
   time. `runCommand` gained a `cwd` passthrough, which is why backend setup
-  had its own raw spawn (#160).
+  had its own raw spawn (#160). The wrappers also dropped `runCommand`'s
+  `error`, and a timed-out spawn leaves stdout and stderr empty — so the new
+  bound turned a hang into a blank message indistinguishable from a silent
+  success. All three now carry it, and the KV adapter and setup diagnostics
+  fall back to it through a shared `failureDetail`.
 - `publish-site`: card initials and relationship-graph labels counted UTF-16
   code units, so a decomposed accent dropped off an initial ("Bestia Ñu"
   showed "BN") and cost a label one of its fifteen characters, truncating
   names that fit composed. Both now measure graphemes, which also keeps
   astral characters whole (#157).
 - `publish-site`: a session filed in one chapter's folder while its
-  `chapter:` ref named another was listed under **both** chapters. The
-  explicit ref now outranks the folder; a ref matching no chapter on the
-  page still falls back to folder grouping. Filed as unreachable dead code
-  (#156) — the clauses are reachable, and deleting them left the suite
-  green, so the gap was coverage.
+  `chapter:` ref named another was listed under **both** chapters. Each
+  session now resolves to exactly one chapter — an exact title beats a loose
+  containment, longest title breaks a tie — and that ref outranks the
+  folder, with folder grouping still the fallback when a ref names no
+  chapter on the page. The ref test that compared ref-inside-chapter-title
+  is gone: it ran opposite to both sibling copies of this matcher and let
+  `[[Vienna]]` claim "Vienna" and "The Vienna Files" at once. Filed as
+  unreachable dead code (#156) — the clauses are reachable, and deleting
+  them left the suite green, so the gap was coverage.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.50] — 2026-08-17
+
+Publish tool 1.11.23. The five follow-up bugs left open by the 1.8.49
+review, closed as one pass.
+
+### Fixed
+
+- `publish-site`: `data-character` was emitted without unicode
+  normalization, so an accented PC's change requests could fail to match
+  back to their vault note — the one place a normal-form mismatch survived
+  #139's sweep into a runtime comparison rather than a build-time one. The
+  flush side was suspected too and turns out to be safe already: it keys on
+  `slugify(title)`, which strips combining marks (#158).
+- `publish-site`: `flush` and backend setup still spawned wrangler with no
+  timeout, so a hung call blocked them indefinitely. Both now route through
+  `runCommand` on the same 60s bound the inbox poll received in 1.8.49, and
+  the constant moved to `run-command.js` instead of being copied a third
+  time. `runCommand` gained a `cwd` passthrough, which is why backend setup
+  had its own raw spawn (#160).
+- `publish-site`: card initials and relationship-graph labels counted UTF-16
+  code units, so a decomposed accent dropped off an initial ("Bestia Ñu"
+  showed "BN") and cost a label one of its fifteen characters, truncating
+  names that fit composed. Both now measure graphemes, which also keeps
+  astral characters whole (#157).
+- `publish-site`: a session filed in one chapter's folder while its
+  `chapter:` ref named another was listed under **both** chapters. The
+  explicit ref now outranks the folder; a ref matching no chapter on the
+  page still falls back to folder grouping. Filed as unreachable dead code
+  (#156) — the clauses are reachable, and deleting them left the suite
+  green, so the gap was coverage.
+
+### Removed
+
+- `publish-site`: `scoreNPCs` and its only reader `IMPORTANCE_TAGS`. Nothing
+  but its own test called it — `scoreByRecency` superseded it — and it
+  carried an unfixed copy of the #139 ref-matching bug, so reviving it would
+  have reintroduced a defect the rest of the tool no longer has (#155).
+
+---
+
 ## [1.8.49] — 2026-08-12
 
 Publish tool 1.11.22. Published-site content-leak and encoding bugs fixed,

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -14,11 +14,14 @@ const { applyGURPSFlush } = require('./flush/gurps-writeback');
 const { deriveGurpsMax } = require('./flush/gurps-max');
 const { loadPublishConfig } = require('./config');
 
-const { spawnSync } = require('child_process');
+const { runCommand, WRANGLER_TIMEOUT_MS } = require('./run-command');
 
-function defaultRunWrangler(args) {
-  const res = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8' });
-  return { code: res.status == null ? 1 : res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+// Bounded like the watcher's poll (#154). The failure here is milder — the GM
+// watches a flush hang rather than a background watcher going silently dark —
+// but an unbounded spawn still blocks the flush with no exit and no signal.
+function defaultRunWrangler(args, run = runCommand) {
+  const res = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS });
+  return { code: res.code, stdout: res.stdout || '', stderr: res.stderr || '' };
 }
 
 function defaultAdapter(cwd) {
@@ -119,4 +122,4 @@ async function runFlush(deps) {
   return 0;
 }
 
-module.exports = { runFlush };
+module.exports = { runFlush, defaultRunWrangler, WRANGLER_TIMEOUT_MS };

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -21,7 +21,7 @@ const { runCommand, WRANGLER_TIMEOUT_MS } = require('./run-command');
 // but an unbounded spawn still blocks the flush with no exit and no signal.
 function defaultRunWrangler(args, run = runCommand) {
   const res = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS });
-  return { code: res.code, stdout: res.stdout || '', stderr: res.stderr || '' };
+  return { code: res.code, stdout: res.stdout || '', stderr: res.stderr || '', error: res.error || null };
 }
 
 function defaultAdapter(cwd) {

--- a/tools/publish/lib/inbox-cli.js
+++ b/tools/publish/lib/inbox-cli.js
@@ -2,7 +2,7 @@
 // GM). Reuses Part 1's inbox-core.mjs over a wrangler-backed KV adapter.
 const fs = require('fs');
 const path = require('path');
-const { runCommand } = require('./run-command.js');
+const { runCommand, WRANGLER_TIMEOUT_MS } = require('./run-command.js');
 const { readNamespaceId, makeAdapter } = require('./inbox-wrangler.js');
 
 // The change-request watcher polls `inbox pull` in a loop and writes
@@ -10,10 +10,8 @@ const { readNamespaceId, makeAdapter } = require('./inbox-wrangler.js');
 // wrangler call that never comes back stalls the heartbeat with no exit and no
 // failure line, so the loop is indistinguishable from a dead one — the exact
 // case the heartbeat exists to rule out. Bound it: a hung call becomes a failed
-// poll, which the loop's failure streak already reports. 60s rather than
-// run-command's 30s default because a cold `npx wrangler@4` may have to fetch
-// the package before it does any work.
-const WRANGLER_TIMEOUT_MS = 60000;
+// poll, which the loop's failure streak already reports. The bound itself now
+// lives in run-command.js, shared with the flush and backend-setup entry points.
 
 function defaultRunWrangler(args, run = runCommand) {
   const res = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS });

--- a/tools/publish/lib/inbox-cli.js
+++ b/tools/publish/lib/inbox-cli.js
@@ -15,7 +15,7 @@ const { readNamespaceId, makeAdapter } = require('./inbox-wrangler.js');
 
 function defaultRunWrangler(args, run = runCommand) {
   const res = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS });
-  return { code: res.code, stdout: res.stdout || '', stderr: res.stderr || '' };
+  return { code: res.code, stdout: res.stdout || '', stderr: res.stderr || '', error: res.error || null };
 }
 
 function defaultAdapter(cwd) {

--- a/tools/publish/lib/inbox-wrangler.js
+++ b/tools/publish/lib/inbox-wrangler.js
@@ -1,6 +1,7 @@
 // KV-like adapter that reaches the site's INBOX namespace from the GM's laptop
 // via `wrangler kv key` commands. Same shape inbox-core.mjs expects, so the
 // loop reuses the exact Part 1 queue logic locally.
+const { failureDetail } = require('./run-command');
 
 // Pull the INBOX namespace id straight out of wrangler.toml (unambiguous —
 // we pass --namespace-id rather than relying on binding resolution).
@@ -42,12 +43,12 @@ function makeAdapter({ runWrangler, namespaceId }) {
       const err = (res.stderr || '').toLowerCase().replace(/https?:\/\/\S+/g, '');
       const operational = /namespace|authenticat|authoriz|unauthor|permission|credential|not logged in|network|fetch failed|timeout|econn|enotfound|10041|10000/.test(err);
       if (!operational && /not found|not_found|no value|does not exist/.test(err)) return null;
-      throw new Error('wrangler kv get failed for "' + key + '": ' + ((res.stderr || '').trim() || 'exit ' + res.code));
+      throw new Error('wrangler kv get failed for "' + key + '": ' + failureDetail(res));
     },
     async put(key, value, opts) {
       const extra = opts && opts.expirationTtl ? ['--ttl', String(opts.expirationTtl)] : [];
       const res = runWrangler(['kv', 'key', 'put', key, value, ...ns, ...extra]);
-      if (res.code !== 0) throw new Error(`wrangler put failed: ${res.stderr}`);
+      if (res.code !== 0) throw new Error(`wrangler put failed: ${failureDetail(res)}`);
     },
     async delete(key) {
       runWrangler(['kv', 'key', 'delete', key, ...ns]);
@@ -56,7 +57,7 @@ function makeAdapter({ runWrangler, namespaceId }) {
       const args = ['kv', 'key', 'list', ...ns];
       if (prefix) args.push('--prefix', prefix);
       const res = runWrangler(args);
-      if (res.code !== 0) throw new Error(`wrangler list failed: ${res.stderr}`);
+      if (res.code !== 0) throw new Error(`wrangler list failed: ${failureDetail(res)}`);
       const parsed = JSON.parse(res.stdout || '[]');
       return { keys: parsed.map(k => ({ name: k.name })) };
     },

--- a/tools/publish/lib/relationship-graph.js
+++ b/tools/publish/lib/relationship-graph.js
@@ -1,5 +1,5 @@
 const { escapeHtml, encodeHref } = require('./processor');
-const { canonicalNfc, nfcLookupTable } = require('./unicode');
+const { canonicalNfc, nfcLookupTable, truncateGraphemes } = require('./unicode');
 
 const SHAPE_MAP = {
   pc: 'circle',
@@ -185,7 +185,10 @@ function renderRelationshipSVG(graph, options = {}) {
     }
 
     const fontSize = node.hop === 2 ? 9 : 11;
-    const label = node.displayTitle.length > 15 ? node.displayTitle.slice(0, 13) + '…' : node.displayTitle;
+    // Measured in graphemes: a decomposed accent used to spend one of the 15 and
+    // truncate a name that fits when composed (#157). Display text only — the
+    // node's href still comes from its own path, untouched.
+    const label = truncateGraphemes(node.displayTitle, 15, 13);
     svg += `    <text x="${pos.x}" y="${pos.y + size + fontSize + 4}" text-anchor="middle" font-size="${fontSize}" fill="var(--text, #c9d1d9)">${escapeHtml(label)}</text>\n`;
     svg += `  </g>${linkClose}\n`;
   }

--- a/tools/publish/lib/run-command.js
+++ b/tools/publish/lib/run-command.js
@@ -20,4 +20,18 @@ function runCommand(cmd, args, { timeoutMs = 30000, cwd } = {}) {
   };
 }
 
-module.exports = { runCommand, WRANGLER_TIMEOUT_MS };
+// Best available description of a failed run, for a message a human will read.
+//
+// spawnSync reports a timeout or an un-spawnable command through `error`, leaving
+// stdout and stderr empty — so a diagnostic assembled from those two alone renders
+// blank, which reads exactly like a silent success. That makes the timeouts above
+// worse than useless: the call stops hanging but says nothing about why. Prefer real
+// output, fall back to the process error, then to the exit code.
+function failureDetail(res) {
+  return (res.stderr || '').trim()
+    || (res.stdout || '').trim()
+    || (res.error ? String(res.error) : '')
+    || ('exit ' + res.code);
+}
+
+module.exports = { runCommand, WRANGLER_TIMEOUT_MS, failureDetail };

--- a/tools/publish/lib/run-command.js
+++ b/tools/publish/lib/run-command.js
@@ -5,8 +5,13 @@ const { spawnSync } = require('child_process');
 // A timeout guards against a stalled child (e.g. a hung `wrangler whoami`)
 // freezing the preflight; a timed-out or un-spawnable child yields code 1 with
 // the underlying error code surfaced in `error`.
-function runCommand(cmd, args, { timeoutMs = 30000 } = {}) {
-  const res = spawnSync(cmd, args, { encoding: 'utf8', timeout: timeoutMs });
+// Every wrangler entry point (inbox poll, flush, backend setup) shares this
+// bound. 60s rather than the 30s default because a cold `npx wrangler@4` may
+// have to fetch the package before it does any work.
+const WRANGLER_TIMEOUT_MS = 60000;
+
+function runCommand(cmd, args, { timeoutMs = 30000, cwd } = {}) {
+  const res = spawnSync(cmd, args, { encoding: 'utf8', timeout: timeoutMs, ...(cwd ? { cwd } : {}) });
   return {
     code: res.status == null ? 1 : res.status,
     stdout: res.stdout || '',
@@ -15,4 +20,4 @@ function runCommand(cmd, args, { timeoutMs = 30000 } = {}) {
   };
 }
 
-module.exports = { runCommand };
+module.exports = { runCommand, WRANGLER_TIMEOUT_MS };

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { runCommand, WRANGLER_TIMEOUT_MS } = require('./run-command');
+const { runCommand, WRANGLER_TIMEOUT_MS, failureDetail } = require('./run-command');
 const { readNamespaceId } = require('./inbox-wrangler');
 
 const KV_PLACEHOLDER = 'PUT-YOUR-KV-NAMESPACE-ID-HERE';
@@ -13,7 +13,7 @@ function checkKvPermission({ runWrangler }) {
   if (r.code === 0) return { ok: true };
   const blob = `${r.stdout || ''}\n${r.stderr || ''}`;
   if (/10000|Authentication/i.test(blob)) return { ok: false, fix: KV_PERMISSION_FIX };
-  return { ok: false, fix: `wrangler could not list KV namespaces: ${(r.stderr || '').trim()}` };
+  return { ok: false, fix: `wrangler could not list KV namespaces: ${failureDetail(r)}` };
 }
 
 // Parse the id from `wrangler kv namespace create` output (prints an `id = "..."`
@@ -32,7 +32,7 @@ function ensureKvNamespace({ runWrangler, tomlText }) {
   const created = runWrangler(['kv', 'namespace', 'create', 'INBOX']);
   const id = parseCreatedId(created.stdout);
   if (created.code !== 0 || !id) {
-    throw new Error(`Could not create the INBOX KV namespace: ${(created.stderr || created.stdout || '').trim()}`);
+    throw new Error(`Could not create the INBOX KV namespace: ${failureDetail(created)}`);
   }
   return { id, created: true };
 }
@@ -71,7 +71,7 @@ function patchWranglerToml(tomlText, { name, kvId }) {
 // setup with nothing on screen to explain it.
 const defaultRunWrangler = (args, opts = {}, run = runCommand) => {
   const r = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS, cwd: opts.cwd });
-  return { code: r.code, stdout: r.stdout || '', stderr: r.stderr || '' };
+  return { code: r.code, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error || null };
 };
 
 const FLAG_KEY = { 'status-bar': 'statusBar', inbox: 'inbox' };
@@ -120,7 +120,7 @@ async function runSetupBackend(feature, { configPath }, deps = {}) {
   syncFunctions(siteRoot);
   build({ configPath });
   const dep = runWranglerAt(['pages', 'deploy']);
-  if (dep.code !== 0) { out(`Deploy failed: ${(dep.stderr || dep.stdout || '').trim()}`); return 1; }
+  if (dep.code !== 0) { out(`Deploy failed: ${failureDetail(dep)}`); return 1; }
 
   const url = config.siteUrl || `https://${projectName}.pages.dev`;
   out(`Your ${LABEL[feature]} is set up and deployed. Live at ${url}.`);

--- a/tools/publish/lib/setup-backend.js
+++ b/tools/publish/lib/setup-backend.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { runCommand, WRANGLER_TIMEOUT_MS } = require('./run-command');
 const { readNamespaceId } = require('./inbox-wrangler');
 
 const KV_PLACEHOLDER = 'PUT-YOUR-KV-NAMESPACE-ID-HERE';
@@ -66,9 +66,12 @@ function patchWranglerToml(tomlText, { name, kvId }) {
   return out;
 }
 
-const defaultRunWrangler = (args, opts = {}) => {
-  const r = spawnSync('npx', ['wrangler@4', ...args], { encoding: 'utf8', cwd: opts.cwd });
-  return { code: r.status == null ? 1 : r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+// Bounded like the other two wrangler entry points (#160). These are quick
+// control-plane calls (kv namespace list/create), so a stall means a wedged
+// setup with nothing on screen to explain it.
+const defaultRunWrangler = (args, opts = {}, run = runCommand) => {
+  const r = run('npx', ['wrangler@4', ...args], { timeoutMs: WRANGLER_TIMEOUT_MS, cwd: opts.cwd });
+  return { code: r.code, stdout: r.stdout || '', stderr: r.stderr || '' };
 };
 
 const FLAG_KEY = { 'status-bar': 'statusBar', inbox: 'inbox' };
@@ -132,4 +135,6 @@ module.exports = {
   KV_PERMISSION_FIX,
   runSetupBackend,
   parseCreatedId,
+  defaultRunWrangler,
+  WRANGLER_TIMEOUT_MS,
 };

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -371,22 +371,39 @@ function renderChapterList(pages, indexDir) {
 
   if (chapters.length === 0 && sessions.length === 0) return '';
 
-  function sessionsForChapter(chapter) {
-    // The third copy of the chapter matcher (story-spine.js and build.js hold the others).
-    // Author-typed ref vs filename-derived title on both substring tests, so both sides are
-    // canonicalized to NFC (#139) — but the two ref clauses are UNREACHABLE TODAY: this
-    // function only ever sees the pages of a single output dir, so the folder-prefix clause
-    // below is true for every session it is given and always decides first. Kept in the same
-    // normal form as its two live siblings so the three cannot drift.
+  // The third copy of the chapter matcher (story-spine.js and build.js hold the
+  // others). Author-typed ref vs filename-derived title on both substring tests, so
+  // both sides are canonicalized to NFC (#139). Kept in the same normal form as its
+  // two live siblings so the three cannot drift.
+  //
+  // #156 filed these two ref tests as unreachable. They are not: the index page is
+  // built from every page under `chapters/`, subfolders included, so a session in one
+  // chapter's folder whose `chapter:` ref names another reaches both tests. Deleting
+  // them leaves the whole suite green, which is what made them look dead.
+  function refMatchesChapter(session, chapter) {
+    const ref = canonicalNfc(String(session.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '')).toLowerCase();
+    if (!ref) return false;
     const chTitle = canonicalNfc(chapter.displayTitle).toLowerCase();
     const chFrontTitle = chapter.frontmatter.title ? canonicalNfc(chapter.frontmatter.title).toLowerCase() : '___';
+    if (chTitle.includes(ref.replace(/^chapter \d+\s*[-–—]\s*/i, '').trim().toLowerCase())) return true;
+    if (ref.includes(chFrontTitle)) return true;
+    return false;
+  }
+
+  // An explicit ref outranks the folder. Before this, a session filed under Calcutta
+  // but tagged `chapter: [[Vienna]]` matched the ref test for Vienna *and* the folder
+  // test for Calcutta, and was listed under both chapters. A ref that names no chapter
+  // on the page claims nothing, so those sessions still fall back to their folder.
+  const refClaimed = new Set(
+    sessions.filter(s => chapters.some(c => refMatchesChapter(s, c))).map(s => s.outputPath)
+  );
+
+  function sessionsForChapter(chapter) {
     const chFolder = chapter.outputPath.split('/').slice(0, -1).join('/');
     return sessions.filter(s => {
-      const ref = canonicalNfc(String(s.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '')).toLowerCase();
-      if (ref && chTitle.includes(ref.replace(/^chapter \d+\s*[-–—]\s*/i, '').trim().toLowerCase())) return true;
-      if (ref && ref.includes(chFrontTitle)) return true;
-      if (s.outputPath.startsWith(chFolder + '/')) return true;
-      return false;
+      if (refMatchesChapter(s, chapter)) return true;
+      if (refClaimed.has(s.outputPath)) return false;
+      return s.outputPath.startsWith(chFolder + '/');
     });
   }
 

--- a/tools/publish/lib/templates/index-page.js
+++ b/tools/publish/lib/templates/index-page.js
@@ -380,29 +380,63 @@ function renderChapterList(pages, indexDir) {
   // built from every page under `chapters/`, subfolders included, so a session in one
   // chapter's folder whose `chapter:` ref names another reaches both tests. Deleting
   // them leaves the whole suite green, which is what made them look dead.
-  function refMatchesChapter(session, chapter) {
-    const ref = canonicalNfc(String(session.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '')).toLowerCase();
-    if (!ref) return false;
-    const chTitle = canonicalNfc(chapter.displayTitle).toLowerCase();
-    const chFrontTitle = chapter.frontmatter.title ? canonicalNfc(chapter.frontmatter.title).toLowerCase() : '___';
-    if (chTitle.includes(ref.replace(/^chapter \d+\s*[-–—]\s*/i, '').trim().toLowerCase())) return true;
-    if (ref.includes(chFrontTitle)) return true;
-    return false;
+  const CHAPTER_PREFIX = /^chapter\s+\d+\s*[-–—:]\s*/i;
+  const bare = (s) => s.replace(CHAPTER_PREFIX, '').trim();
+  const refOf = (session) => canonicalNfc(
+    String(session.frontmatter.chapter || '').replace(/\[\[|\]\]/g, '').split('|')[0].trim()
+  ).toLowerCase();
+
+  // How strongly a ref names this chapter. 2 = the two titles are the same once a
+  // "Chapter 3 — " prefix is discounted on either side. 1 = the chapter's own title
+  // appears inside a longer ref ("Chapter 1 — London: The Orphean Society" naming
+  // "London") — the direction both sibling matchers implement. 0 = no claim.
+  //
+  // The reverse of that substring test, ref-inside-title, is deliberately absent: it
+  // is what let `[[Vienna]]` claim both "Vienna" and "The Vienna Files", and it is
+  // also the one direction neither sibling uses.
+  function refScore(ref, chapter) {
+    if (!ref) return 0;
+    const titles = [chapter.displayTitle, chapter.frontmatter.title]
+      .filter(Boolean)
+      .map(t => canonicalNfc(String(t)).toLowerCase());
+    if (titles.some(t => bare(ref) === bare(t))) return 2;
+    if (titles.some(t => t && ref.includes(t))) return 1;
+    return 0;
+  }
+
+  // Resolve each session to at most ONE chapter up front. Scoring rather than
+  // first-match-wins so an exact title beats a loose containment, and the longest
+  // title breaks a tie as the most specific claim. Without this a ref that matched
+  // two chapters put the session under both.
+  const resolvedChapter = new Map();
+  for (const s of sessions) {
+    const ref = refOf(s);
+    if (!ref) continue;
+    let best = null;
+    let bestScore = 0;
+    let bestLen = -1;
+    for (const c of chapters) {
+      const score = refScore(ref, c);
+      if (!score) continue;
+      const len = canonicalNfc(String(c.displayTitle || '')).length;
+      if (score > bestScore || (score === bestScore && len > bestLen)) {
+        best = c;
+        bestScore = score;
+        bestLen = len;
+      }
+    }
+    if (best) resolvedChapter.set(s.outputPath, best);
   }
 
   // An explicit ref outranks the folder. Before this, a session filed under Calcutta
   // but tagged `chapter: [[Vienna]]` matched the ref test for Vienna *and* the folder
   // test for Calcutta, and was listed under both chapters. A ref that names no chapter
-  // on the page claims nothing, so those sessions still fall back to their folder.
-  const refClaimed = new Set(
-    sessions.filter(s => chapters.some(c => refMatchesChapter(s, c))).map(s => s.outputPath)
-  );
-
+  // on the page resolves to nothing, so those sessions still fall back to their folder.
   function sessionsForChapter(chapter) {
     const chFolder = chapter.outputPath.split('/').slice(0, -1).join('/');
     return sessions.filter(s => {
-      if (refMatchesChapter(s, chapter)) return true;
-      if (refClaimed.has(s.outputPath)) return false;
+      const resolved = resolvedChapter.get(s.outputPath);
+      if (resolved) return resolved === chapter;
       return s.outputPath.startsWith(chFolder + '/');
     });
   }

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -79,10 +79,6 @@ const PATRON_TAGS = new Set(['employer', 'patron']);
 const ANTAGONIST_TAGS = new Set(['villain', 'antagonist']);
 const COMPANION_TAGS = new Set(['companion', 'ally']);
 const THREAT_TAGS = new Set(['super', 'fragment-empowered']);
-const IMPORTANCE_TAGS = new Set([
-  'employer', 'patron', 'villain', 'antagonist', 'rival',
-  'companion', 'ally', 'recurring', 'boss',
-]);
 
 function inferNPCRole(npc, sessionCount) {
   const tags = new Set(npc.frontmatter.tags || []);
@@ -95,49 +91,6 @@ function inferNPCRole(npc, sessionCount) {
   if (rels.some(r => r.type === 'leads' || r.type === 'commands')) return 'Leader';
   if (sessionCount >= 2) return 'Recurring';
   return 'NPC';
-}
-
-function scoreNPCs(allPages) {
-  const npcs = allPages.filter(p => p.frontmatter.type === 'npc');
-  const sessions = allPages.filter(
-    p => p.frontmatter.type === 'session' && (p.frontmatter.status === 'played' || p.frontmatter.status === 'reviewed')
-  );
-
-  const scored = npcs.map(npc => {
-    let score = 0;
-    let sessionCount = 0;
-    const names = [npc.title, ...(npc.frontmatter.aliases || [])];
-
-    for (const session of sessions) {
-      const md = session.markdown || '';
-      const mentioned = names.some(name => md.includes(`[[${name}]]`));
-      if (mentioned) {
-        score += 2;
-        sessionCount++;
-      }
-    }
-
-    const rels = npc.frontmatter.relationships || [];
-    score += rels.length;
-
-    const tags = npc.frontmatter.tags || [];
-    for (const tag of tags) {
-      if (IMPORTANCE_TAGS.has(tag)) score += 3;
-    }
-
-    if (rels.some(r => r.type === 'leads' || r.type === 'commands')) score += 2;
-
-    if (tags.some(t => THREAT_TAGS.has(t))) score += 2;
-
-    const role = inferNPCRole(npc, sessionCount);
-
-    return { page: npc, score, role };
-  });
-
-  return scored
-    .filter(s => s.score >= 3)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 8);
 }
 
 const EXPLORE_DESCRIPTIONS = {
@@ -274,4 +227,4 @@ function getLatestWrapUp(pages, session) {
   return null;
 }
 
-module.exports = { getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs, scoreNPCs, inferNPCRole, getRecentEvents, getExploreDescriptions };
+module.exports = { getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs, inferNPCRole, getRecentEvents, getExploreDescriptions };

--- a/tools/publish/lib/templates/landing-data.js
+++ b/tools/publish/lib/templates/landing-data.js
@@ -1,4 +1,4 @@
-const { canonicalNfc } = require('../unicode');
+const { canonicalNfc, graphemes } = require('../unicode');
 const { parseWikiRef } = require('../processor');
 
 function getLatestSession(pages) {
@@ -64,7 +64,9 @@ function extractRecap(page) {
 function getInitials(name) {
   if (!name) return '';
   const words = name.split(/\s+/).filter(Boolean);
-  return words.slice(0, 2).map(w => w[0].toUpperCase()).join('');
+  // First *grapheme*, not first code unit: w[0] dropped a decomposed accent and
+  // would halve an astral character (#157).
+  return words.slice(0, 2).map(w => (graphemes(w)[0] || '').toUpperCase()).join('');
 }
 
 function getPCs(pages) {

--- a/tools/publish/lib/templates/pc.js
+++ b/tools/publish/lib/templates/pc.js
@@ -364,8 +364,12 @@ function pcTemplate(page, processedContent, sections, navFor, config, imageMap, 
     ? `\n<div class="tab-panel" id="tab-combat">\n${systemCombatHtml}\n</div>` : '';
 
   // --- Assemble ---
+  // NFC at the boundary, not because this is a path (it isn't — see unicode.js on
+  // why emitted paths stay byte-exact) but because the browser posts this value
+  // back as the inbox entry's `character`, where it is matched against vault note
+  // names. A decomposed name would survive into that runtime comparison and miss.
   const crWidget = showInbox
-    ? `<div id="cr-root" data-character="${escapeHtml(page.frontmatter.name || page.displayTitle || page.title || '')}"></div>`
+    ? `<div id="cr-root" data-character="${escapeHtml(canonicalNfc(page.frontmatter.name || page.displayTitle || page.title || ''))}"></div>`
     : '';
 
   // --- CoC parchment folio (branch off the generic assembly) ---

--- a/tools/publish/lib/unicode.js
+++ b/tools/publish/lib/unicode.js
@@ -60,4 +60,30 @@ function nfcLookupTable(map) {
   });
 }
 
-module.exports = { canonicalNfc, nfcLookupTable };
+// --- Display-side helpers (#157) ---
+//
+// Distinct in purpose from everything above: those exist so two strings *compare*
+// equal, these exist so one string *renders* and *measures* the way a reader sees
+// it. The failures they fix are cosmetic, not structural — an initial that loses
+// its accent, a label truncated a character early — but they share the same root
+// cause, which is that JS string indexing counts UTF-16 code units while a reader
+// counts what looks like one character.
+//
+// Composing first collapses the common case (base + combining mark becomes one
+// code point); segmenting handles the rest, including marks with no precomposed
+// form and astral characters, which are surrogate pairs.
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+function graphemes(value) {
+  return Array.from(graphemeSegmenter.segment(canonicalNfc(value)), (g) => g.segment);
+}
+
+// Truncate by what the reader counts as a character, not by code unit. Returns the
+// composed string untouched when it fits.
+function truncateGraphemes(value, max, keep, ellipsis = '…') {
+  const composed = canonicalNfc(value);
+  const parts = graphemes(composed);
+  return parts.length > max ? parts.slice(0, keep).join('') + ellipsis : composed;
+}
+
+module.exports = { canonicalNfc, nfcLookupTable, graphemes, truncateGraphemes };

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.22",
+  "version": "1.11.23",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/change-request-widget.test.js
+++ b/tools/publish/test/change-request-widget.test.js
@@ -24,6 +24,20 @@ test('widget falls back to displayTitle when frontmatter.name is absent', () => 
   assert.ok(html.includes('data-character="Hero"'));
 });
 
+// The attribute is the only author-typed string that leaves the build and comes
+// back at runtime: the browser posts it as the inbox entry's `character`, which
+// the GM side matches against vault note names. A decomposed name emitted as-is
+// never matches a composed note title, so normalize at this boundary like every
+// other comparison site does (#139).
+test('data-character is emitted NFC-normalized even when the name is decomposed', () => {
+  const nfd = 'Gonza\u0301lez'; // n, a, combining acute
+  const nfc = 'Gonz\u00e1lez';   // precomposed a-acute
+  const p = { frontmatter: { type: 'pc', name: nfd }, displayTitle: nfd, outputPath: 'pcs/gonzalez.html', title: nfd };
+  const html = pcTemplate(p, { html: '', relationships: '' }, [], noop, cfg, {}, undefined, inboxOn);
+  assert.ok(html.includes(`data-character="${nfc}"`), 'attribute carries the composed form');
+  assert.ok(!html.includes(`data-character="${nfd}"`), 'attribute does not carry the decomposed form');
+});
+
 const fs = require('node:fs');
 test('widget script ships the chat-log and hint UI hooks', () => {
   const src = fs.readFileSync(require('path').join(__dirname, '../js/change-request.js'), 'utf8');

--- a/tools/publish/test/flush-cli.test.js
+++ b/tools/publish/test/flush-cli.test.js
@@ -174,3 +174,22 @@ test('flush skips a GURPS PC whose HP/FP are pinned in frontmatter (status objec
   assert.equal(writes['/vault/PCs/Karl.md'], undefined, 'sheet must not be written');
   assert.ok(lines.some((l) => /Karl Brenner/.test(l) && /frontmatter/.test(l)), 'warns about frontmatter-pinned vitals');
 });
+
+// #160: flush's wrangler spawn was unbounded. Milder than the watcher poll it
+// mirrors (#154) — a GM sees the flush hang rather than a background watcher
+// going quietly dark — but a hung wrangler still blocks the flush forever.
+test('the wrangler call flush runs through is bounded by a timeout', () => {
+  const { defaultRunWrangler, WRANGLER_TIMEOUT_MS } = require('../lib/flush-cli');
+  const seen = [];
+  const res = defaultRunWrangler(['kv', 'key', 'get', 'x'], (cmd, args, opts) => {
+    seen.push({ cmd, args, opts });
+    return { code: 0, stdout: '{}', stderr: '' };
+  });
+  assert.equal(res.code, 0);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].cmd, 'npx');
+  assert.deepEqual(seen[0].args, ['wrangler@4', 'kv', 'key', 'get', 'x']);
+  assert.ok(Number.isFinite(seen[0].opts.timeoutMs) && seen[0].opts.timeoutMs > 0,
+    `expected a finite positive timeoutMs, got ${JSON.stringify(seen[0].opts)}`);
+  assert.equal(seen[0].opts.timeoutMs, WRANGLER_TIMEOUT_MS);
+});

--- a/tools/publish/test/flush-cli.test.js
+++ b/tools/publish/test/flush-cli.test.js
@@ -193,3 +193,10 @@ test('the wrangler call flush runs through is bounded by a timeout', () => {
     `expected a finite positive timeoutMs, got ${JSON.stringify(seen[0].opts)}`);
   assert.equal(seen[0].opts.timeoutMs, WRANGLER_TIMEOUT_MS);
 });
+
+test('the flush wrapper passes the process error through', () => {
+  const { defaultRunWrangler } = require('../lib/flush-cli');
+  const res = defaultRunWrangler(['kv', 'key', 'get', 'x'],
+    () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }));
+  assert.equal(res.error, 'ETIMEDOUT');
+});

--- a/tools/publish/test/inbox-wrangler.test.js
+++ b/tools/publish/test/inbox-wrangler.test.js
@@ -78,3 +78,13 @@ test('adapter.list parses wrangler JSON into {keys:[{name}]}', async () => {
   const out = await kv.list({ prefix: 'req:' });
   assert.deepEqual(out.keys.map(k => k.name), ['req:a', 'req:b']);
 });
+
+// #161 review: a timed-out wrangler leaves stdout/stderr empty, so the adapter's
+// throw degraded to a bare "exit 1" and the flush reported nothing a GM could act on.
+test('a KV read that times out reports the process error, not a bare exit code', async () => {
+  const adapter = makeAdapter({
+    runWrangler: () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }),
+    namespaceId: 'ns',
+  });
+  await assert.rejects(() => adapter.get('some-key'), /ETIMEDOUT/);
+});

--- a/tools/publish/test/unit/chapter-session-grouping.test.js
+++ b/tools/publish/test/unit/chapter-session-grouping.test.js
@@ -1,0 +1,42 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { indexTemplate } = require('../../lib/templates/index-page');
+
+const navFor = () => '';
+const cfg = { siteTitle: 'S', footer: '' };
+
+// #156 filed these two clauses as unreachable dead code. They are not: the index
+// page is built from every page under `chapters/`, including per-chapter
+// subfolders, so a session sitting in one chapter's folder while its `chapter:`
+// ref names another reaches both the ref test and the folder test. What made
+// them look dead is that deleting them leaves the whole suite green.
+function chapterPages(sessionFrontmatter) {
+  return [
+    { title: 'Vienna', displayTitle: 'Vienna', outputPath: 'chapters/vienna/vienna.html',
+      frontmatter: { type: 'chapter', sort_order: 1 }, markdown: '' },
+    { title: 'Calcutta', displayTitle: 'Calcutta', outputPath: 'chapters/calcutta/calcutta.html',
+      frontmatter: { type: 'chapter', sort_order: 2 }, markdown: '' },
+    { title: 'Session 04', displayTitle: 'Session 04', outputPath: 'chapters/calcutta/session-04.html',
+      frontmatter: Object.assign({ type: 'session', session_number: 4, status: 'played' }, sessionFrontmatter),
+      markdown: '' },
+  ];
+}
+
+const countSession = (html) => (html.match(/Session 04/g) || []).length;
+
+describe('chapter/session grouping', () => {
+  it('files a session by its chapter ref, not also by the folder it sits in', () => {
+    const html = indexTemplate('chapters', 'Chapters', chapterPages({ chapter: '[[Vienna]]' }), navFor, cfg, {}, {});
+    assert.strictEqual(countSession(html), 1, 'listed under exactly one chapter');
+  });
+
+  it('still groups by folder when the session carries no chapter ref', () => {
+    const html = indexTemplate('chapters', 'Chapters', chapterPages({}), navFor, cfg, {}, {});
+    assert.strictEqual(countSession(html), 1, 'the folder clause still places it');
+  });
+
+  it('still groups by folder when the ref names no chapter on the page', () => {
+    const html = indexTemplate('chapters', 'Chapters', chapterPages({ chapter: '[[Nowhere]]' }), navFor, cfg, {}, {});
+    assert.strictEqual(countSession(html), 1, 'an unmatched ref falls back to the folder');
+  });
+});

--- a/tools/publish/test/unit/chapter-session-grouping.test.js
+++ b/tools/publish/test/unit/chapter-session-grouping.test.js
@@ -40,3 +40,44 @@ describe('chapter/session grouping', () => {
     assert.strictEqual(countSession(html), 1, 'an unmatched ref falls back to the folder');
   });
 });
+
+// #161 review: the ref test compared `chapterTitle.includes(ref)` — the opposite
+// direction from both sibling copies of this matcher (story-spine.js, build.js),
+// which test whether the chapter's title appears in the ref. That backwards
+// direction is what lets one ref claim two chapters.
+describe('chapter reference matching is unambiguous', () => {
+  const twoChapters = (chapterRef) => [
+    { title: 'Vienna', displayTitle: 'Vienna', outputPath: 'chapters/vienna/vienna.html',
+      frontmatter: { type: 'chapter', sort_order: 1 }, markdown: '' },
+    { title: 'The Vienna Files', displayTitle: 'The Vienna Files', outputPath: 'chapters/files/files.html',
+      frontmatter: { type: 'chapter', sort_order: 2 }, markdown: '' },
+    { title: 'Session 04', displayTitle: 'Session 04', outputPath: 'chapters/vienna/session-04.html',
+      frontmatter: { type: 'session', session_number: 4, status: 'played', chapter: chapterRef }, markdown: '' },
+  ];
+
+  it('does not let one ref claim two chapters by substring', () => {
+    const html = indexTemplate('chapters', 'Chapters', twoChapters('[[Vienna]]'), navFor, cfg, {}, {});
+    assert.strictEqual((html.match(/Session 04/g) || []).length, 1, 'listed under exactly one chapter');
+  });
+
+  it('files it under the chapter the ref actually names', () => {
+    const html = indexTemplate('chapters', 'Chapters', twoChapters('[[The Vienna Files]]'), navFor, cfg, {}, {});
+    const idx = html.indexOf('Session 04');
+    assert.ok(idx > html.indexOf('The Vienna Files'), 'sits under The Vienna Files, not Vienna');
+    assert.strictEqual((html.match(/Session 04/g) || []).length, 1);
+  });
+
+  // Capability that must survive: a long descriptive ref naming a short chapter.
+  // This is the direction the two sibling matchers implement.
+  it('still matches a long ref that contains the chapter title', () => {
+    const pages = [
+      { title: 'London', displayTitle: 'London', outputPath: 'chapters/london/london.html',
+        frontmatter: { type: 'chapter', title: 'London', sort_order: 1 }, markdown: '' },
+      { title: 'Session 09', displayTitle: 'Session 09', outputPath: 'chapters/misfiled/session-09.html',
+        frontmatter: { type: 'session', session_number: 9, status: 'played',
+          chapter: '[[Chapter 1 — London: The Orphean Society]]' }, markdown: '' },
+    ];
+    const html = indexTemplate('chapters', 'Chapters', pages, navFor, cfg, {}, {});
+    assert.strictEqual((html.match(/Session 09/g) || []).length, 1, 'the long ref still finds London');
+  });
+});

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs, scoreNPCs, inferNPCRole, getRecentEvents, getExploreDescriptions } = require('../../lib/templates/landing-data');
+const { getLatestSession, getLatestWrapUp, extractRecap, getInitials, getPCs, inferNPCRole, getRecentEvents, getExploreDescriptions } = require('../../lib/templates/landing-data');
 
 describe('getLatestSession', () => {
   it('returns the most recent played session by session_number', () => {
@@ -367,87 +367,6 @@ describe('inferNPCRole', () => {
   it('returns NPC when sessionCount < 2 and no tag matches', () => {
     const npc = { frontmatter: { tags: [], relationships: [] } };
     assert.strictEqual(inferNPCRole(npc, 1), 'NPC');
-  });
-});
-
-describe('scoreNPCs', () => {
-  it('scores NPCs by session mentions, relationships, and tags', () => {
-    const npcPage = {
-      title: 'Adrian Voss',
-      frontmatter: {
-        type: 'npc',
-        tags: ['employer'],
-        relationships: [
-          { type: 'employs', target: '[[PCs]]' },
-          { type: 'owns', target: '[[Voss Dynamics]]' },
-        ],
-        occupation: 'CEO',
-      },
-      outputPath: 'characters/npcs/adrian-voss.html',
-    };
-    const session1 = {
-      frontmatter: { type: 'session', status: 'played', session_number: 1 },
-      markdown: '# S1\n\nThe team met [[Adrian Voss]] at HQ.\n',
-    };
-    const session2 = {
-      frontmatter: { type: 'session', status: 'played', session_number: 2 },
-      markdown: '# S2\n\n[[Adrian Voss]] gave orders.\n',
-    };
-    const allPages = [npcPage, session1, session2];
-    const result = scoreNPCs(allPages);
-    assert.ok(result.length > 0);
-    assert.strictEqual(result[0].page.title, 'Adrian Voss');
-    assert.ok(result[0].score >= 3);
-    assert.strictEqual(result[0].role, 'Patron');
-  });
-
-  it('excludes NPCs scoring below 3', () => {
-    const npcPage = {
-      title: 'Random NPC',
-      frontmatter: { type: 'npc', tags: [], relationships: [] },
-      outputPath: 'characters/npcs/random.html',
-    };
-    const allPages = [npcPage];
-    const result = scoreNPCs(allPages);
-    assert.strictEqual(result.length, 0);
-  });
-
-  it('caps results at 8', () => {
-    const pages = [];
-    for (let i = 0; i < 12; i++) {
-      pages.push({
-        title: `NPC ${i}`,
-        frontmatter: {
-          type: 'npc',
-          tags: ['employer', 'recurring'],
-          relationships: [{ type: 'employs', target: '[[X]]' }],
-        },
-        outputPath: `characters/npcs/npc-${i}.html`,
-      });
-    }
-    const result = scoreNPCs(pages);
-    assert.ok(result.length <= 8);
-  });
-
-  it('checks NPC aliases for session mentions', () => {
-    const npcPage = {
-      title: 'The Dragon',
-      frontmatter: {
-        type: 'npc',
-        aliases: ['Dragon', 'Dragonman'],
-        tags: ['super'],
-        relationships: [],
-      },
-      outputPath: 'characters/npcs/the-dragon.html',
-    };
-    const session1 = {
-      frontmatter: { type: 'session', status: 'played', session_number: 1 },
-      markdown: '# S1\n\nThey encountered [[Dragon]] in the sky.\n',
-    };
-    const result = scoreNPCs([npcPage, session1]);
-    const dragon = result.find(r => r.page.title === 'The Dragon');
-    assert.ok(dragon, 'Dragon should appear in scored NPCs');
-    assert.ok(dragon.score >= 3);
   });
 });
 

--- a/tools/publish/test/unit/landing-data.test.js
+++ b/tools/publish/test/unit/landing-data.test.js
@@ -279,6 +279,19 @@ describe('getInitials', () => {
   it('returns empty string for empty input', () => {
     assert.strictEqual(getInitials(''), '');
   });
+
+  // #157: w[0] takes one UTF-16 code unit, so a decomposed accent — the form
+  // macOS filenames arrive in — left its base letter behind and the mark on the
+  // floor. Card initials showed "BN" for a decomposed "Bestia Ñu".
+  it('keeps a decomposed accent on the initial', () => {
+    assert.strictEqual(getInitials('Bestia N\u0303u'), 'B\u00d1');
+  });
+
+  // Same code-unit assumption, one step further out: an astral character is a
+  // surrogate pair, so w[0] would emit half of it.
+  it('does not split an astral character in half', () => {
+    assert.strictEqual(getInitials('\u{1F409} Dragon'), '\u{1F409}D');
+  });
 });
 
 describe('getPCs', () => {

--- a/tools/publish/test/unit/relationship-graph.test.js
+++ b/tools/publish/test/unit/relationship-graph.test.js
@@ -86,3 +86,37 @@ describe('index-page exclusion', () => {
     assert.ok(graph.edges.some(e => e.from === 'Hero' && e.to === 'Villain'));
   });
 });
+
+describe('renderRelationshipSVG label truncation', () => {
+  const { renderRelationshipSVG } = require('../../lib/relationship-graph');
+
+  // #157: the cap counts UTF-16 code units, so a decomposed accent spent one of
+  // the 15 budgeted characters. "La Desaparición" fits composed and rendered as
+  // "La Desaparici…" decomposed — same visible name, two different labels.
+  it('does not truncate a decomposed name that fits when composed', () => {
+    const nfc = 'La Desaparición';
+    const nfd = nfc.normalize('NFD');
+    assert.notStrictEqual(nfd, nfc, 'fixture must actually differ by normal form');
+    const graph = {
+      nodes: [
+        { id: 'Hero', displayTitle: 'Hero', hop: 0, shape: 'circle' },
+        { id: 'X', displayTitle: nfd, hop: 1, shape: 'circle' },
+      ],
+      edges: [{ from: 'Hero', to: 'X', type: 'knows' }],
+    };
+    const svg = renderRelationshipSVG(graph, {});
+    assert.ok(svg.includes(nfc), 'renders the full composed name');
+    assert.ok(!svg.includes('…'), 'nothing was truncated');
+  });
+
+  it('still truncates a name that is genuinely too long', () => {
+    const graph = {
+      nodes: [
+        { id: 'Hero', displayTitle: 'Hero', hop: 0, shape: 'circle' },
+        { id: 'X', displayTitle: 'The Extremely Long Location Name', hop: 1, shape: 'circle' },
+      ],
+      edges: [{ from: 'Hero', to: 'X', type: 'knows' }],
+    };
+    assert.ok(renderRelationshipSVG(graph, {}).includes('…'), 'long label is capped');
+  });
+});

--- a/tools/publish/test/unit/run-command.test.js
+++ b/tools/publish/test/unit/run-command.test.js
@@ -17,3 +17,24 @@ describe('runCommand', () => {
     assert.ok(res.error, 'error code surfaced on timeout');
   });
 });
+
+// A bounded wrangler call that times out has NOTHING in stdout/stderr — spawnSync
+// reports it via `error`. Diagnostics built from stdout/stderr alone therefore come
+// out blank, which is the same blank a caller sees on success-with-no-output. The
+// timeouts added in #160 are only useful if the resulting failure says something.
+describe('failureDetail', () => {
+  const { failureDetail } = require('../../lib/run-command');
+
+  it('falls back to the process error when there is no output', () => {
+    assert.equal(failureDetail({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }), 'ETIMEDOUT');
+  });
+
+  it('prefers real output over the process error', () => {
+    assert.equal(failureDetail({ code: 1, stdout: '', stderr: 'boom', error: 'ETIMEDOUT' }), 'boom');
+    assert.equal(failureDetail({ code: 1, stdout: 'out', stderr: '', error: 'ETIMEDOUT' }), 'out');
+  });
+
+  it('falls back to the exit code when there is nothing else', () => {
+    assert.equal(failureDetail({ code: 3, stdout: '', stderr: '', error: null }), 'exit 3');
+  });
+});

--- a/tools/publish/test/unit/setup-backend.test.js
+++ b/tools/publish/test/unit/setup-backend.test.js
@@ -93,3 +93,19 @@ test('the wrangler call backend setup runs through is bounded by a timeout', () 
     `expected a finite positive timeoutMs, got ${JSON.stringify(seen[0].opts)}`);
   assert.equal(seen[0].opts.timeoutMs, WRANGLER_TIMEOUT_MS);
 });
+
+// #161 review: the wrappers dropped run-command's `error`, so a timed-out or
+// un-spawnable wrangler produced "wrangler could not list KV namespaces: " with
+// nothing after the colon — indistinguishable from a silent success.
+test('a permission check on a timed-out wrangler names the failure', () => {
+  const res = checkKvPermission({ runWrangler: () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }) });
+  assert.equal(res.ok, false);
+  assert.match(res.fix, /ETIMEDOUT/);
+});
+
+test('the backend-setup wrapper passes the process error through', () => {
+  const { defaultRunWrangler } = require('../../lib/setup-backend');
+  const res = defaultRunWrangler(['kv', 'namespace', 'list'], {},
+    () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }));
+  assert.equal(res.error, 'ETIMEDOUT');
+});

--- a/tools/publish/test/unit/setup-backend.test.js
+++ b/tools/publish/test/unit/setup-backend.test.js
@@ -73,3 +73,23 @@ test('ensureKvNamespace creates when only the placeholder is present (never list
   assert.ok(!calls.some((a) => a.join(' ') === 'kv namespace list'));
   assert.deepStrictEqual(calls, [['kv', 'namespace', 'create', 'INBOX']]);
 });
+
+// #160 audit: setup-backend is the third wrangler entry point and was the other
+// unbounded spawn. Its calls are quick control-plane ones (kv namespace
+// list/create), so a stall means a wedged setup with no error.
+test('the wrangler call backend setup runs through is bounded by a timeout', () => {
+  const { defaultRunWrangler, WRANGLER_TIMEOUT_MS } = require('../../lib/setup-backend');
+  const seen = [];
+  const res = defaultRunWrangler(['kv', 'namespace', 'list'], { cwd: '/site' }, (cmd, args, opts) => {
+    seen.push({ cmd, args, opts });
+    return { code: 0, stdout: '[]', stderr: '' };
+  });
+  assert.equal(res.code, 0);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].cmd, 'npx');
+  assert.deepEqual(seen[0].args, ['wrangler@4', 'kv', 'namespace', 'list']);
+  assert.equal(seen[0].opts.cwd, '/site', 'cwd still reaches the child');
+  assert.ok(Number.isFinite(seen[0].opts.timeoutMs) && seen[0].opts.timeoutMs > 0,
+    `expected a finite positive timeoutMs, got ${JSON.stringify(seen[0].opts)}`);
+  assert.equal(seen[0].opts.timeoutMs, WRANGLER_TIMEOUT_MS);
+});


### PR DESCRIPTION
The five follow-up bugs filed off the 1.8.49 review, closed as one pass.
One commit per issue, so this can be split into per-issue branches with
cherry-picks if preferred. Kept as one branch because five branches off
main would each need their own version bump and CHANGELOG entry.

Plugin 1.8.50, publish tool 1.11.23. Suite 1431 passing.

Closes #155
Closes #156
Closes #157
Closes #158
Closes #160

## Two issues were wrong as filed

**#156 said the two ref clauses were unreachable dead code and proposed
deleting them.** They are reachable. The chapters index is built from every
page under `chapters/`, subfolders included, so a session filed in one
chapter's folder whose `chapter:` ref names another hits the ref tests *and*
the folder test — and was listed under **both** chapters. Confirmed with a
probe, then mutation-tested by deleting the clauses and watching the
double-listing collapse to a single entry.

Deleting them leaves the entire suite green, which is exactly why a
code-reading audit called them dead: the gap was coverage, not
reachability. Fixed by making an explicit ref outrank the folder, with the
fallback pinned by two control tests.

**#158 also suspected the flush-side comparison.** It is already safe: flush
keys on `slugify(title)`, and slugify NFD-normalizes and strips combining
marks, so both sides agree whatever normal form the source file uses. Only
the emitted attribute needed fixing.

## The fixes

- **#158** — `data-character` was emitted unnormalized. It is the one
  author-typed string that leaves the build and returns at runtime, as the
  inbox entry's `character`, matched against vault note names. A decomposed
  name never matched a composed note title.
- **#160** — `flush-cli` and `setup-backend` still spawned wrangler with no
  timeout. Both now route through `runCommand` on the same 60s bound the
  inbox poll got, and the constant moved to `run-command.js` rather than
  being copied a third time. `runCommand` gained a `cwd` passthrough, which
  is why setup-backend had its own raw spawn. `inbox-wrangler`, the third
  entry point named in the issue, spawns nothing itself.
- **#157** — card initials and graph labels counted UTF-16 code units, so a
  decomposed accent dropped off an initial and cost a label one of its
  fifteen characters. Both now measure graphemes, which also keeps astral
  characters whole. Display-side helpers, marked as such — no emitted path
  or URL is normalized, and the #139 pinning tests still pass.
- **#155** — deleted `scoreNPCs` and its only reader `IMPORTANCE_TAGS`.
  Nothing but its own test called it, `scoreByRecency` superseded it, and it
  carried an unfixed copy of the #139 ref-matching bug.

## Testing

Every fix was written test-first. Where the initial failure was a missing
test seam rather than the assertion under test, the fix was mutation-tested
afterwards to confirm the assertion actually catches the defect.

Suite 1431 passing, including the #139 differential unicode build and the
`unicode-lookup` pinning test. Schema and ontology validation pass. No skill
files changed.