### PR TITLE
session-prep: pick the session by chapter, and actually read _midwife/

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.50",
+  "version": "1.8.51",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.51] — 2026-08-17
 
-Session-prep picked the wrong session in vaults whose numbering restarts
-each chapter.
+Two session-prep bugs found in one live prep pass: the wrong session picked
+in vaults whose numbering restarts each chapter, and a chapter's midwife
+design never read at all.
 
 ### Fixed
 
@@ -27,6 +28,19 @@ each chapter.
   on directory walk order. Where the answer is ambiguous — a stale overview
   pointer, a number appearing in more than one chapter — the bundle now says
   so instead of choosing quietly (#162).
+- `session-prep`/`session-play`: neither skill ever read `_midwife/`. Step
+  10c scanned only `Chapters/{chapter}/Planning/` and matched on `plan_type`
+  frontmatter, so a chapter whose forward design lived in `_midwife/` was
+  reported as having no plans and scene structure was generated from
+  scratch, contradicting a day-by-day timeline already sitting in the vault.
+  Both skills now read `_midwife/{chapter-slug}/` by path rather than
+  frontmatter — those files carry none by design — with `timeline.md`
+  surfaced before scene design begins. `vault-structure.md` now states both
+  halves of the posture: `campaign-qa` ignores `_midwife/` for auditing,
+  prep and play read it for design. An empty result is no longer written up
+  as a vault gap, which was a claim about the vault when the real cause was
+  a scan that never opened the directory (#163).
+
 - `session-prep`/`campaign-qa`: a quoted wikilink reaches the frontmatter
   reader as a one-item list (`"[[Note]]"` parses as a YAML flow sequence),
   so reading `last_session` as a string silently disabled the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,12 @@ design never read at all.
   months-stale wrap-up, the wrong PC world-state, and a meaningless "no
   existing plan" — all of it reading as authoritative. Selection now
   follows the campaign overview's `last_session`, falling back to the most
-  recent `play_date`, and every downstream lookup is scoped to the selected
-  session's chapter. Sessions are keyed on `(chapter, number)` rather than
+  recent `play_date`, and the session-anchored lookups (wrap-up, upcoming
+  plan) are scoped to the selected session's chapter — the rest of the bundle
+  stays vault-wide, which is correct for PCs, flags, and the overview. A
+  document that names no chapter no longer outranks the chapter's own by
+  sorting earlier, and a chapter ref written as a path keys the same as one
+  written as a folder name. Sessions are keyed on `(chapter, number)` rather than
   the bare integer, which two chapters could silently collide on depending
   on directory walk order. Where the answer is ambiguous — a stale overview
   pointer, a number appearing in more than one chapter — the bundle now says

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.51] — 2026-08-17
+
+Session-prep picked the wrong session in vaults whose numbering restarts
+each chapter.
+
+### Fixed
+
+- `session-prep`: `session_context.py` chose "just played" by taking a
+  vault-wide `max()` over `session_number`. Where numbering restarts per
+  chapter that is not a campaign-wide ordinal, so a finished chapter's
+  higher-numbered session won permanently and the bundle handed back a
+  months-stale wrap-up, the wrong PC world-state, and a meaningless "no
+  existing plan" — all of it reading as authoritative. Selection now
+  follows the campaign overview's `last_session`, falling back to the most
+  recent `play_date`, and every downstream lookup is scoped to the selected
+  session's chapter. Sessions are keyed on `(chapter, number)` rather than
+  the bare integer, which two chapters could silently collide on depending
+  on directory walk order. Where the answer is ambiguous — a stale overview
+  pointer, a number appearing in more than one chapter — the bundle now says
+  so instead of choosing quietly (#162).
+- `session-prep`/`campaign-qa`: a quoted wikilink reaches the frontmatter
+  reader as a one-item list (`"[[Note]]"` parses as a YAML flow sequence),
+  so reading `last_session` as a string silently disabled the
+  authoritative-metadata path entirely. `wikilink_target` now unwraps it.
+- `campaign-qa`: `vault_check.py stale-drafts` carried the same flat
+  assumption, measuring every draft against the vault-wide highest session
+  number. In a restarting vault that made the live chapter's newest content
+  read as many sessions old and told the GM to "promote to AUTHORITATIVE or
+  delete" it. Staleness is now measured within a chapter; a draft that names
+  no chapter in such a vault is reported as undatable rather than judged
+  against an unrelated chapter's count.
+
+---
+
 ## [1.8.50] — 2026-08-17
 
 Publish tool 1.11.23. The five follow-up bugs left open by the 1.8.49

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -96,7 +96,7 @@ Route these requests directly — don't search, load the file.
 | Scene fell flat | `ttrpg-expert/active-play-management.md` §Mid-Session Adjustments |
 | Pacing / tension | `ttrpg-expert/active-play-management.md` §Pacing and Flow |
 | Improvisation help | `ttrpg-expert/active-play-management.md` §Improvisation |
-| Narrative plan | `Chapters/{chapter}/Planning/` — read the relevant plan entity (scene designs, arc structure, investigation flow, or timeline) |
+| Narrative plan | `Chapters/{chapter}/Planning/` — read the relevant plan entity (scene designs, arc structure, investigation flow, or timeline). Also check `_midwife/{chapter-slug}/`, found by path not frontmatter (those files carry none) — chapter design often lives only there, `timeline.md` and `npcs/` first |
 
 Read `ttrpg-expert/active-play-management.md` when the GM needs
 GM-craft advice (spotlight, pacing, improv, difficulty tuning)

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -96,7 +96,7 @@ Route these requests directly — don't search, load the file.
 | Scene fell flat | `ttrpg-expert/active-play-management.md` §Mid-Session Adjustments |
 | Pacing / tension | `ttrpg-expert/active-play-management.md` §Pacing and Flow |
 | Improvisation help | `ttrpg-expert/active-play-management.md` §Improvisation |
-| Narrative plan | `Chapters/{chapter}/Planning/` — read the relevant plan entity (scene designs, arc structure, investigation flow, or timeline). Also check `_midwife/{chapter-slug}/`, found by path not frontmatter (those files carry none) — chapter design often lives only there, `timeline.md` and `npcs/` first |
+| Narrative plan | `Chapters/{chapter}/Planning/` — read the relevant plan entity (scene designs, arc structure, investigation flow, or timeline). Also check the midwife workspace, which is often the only place the design lives: resolve the adventure directory via `_midwife/index.md` (dirs are named per adventure, not per chapter) and read by path, not frontmatter — those files carry none. `timeline.md` and `npcs/` first; if the manifest leaves it ambiguous, ask rather than guess |
 
 Read `ttrpg-expert/active-play-management.md` when the GM needs
 GM-craft advice (spotlight, pacing, improv, difficulty tuning)

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -181,30 +181,65 @@ what's already established.
 
 #### Step 10c: Narrative plans
 
-If `Chapters/{chapter}/Planning/` exists, scan it for plan
-entities relevant to the upcoming session:
+Forward design for a chapter lives in **two** places and you
+must check both. `Chapters/{chapter}/Planning/` holds stamped
+plan entities. `_midwife/{chapter-slug}/` holds whatever a
+midwife session produced — often the richer of the two, and
+frequently the only one populated.
 
-1. Read all files in `Planning/` and categorize by
-   `plan_type` (arc, scene, investigation, timeline)
+**A. `Chapters/{chapter}/Planning/`**, if it exists:
+
+1. Read all files and categorize by `plan_type` (arc, scene,
+   investigation, timeline)
 2. Surface scene plans whose `participants` or `locations`
    overlap with the threads, NPCs, or locations already
    gathered in steps 8-10
-3. Present a brief summary:
+
+**B. `_midwife/{chapter-slug}/`**, if it exists. Match the
+slug loosely — a chapter titled "Chapter 4 - Calcutta" maps
+to `chapter-4-calcutta`; if no directory matches, list
+`_midwife/` and pick by name.
+
+Discover these by **path, not frontmatter**. Midwife files are
+creative working documents and carry no `---` block at all, so
+a `plan_type` scan finds nothing however wide its root. Read
+each file's `#` H1 and `##` headings to summarise it.
+
+**Read `timeline.md` first if one exists.** A midwife
+day-by-day timeline is the highest-value prep artifact in the
+tree: it says which beats belong to the upcoming days and,
+just as importantly, which must not be pulled forward. Surface
+it *before* any scene design in Phase 2, not after — scene
+work invented against an unread timeline contradicts it, and
+the GM is the one who has to catch that.
+
+3. Present a brief summary of both roots:
 
 > **Narrative plans available for this chapter:**
 > - Arc: Arc_Shape.md — four-phase dramatic structure
 > - Scenes: Temple_Approach.md, Recognition_Scene.md,
 >   Escort_Betrayal.md — scene designs with decision trees
 > - Investigation: Investigation_Design.md — clue flow
+> - Midwife design (`_midwife/chapter-4-calcutta/`, 55 files):
+>   timeline.md — day-by-day skeleton, all 18 days;
+>   chapter-shape.md, narrative-arc.md, social-events.md;
+>   npcs/ profiles; handouts/ prose
 >
 > **Most relevant for next session:** [list based on thread
-> and NPC overlap]
+> and NPC overlap, and on which days the timeline assigns]
 
 Do not copy plan content into the session plan — link to
 it. Plans are reference documents the GM consults during
-play, not material to be duplicated.
+play, not material to be duplicated. This applies to
+`_midwife/` exactly as it does to `Planning/`.
 (rationale: `shared/content-fidelity.md`)
 → Write `## Available Plans` to Plan file.
+
+**If both roots are empty, say that plainly** — "no narrative
+plans found for this chapter" — and do not write it up as a
+vault gap. A Gap/Action asserting no plan entities exist is a
+claim about the vault, and it is false whenever the design is
+sitting in a directory this step failed to open.
 
 ## Phase 2: Prep Forward — Creative Planning (elicited)
 

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -183,7 +183,7 @@ what's already established.
 
 Forward design for a chapter lives in **two** places and you
 must check both. `Chapters/{chapter}/Planning/` holds stamped
-plan entities. `_midwife/{chapter-slug}/` holds whatever a
+plan entities. The `_midwife/` workspace holds whatever a
 midwife session produced — often the richer of the two, and
 frequently the only one populated.
 
@@ -195,15 +195,36 @@ frequently the only one populated.
    overlap with the threads, NPCs, or locations already
    gathered in steps 8-10
 
-**B. `_midwife/{chapter-slug}/`**, if it exists. Match the
-slug loosely — a chapter titled "Chapter 4 - Calcutta" maps
-to `chapter-4-calcutta`; if no directory matches, list
-`_midwife/` and pick by name.
+**B. The midwife workspace**, if `_midwife/` exists.
 
-Discover these by **path, not frontmatter**. Midwife files are
-creative working documents and carry no `---` block at all, so
-a `plan_type` scan finds nothing however wide its root. Read
-each file's `#` H1 and `##` headings to summarise it.
+Directories under `_midwife/` are named per **adventure**, not
+per chapter. An adventure may be a chapter, span several, or
+be named nothing like one — so do not guess a slug. Use the
+manifest:
+
+1. Read `_midwife/index.md` — the master list of adventures
+   and their status (Active / Parked / Complete / Ingested).
+2. Identify the adventure covering the upcoming chapter.
+   **Exactly one, or none.** If two or more could plausibly
+   match, or the manifest is missing and several directories
+   exist, say so and ask the GM which — do not pick. Prepping
+   against another chapter's timeline is the failure this
+   step exists to prevent.
+3. Read that adventure's `_midwife/{adventure}/index.md`,
+   which carries a one-line summary per topic file. Use it to
+   choose what to open rather than reading the whole tree.
+
+`Ingested` in the manifest means the design was already
+promoted into `Planning/`; root A then covers it and this root
+is history. Anything not yet ingested is exactly the case
+where `Planning/` is empty and this step is the only way the
+design gets seen.
+
+Discover these files by **path, not frontmatter**. Midwife
+files are creative working documents and carry no `---` block
+at all, so a `plan_type` scan finds nothing however wide its
+root. Read each file's `#` H1 and `##` headings to summarise
+it.
 
 **Read `timeline.md` first if one exists.** A midwife
 day-by-day timeline is the highest-value prep artifact in the
@@ -220,7 +241,7 @@ the GM is the one who has to catch that.
 > - Scenes: Temple_Approach.md, Recognition_Scene.md,
 >   Escort_Betrayal.md — scene designs with decision trees
 > - Investigation: Investigation_Design.md — clue flow
-> - Midwife design (`_midwife/chapter-4-calcutta/`, 55 files):
+> - Midwife design (`_midwife/{adventure}/`, 55 files):
 >   timeline.md — day-by-day skeleton, all 18 days;
 >   chapter-shape.md, narrative-arc.md, social-events.md;
 >   npcs/ profiles; handouts/ prose

--- a/skills/shared/scripts/schema_rules.py
+++ b/skills/shared/scripts/schema_rules.py
@@ -221,7 +221,11 @@ def chapter_of(rel: str, fm: dict) -> str | None:
     """
     ref = wikilink_target(fm.get("chapter"))
     if ref:
-        return ref
+        # A ref may be written as a path ("[[Chapters/Chapter 4 - Calcutta]]")
+        # while the folder fallback yields only the segment. Keep the last
+        # segment either way, or one chapter acquires two identities and stops
+        # matching its own wrap-ups and plans.
+        return ref.rsplit("/", 1)[-1]
     parts = rel.split("/")
     if len(parts) > 1 and parts[0].casefold() in {"chapters", "_chapters"}:
         return parts[1]

--- a/skills/shared/scripts/schema_rules.py
+++ b/skills/shared/scripts/schema_rules.py
@@ -191,6 +191,49 @@ def parse_session_number(value) -> int | None:
     return n if n <= MAX_PLAUSIBLE_SESSION else None
 
 
+def wikilink_target(value) -> str:
+    """Bare target of a `[[Link|alias]]`, or the plain string.
+
+    A quoted wikilink reaches us as a one-item list, not a string: the
+    frontmatter reader treats the outer `[...]` of `"[[Note]]"` as a YAML
+    flow sequence and yields `['[Note]']`. Rejecting lists here silently
+    disabled every wikilink-valued lookup, so unwrap the single-item case
+    and strip whatever brackets survive.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        if len(value) != 1:
+            return ""
+        value = value[0]
+    return re.sub(r"[\[\]]", "", str(value)).split("|")[0].split("#")[0].strip()
+
+
+def chapter_of(rel: str, fm: dict) -> str | None:
+    """Which chapter a note belongs to, or None if it cannot be told.
+
+    Session numbering restarts per chapter in real vaults, so a bare
+    `session_number` is not a campaign-wide ordinal (#162). The
+    frontmatter ref is authoritative; the path is the fallback for
+    vaults that file by folder without tagging. Returns None for a
+    flat vault, where number alone is the only ordering available and
+    is correct.
+    """
+    ref = wikilink_target(fm.get("chapter"))
+    if ref:
+        return ref
+    parts = rel.split("/")
+    if len(parts) > 1 and parts[0].casefold() in {"chapters", "_chapters"}:
+        return parts[1]
+    return None
+
+
+def chapter_key(rel: str, fm: dict) -> str | None:
+    """chapter_of, casefolded for comparison. None stays None."""
+    c = chapter_of(rel, fm)
+    return c.casefold() if c else None
+
+
 # Relationship predicate vocabulary
 #
 # The authoritative list is the predicate table in entity-schema.md; the

--- a/skills/shared/scripts/session_context.py
+++ b/skills/shared/scripts/session_context.py
@@ -130,12 +130,32 @@ def main() -> int:
         # behaviour and right for a flat vault.
         return max(entries, key=lambda s: (bool(s["date"]), s["date"], s["n"]))
 
+    def resolve_ref(ref, pool):
+        """The session a wikilink names: (record, problem).
+
+        An exact relative path wins outright. A bare stem is accepted only
+        when it identifies one file — two chapters can hold identically named
+        sessions, and picking the first off the walk is the collision this
+        whole change exists to remove.
+        """
+        target = ref.casefold()
+        exact = [s for s in pool if s["rel"][:-3].casefold() == target]
+        if len(exact) == 1:
+            return exact[0], None
+        if len(exact) > 1:
+            return None, "ambiguous"
+        base = target.rsplit("/", 1)[-1]
+        hits = [s for s in pool if stem_of(s) == base]
+        if len(hits) == 1:
+            return hits[0], None
+        return None, ("ambiguous" if hits else "missing")
+
     chosen = None
     if args.session is not None:
         matches = [s for s in sessions if s["n"] == args.session]
         if matches:
-            named = next((s for s in matches if overview_last and stem_of(s)
-                          == overview_last.casefold()), None)
+            named = (resolve_ref(overview_last, matches)[0]
+                     if overview_last else None)
             chosen = named or by_recency(matches)
             if len(matches) > 1:
                 others = [s["chapter_label"] or s["rel"] for s in matches
@@ -146,9 +166,14 @@ def main() -> int:
                     f"{', '.join(sorted(str(o) for o in others))}) — resolved "
                     f"to {chosen['chapter_label'] or chosen['rel']}.")
     elif overview_last:
-        target = overview_last.casefold()
-        chosen = next((s for s in sessions if stem_of(s) == target), None)
-        if chosen is None:
+        chosen, problem = resolve_ref(overview_last, sessions)
+        if problem == "ambiguous":
+            warnings.append(
+                f"Note: campaign overview names last_session "
+                f"'{overview_last}', which matches more than one session "
+                f"file — falling back to the most recently played session. "
+                f"Qualify the link with its folder to disambiguate.")
+        elif problem == "missing":
             warnings.append(
                 f"Note: campaign overview names last_session "
                 f"'{overview_last}', which matches no session file — "
@@ -204,22 +229,31 @@ def main() -> int:
     # vault where numbering restarts they could pair the right number with the
     # wrong chapter's documents. An unknown chapter on either side matches, which
     # keeps flat vaults working exactly as before.
-    def in_chapter(rel, fm):
-        other = chapter_key(rel, fm)
-        return chapter is None or other is None or other == chapter
+    def prefer_chapter(candidates):
+        """The selected chapter's own document, else an unfiled one.
 
-    wrap = next(
-        ((rel, text) for rel, text, fm in files
+        Accepting any unresolvable chapter equally let a document that merely
+        sorted earlier — an archived copy at the vault root — outrank the
+        chapter's real one. Scoped first, unscoped only as a fallback.
+        """
+        if chapter is not None:
+            own = [c for c in candidates if chapter_key(c[0], c[2]) == chapter]
+            if own:
+                return (own[0][0], own[0][1])
+        loose = [c for c in candidates
+                 if chapter is None or chapter_key(c[0], c[2]) is None]
+        return (loose[0][0], loose[0][1]) if loose else None
+
+    wrap = prefer_chapter(
+        [(rel, text, fm) for rel, text, fm in files
          if fm.get("type") in ("session-wrap-up", "session_wrap")
-         and parse_session_number(fm.get("session")) == current
-         and in_chapter(rel, fm)),
-        None)
+         and parse_session_number(fm.get("session")) == current])
     if wrap is None:
         # Fallback: filename convention Chapter_CC_Session_NN_Wrap_Up.md
         pat = re.compile(rf"Session[ _-]0*{current}[ _-].*Wrap[ _-]?Up",
                          re.IGNORECASE)
-        wrap = next(((rel, text) for rel, text, fm in files
-                     if pat.search(rel) and in_chapter(rel, fm)), None)
+        wrap = prefer_chapter([(rel, text, fm) for rel, text, fm in files
+                               if pat.search(rel)])
     emit(f"Wrap-Up — Session {current}",
          wrap[0] if wrap else None,
          body_of(wrap[1]) if wrap else None)
@@ -243,12 +277,10 @@ def main() -> int:
         print("(no active PC entities found)")
 
     # --- existing plan for the upcoming session ---
-    plan = next(
-        ((rel, text) for rel, text, fm in files
+    plan = prefer_chapter(
+        [(rel, text, fm) for rel, text, fm in files
          if fm.get("type") == "session-plan"
-         and parse_session_number(fm.get("session")) == upcoming
-         and in_chapter(rel, fm)),
-        None)
+         and parse_session_number(fm.get("session")) == upcoming])
     emit(f"Existing Plan — Session {upcoming}",
          plan[0] if plan else None,
          body_of(plan[1]) if plan else None)

--- a/skills/shared/scripts/session_context.py
+++ b/skills/shared/scripts/session_context.py
@@ -11,11 +11,22 @@ it needs to.
 Usage:
   session_context.py VAULT [--session N]
 
---session N treats N as the just-played session. The default is
-the highest `session_number` whose status is played/wrap-up/
-reviewed — pre-created `planned`/`prepped` indexes for the next
-session are ignored. Each section is headed with its source
-path; missing pieces are reported, not fatal.
+--session N treats N as the just-played session. Otherwise the
+campaign overview's `last_session` decides, and failing that the
+most recently played session by `play_date` — NOT the highest
+`session_number`, which is only a campaign-wide ordinal in vaults
+that never restart numbering per chapter (#162). Pre-created
+`planned`/`prepped` indexes for the next session are ignored.
+
+Everything downstream is scoped to the selected session's chapter,
+so a vault where two chapters each hold a Session 07 pairs the
+right wrap-up and plan. Where the answer is ambiguous — a stale
+overview pointer, a session number that appears in more than one
+chapter — the bundle says so rather than choosing quietly: a wrong
+bundle is worse than no bundle, because it reads as authoritative.
+
+Each section is headed with its source path; missing pieces are
+reported, not fatal.
 """
 
 import argparse
@@ -23,7 +34,8 @@ import re
 import sys
 from pathlib import Path
 
-from schema_rules import extract_frontmatter, parse_session_number
+from schema_rules import (chapter_key, chapter_of, extract_frontmatter,
+                          parse_session_number, wikilink_target)
 
 SKIP_DIRS = {"_Templates", "_templates", "_inbox"}
 
@@ -39,6 +51,11 @@ def vault_files(vault: Path):
         except OSError:
             continue
         yield rel, text, extract_frontmatter(text) or {}
+
+
+def stem_of(entry) -> str:
+    """Filename stem of a session record, casefolded, for ref matching."""
+    return entry["rel"].rsplit("/", 1)[-1][:-3].casefold()
 
 
 def section(text: str, heading: str) -> str | None:
@@ -78,33 +95,102 @@ def main() -> int:
     # or `prepped`, and that pre-created index must not shift the
     # bundle forward a session.
     PLAYED = {"played", "wrap-up", "reviewed"}
-    sessions, played = {}, {}
+    # A session is identified by (chapter, number), never by number alone:
+    # two chapters each having a Session 07 is normal, and keying on the bare
+    # integer let whichever was walked last silently win (#162).
+    sessions = []
     for rel, _text, fm in files:
         if fm.get("type") == "session":
             n = parse_session_number(fm.get("session_number"))
             if n is not None:
-                sessions[n] = (rel, fm)
-                if str(fm.get("status", "")).casefold() in PLAYED:
-                    played[n] = (rel, fm)
+                sessions.append({
+                    "rel": rel,
+                    "fm": fm,
+                    "n": n,
+                    "chapter": chapter_key(rel, fm),
+                    "chapter_label": chapter_of(rel, fm),
+                    "played": str(fm.get("status", "")).casefold() in PLAYED,
+                    "date": str(fm.get("play_date") or ""),
+                })
+    played = [s for s in sessions if s["played"]]
+
+    warnings = []
+
+    # The campaign overview states where the campaign actually stands, and it
+    # is the only vault-wide source that carries the chapter. Prefer it over
+    # any heuristic; fall back only when it is absent or does not resolve.
+    overview_fm = next((fm for rel, _t, fm in files
+                        if fm.get("type") == "campaign_overview"), None)
+    overview_last = wikilink_target((overview_fm or {}).get("last_session"))
+
+    def by_recency(entries):
+        # Most recently *played* wins, which is chapter-agnostic and therefore
+        # correct across a chapter restart. A vault with no play_date at all
+        # falls back to the highest number, which is the old single-chapter
+        # behaviour and right for a flat vault.
+        return max(entries, key=lambda s: (bool(s["date"]), s["date"], s["n"]))
+
+    chosen = None
     if args.session is not None:
-        current = args.session
-    elif played:
-        current = max(played)
-    elif sessions:
-        current = max(sessions)
-    else:
-        current = 0
+        matches = [s for s in sessions if s["n"] == args.session]
+        if matches:
+            named = next((s for s in matches if overview_last and stem_of(s)
+                          == overview_last.casefold()), None)
+            chosen = named or by_recency(matches)
+            if len(matches) > 1:
+                others = [s["chapter_label"] or s["rel"] for s in matches
+                          if s is not chosen]
+                warnings.append(
+                    f"Note: {len(matches)} sessions are numbered "
+                    f"{args.session} (also in "
+                    f"{', '.join(sorted(str(o) for o in others))}) — resolved "
+                    f"to {chosen['chapter_label'] or chosen['rel']}.")
+    elif overview_last:
+        target = overview_last.casefold()
+        chosen = next((s for s in sessions if stem_of(s) == target), None)
+        if chosen is None:
+            warnings.append(
+                f"Note: campaign overview names last_session "
+                f"'{overview_last}', which matches no session file — "
+                f"falling back to the most recently played session.")
+    if chosen is None and played:
+        chosen = by_recency(played)
+    elif chosen is None and sessions:
+        chosen = by_recency(sessions)
+
+    current = chosen["n"] if chosen else (args.session or 0)
+    chapter = chosen["chapter"] if chosen else None
     upcoming = current + 1
-    if current in sessions:
-        rel, fm = sessions[current]
-        status = fm.get("status", "?")
-        note = ""
-        pending = [n for n in sessions if n > current]
+
+    # A wrong bundle is worse than no bundle, because it reads as authoritative.
+    overview_as_of = str((overview_fm or {}).get("asOfSession") or "")
+    if chosen and overview_as_of and chapter:
+        # asOfSession is prose ("Chapter 4, Session 7"), so containment on the
+        # chapter's distinctive words is the most it can support.
+        as_of = overview_as_of.casefold()
+        head = re.split(r"[,;]", chapter.split("/")[-1])[0].strip()
+        if head and head not in as_of and not any(
+                w in as_of for w in head.split() if len(w) > 3):
+            warnings.append(
+                f"Note: campaign overview reads asOfSession "
+                f"'{overview_as_of}', but the selected session is in "
+                f"'{chosen['chapter_label']}' — verify before trusting "
+                f"this bundle.")
+
+    if chosen:
+        note = "".join(f"\n{w}" for w in warnings)
+        # Only sessions in the SAME chapter can be "later" — a higher number in
+        # a finished chapter is history, not a pre-created index.
+        pending = sorted(s["n"] for s in sessions
+                         if s["n"] > current and s["chapter"] == chapter)
         if pending:
-            note = (f"\nNote: session index(es) {sorted(pending)} exist "
-                    f"with unplayed status — ignored for 'just played'.")
+            note += (f"\nNote: session index(es) {pending} exist "
+                     f"with unplayed status — ignored for 'just played'.")
+        where = (f", chapter: {chosen['chapter_label']}"
+                 if chosen["chapter_label"] else "")
         print(f"===== Session Context =====\n"
-              f"Just played: session {current} ({rel}, status: {status})\n"
+              f"Just played: session {current} ({chosen['rel']}, "
+              f"status: {chosen['fm'].get('status', '?')}{where})\n"
               f"Preparing: session {upcoming}{note}")
     else:
         print(f"===== Session Context =====\n"
@@ -113,17 +199,27 @@ def main() -> int:
               f"Preparing session {upcoming}.")
 
     # --- latest wrap-up ---
+    # Scoped to the chapter as well as the number: the wrap-up and plan lookups
+    # carried the same flat-namespace assumption as the selection above, so in a
+    # vault where numbering restarts they could pair the right number with the
+    # wrong chapter's documents. An unknown chapter on either side matches, which
+    # keeps flat vaults working exactly as before.
+    def in_chapter(rel, fm):
+        other = chapter_key(rel, fm)
+        return chapter is None or other is None or other == chapter
+
     wrap = next(
         ((rel, text) for rel, text, fm in files
          if fm.get("type") in ("session-wrap-up", "session_wrap")
-         and parse_session_number(fm.get("session")) == current),
+         and parse_session_number(fm.get("session")) == current
+         and in_chapter(rel, fm)),
         None)
     if wrap is None:
         # Fallback: filename convention Chapter_CC_Session_NN_Wrap_Up.md
         pat = re.compile(rf"Session[ _-]0*{current}[ _-].*Wrap[ _-]?Up",
                          re.IGNORECASE)
         wrap = next(((rel, text) for rel, text, fm in files
-                     if pat.search(rel)), None)
+                     if pat.search(rel) and in_chapter(rel, fm)), None)
     emit(f"Wrap-Up — Session {current}",
          wrap[0] if wrap else None,
          body_of(wrap[1]) if wrap else None)
@@ -150,7 +246,8 @@ def main() -> int:
     plan = next(
         ((rel, text) for rel, text, fm in files
          if fm.get("type") == "session-plan"
-         and parse_session_number(fm.get("session")) == upcoming),
+         and parse_session_number(fm.get("session")) == upcoming
+         and in_chapter(rel, fm)),
         None)
     emit(f"Existing Plan — Session {upcoming}",
          plan[0] if plan else None,

--- a/skills/shared/scripts/vault_check.py
+++ b/skills/shared/scripts/vault_check.py
@@ -43,6 +43,7 @@ from schema_rules import (
     extract_frontmatter,
     inverse_predicates,
     iter_relationship_predicates,
+    chapter_key,
     parse_session_number,
     predicate_problem,
     predicate_vocabulary,
@@ -283,13 +284,21 @@ def check_index(vault: Path) -> list[str]:
 
 def check_stale_drafts(vault: Path) -> list[str]:
     files = list(vault_files(vault))
-    current = 0
+    # Staleness is "how many sessions ago", which only means something inside a
+    # chapter: numbering restarts, so a vault-wide max() made every draft in the
+    # live chapter look many sessions old and told the GM to promote or delete
+    # content written last week (#162). Track the latest session per chapter and
+    # measure each draft against its own chapter's.
+    per_chapter: dict[str | None, int] = {}
     for rel, text in files:
         fm = extract_frontmatter(text) or {}
         if fm.get("type") == "session":
             n = parse_session_number(fm.get("session_number"))
             if n:
-                current = max(current, n)
+                key = chapter_key(rel, fm)
+                per_chapter[key] = max(per_chapter.get(key, 0), n)
+    current = max(per_chapter.values(), default=0)
+    chaptered = len([k for k in per_chapter if k is not None]) > 1
     rows = []
     if not current:
         return ["INFO\t(vault)\tno session entities with "
@@ -301,16 +310,27 @@ def check_stale_drafts(vault: Path) -> list[str]:
         if fm.get("type") == "session-plan":
             continue  # prep content is always DRAFT — exempt
         created = parse_session_number(fm.get("createdSession"))
+        own = chapter_key(rel, fm)
+        if chaptered and own is None and created is not None:
+            # Numbering restarts per chapter and this note names none, so its
+            # createdSession cannot be placed on any timeline. Saying so beats
+            # guessing against an unrelated chapter's count.
+            rows.append(f"INFO\t{rel}\tDRAFT createdSession ({created}) "
+                        f"cannot be dated — this vault numbers sessions per "
+                        f"chapter and the note names no chapter")
+            continue
+        # Its own chapter's latest where known, else the vault-wide latest.
+        now = per_chapter.get(own, current)
         if created is None:
             rows.append(f"WARNING\t{rel}\tDRAFT missing createdSession — "
                         f"cannot determine staleness; add it or promote")
-        elif created > current:
+        elif created > now:
             rows.append(f"WARNING\t{rel}\tcreatedSession ({created}) "
-                        f"exceeds current session ({current}) — check "
+                        f"exceeds current session ({now}) — check "
                         f"the value (dates don't belong in this field)")
-        elif current - created >= 3:
+        elif now - created >= 3:
             rows.append(f"WARNING\t{rel}\tstale DRAFT (created session "
-                        f"{created}, now session {current}) — promote "
+                        f"{created}, now session {now}) — promote "
                         f"to AUTHORITATIVE or delete")
     return rows
 

--- a/skills/shared/vault-access.md
+++ b/skills/shared/vault-access.md
@@ -75,6 +75,17 @@ campaign overview — each section tagged with its source path.
 Drill into individual files only where the digest shows the
 need.
 
+Which session counts as "just played" comes from the campaign
+overview's `last_session`, falling back to the most recent
+`play_date` — not the highest `session_number`, which is not a
+campaign-wide ordinal in a vault whose numbering restarts each
+chapter. Everything in the bundle is scoped to that session's
+chapter. **A `Note:` line in the header means the choice was
+ambiguous** — a stale overview pointer, or a session number
+that appears in more than one chapter. Confirm it with the GM
+before trusting the bundle; a wrong bundle reads exactly as
+authoritative as a right one.
+
 `stamp_entities.py <vault> FILE... --session N --date
 YYYY-MM-DD [--retag OLD=NEW]` batch-stamps `asOfSession`,
 `lastUpdated`, and a chapter-tag swap across files. Dry-run

--- a/skills/shared/vault-access.md
+++ b/skills/shared/vault-access.md
@@ -79,12 +79,17 @@ Which session counts as "just played" comes from the campaign
 overview's `last_session`, falling back to the most recent
 `play_date` — not the highest `session_number`, which is not a
 campaign-wide ordinal in a vault whose numbering restarts each
-chapter. Everything in the bundle is scoped to that session's
-chapter. **A `Note:` line in the header means the choice was
-ambiguous** — a stale overview pointer, or a session number
-that appears in more than one chapter. Confirm it with the GM
-before trusting the bundle; a wrong bundle reads exactly as
-authoritative as a right one.
+chapter. The session-anchored lookups — the wrap-up and the
+upcoming plan — are then scoped to that session's chapter. The
+rest of the bundle stays vault-wide, as it should: active PCs,
+deferred flags, and the campaign overview are not per-chapter.
+
+**A `Note:` line in the header means read before trusting.** It
+appears when the choice was ambiguous (a `last_session` pointer
+that resolves to nothing or to several files, a session number
+present in more than one chapter) and when later session
+indexes were ignored as unplayed. Confirm it with the GM: a
+wrong bundle reads exactly as authoritative as a right one.
 
 `stamp_entities.py <vault> FILE... --session N --date
 YYYY-MM-DD [--retag OLD=NEW]` batch-stamps `asOfSession`,

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -175,12 +175,21 @@ scans seeds for relevant prior ideas.
 scratchpad should not be linted for schema compliance.
 
 **That is an auditing rule, not a general one.** `session-prep`
-and `session-play` must *read* `_midwife/{chapter-slug}/`: it is
-where a chapter's forward design actually lives once a midwife
-session has run, and it is often the only place it lives, with
+and `session-play` must *read* the workspace: it is where a
+chapter's forward design actually lives once a midwife session
+has run, and it is often the only place it lives, with
 `Chapters/{chapter}/Planning/` left empty. A prep pass that
 skips it will invent scene structure that contradicts a
 timeline already sitting in the vault.
+
+**Directories here are named per adventure, not per chapter**
+(`_midwife/{adventure-name}/`, as written above). An adventure
+may be one chapter, several, or carry a name resembling
+neither. Readers must therefore resolve the directory through
+`_midwife/index.md`, the master manifest, rather than deriving
+a slug from the chapter title — and where the manifest leaves
+the match ambiguous, ask rather than guess. `Ingested` status
+means the design was already promoted into `Planning/`.
 
 Discover these files **by path**. They are creative working
 documents and carry no frontmatter, so any scan keyed on

--- a/skills/shared/vault-structure.md
+++ b/skills/shared/vault-structure.md
@@ -169,7 +169,23 @@ idea is generated but not used, it goes to the appropriate
 seed category. When starting a new adventure, the midwife
 scans seeds for relevant prior ideas.
 
-`campaign-qa` ignores `_midwife/` during audits.
+### Who reads `_midwife/`
+
+`campaign-qa` ignores `_midwife/` during audits — a creative
+scratchpad should not be linted for schema compliance.
+
+**That is an auditing rule, not a general one.** `session-prep`
+and `session-play` must *read* `_midwife/{chapter-slug}/`: it is
+where a chapter's forward design actually lives once a midwife
+session has run, and it is often the only place it lives, with
+`Chapters/{chapter}/Planning/` left empty. A prep pass that
+skips it will invent scene structure that contradicts a
+timeline already sitting in the vault.
+
+Discover these files **by path**. They are creative working
+documents and carry no frontmatter, so any scan keyed on
+`type:` or `plan_type` finds nothing there regardless of its
+root. Read them, link to them, never copy them.
 
 ## World Layer
 

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 3 - Vienna/Sessions/Chapter_03_Session_14_Wrap_Up.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 3 - Vienna/Sessions/Chapter_03_Session_14_Wrap_Up.md
@@ -1,0 +1,13 @@
+---
+type: session_wrap
+session: 14
+chapter: "[[Chapter 3 - Vienna]]"
+canon_status: DRAFT
+createdSession: 14
+---
+
+# Session 14 Wrap-Up
+
+## Narrative Recap
+
+The Vienna opera burned and the party fled west.

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 3 - Vienna/Sessions/Session 07.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 3 - Vienna/Sessions/Session 07.md
@@ -1,0 +1,10 @@
+---
+type: session
+session_number: 7
+status: reviewed
+chapter: "[[Chapter 3 - Vienna]]"
+play_date: "2026-02-12"
+documents: []
+---
+
+# Vienna Session 07

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 3 - Vienna/Sessions/Session 14.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 3 - Vienna/Sessions/Session 14.md
@@ -1,0 +1,10 @@
+---
+type: session
+session_number: 14
+status: reviewed
+chapter: "[[Chapter 3 - Vienna]]"
+play_date: "2026-05-21"
+documents: []
+---
+
+# Session 14

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 4 - Calcutta/Sessions/Chapter_04_Session_07_Wrap_Up.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 4 - Calcutta/Sessions/Chapter_04_Session_07_Wrap_Up.md
@@ -1,0 +1,13 @@
+---
+type: session_wrap
+session: 7
+chapter: "[[Chapter 4 - Calcutta]]"
+canon_status: DRAFT
+createdSession: 7
+---
+
+# Session 7 Wrap-Up
+
+## Narrative Recap
+
+The sterile bay swallowed the tide gauge.

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 4 - Calcutta/Sessions/Session 07 - The Sterile Bay.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Chapters/Chapter 4 - Calcutta/Sessions/Session 07 - The Sterile Bay.md
@@ -1,0 +1,10 @@
+---
+type: session
+session_number: 7
+status: reviewed
+chapter: "[[Chapter 4 - Calcutta]]"
+play_date: "2026-07-30"
+documents: []
+---
+
+# Session 07 - The Sterile Bay

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Characters/PCs/Hero.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Characters/PCs/Hero.md
@@ -1,0 +1,11 @@
+---
+type: pc
+status: active
+asOfSession: "Chapter 4, Session 7"
+---
+
+# Hero
+
+## Current Status
+
+Camped at the sterile bay.

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/Overview.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/Overview.md
@@ -1,0 +1,11 @@
+---
+type: campaign_overview
+canon_status: AUTHORITATIVE
+status: in_progress
+last_session: "[[Session 09 - The Drowned Godown]]"
+---
+
+# Overview
+
+Calcutta, 1814. last_session points at a session file that does not exist —
+selection must say so and fall back rather than silently guess.

--- a/tests/fixtures/mini-vault-prep-chapters-nolink/_World/_flags.md
+++ b/tests/fixtures/mini-vault-prep-chapters-nolink/_World/_flags.md
@@ -1,0 +1,10 @@
+---
+type: world_flags
+canon_status: DRAFT
+---
+
+# Flags
+
+## Deferred
+
+The dredger's owner is still unnamed.

--- a/tests/fixtures/mini-vault-prep-chapters/Archive_Session_07_Wrap_Up.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Archive_Session_07_Wrap_Up.md
@@ -1,0 +1,12 @@
+---
+type: session_wrap
+session: 7
+canon_status: AUTHORITATIVE
+createdSession: 7
+---
+
+# Archived Session 7 Wrap-Up
+
+## Narrative Recap
+
+An unfiled wrap-up carrying no chapter, sorted before Chapters/ on purpose.

--- a/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 3 - Vienna/Sessions/Chapter_03_Session_14_Wrap_Up.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 3 - Vienna/Sessions/Chapter_03_Session_14_Wrap_Up.md
@@ -1,0 +1,13 @@
+---
+type: session_wrap
+session: 14
+chapter: "[[Chapter 3 - Vienna]]"
+canon_status: DRAFT
+createdSession: 14
+---
+
+# Session 14 Wrap-Up
+
+## Narrative Recap
+
+The Vienna opera burned and the party fled west.

--- a/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 3 - Vienna/Sessions/Session 07.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 3 - Vienna/Sessions/Session 07.md
@@ -1,0 +1,10 @@
+---
+type: session
+session_number: 7
+status: reviewed
+chapter: "[[Chapter 3 - Vienna]]"
+play_date: "2026-02-12"
+documents: []
+---
+
+# Vienna Session 07

--- a/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 3 - Vienna/Sessions/Session 14.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 3 - Vienna/Sessions/Session 14.md
@@ -1,0 +1,10 @@
+---
+type: session
+session_number: 14
+status: reviewed
+chapter: "[[Chapter 3 - Vienna]]"
+play_date: "2026-05-21"
+documents: []
+---
+
+# Session 14

--- a/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 4 - Calcutta/Sessions/Chapter_04_Session_07_Wrap_Up.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 4 - Calcutta/Sessions/Chapter_04_Session_07_Wrap_Up.md
@@ -1,0 +1,13 @@
+---
+type: session_wrap
+session: 7
+chapter: "[[Chapter 4 - Calcutta]]"
+canon_status: DRAFT
+createdSession: 7
+---
+
+# Session 7 Wrap-Up
+
+## Narrative Recap
+
+The sterile bay swallowed the tide gauge.

--- a/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 4 - Calcutta/Sessions/Session 07 - The Sterile Bay.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 4 - Calcutta/Sessions/Session 07 - The Sterile Bay.md
@@ -1,0 +1,10 @@
+---
+type: session
+session_number: 7
+status: reviewed
+chapter: "[[Chapter 4 - Calcutta]]"
+play_date: "2026-07-30"
+documents: []
+---
+
+# Session 07 - The Sterile Bay

--- a/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 4 - Calcutta/Sessions/Session_08_Plan.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Chapters/Chapter 4 - Calcutta/Sessions/Session_08_Plan.md
@@ -1,0 +1,12 @@
+---
+type: session-plan
+session: 8
+chapter: "[[Chapter 4 - Calcutta]]"
+canon_status: DRAFT
+---
+
+# Session 8 Plan
+
+## Scene 1
+
+Follow the dredger's manifest inland.

--- a/tests/fixtures/mini-vault-prep-chapters/Characters/PCs/Hero.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Characters/PCs/Hero.md
@@ -1,0 +1,11 @@
+---
+type: pc
+status: active
+asOfSession: "Chapter 4, Session 7"
+---
+
+# Hero
+
+## Current Status
+
+Camped at the sterile bay.

--- a/tests/fixtures/mini-vault-prep-chapters/Overview.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Overview.md
@@ -1,0 +1,11 @@
+---
+type: campaign_overview
+canon_status: AUTHORITATIVE
+status: in_progress
+last_session: "[[Session 07 - The Sterile Bay]]"
+asOfSession: "Chapter 4, Session 7"
+---
+
+# Overview
+
+Calcutta, 1814. Session numbering restarts each chapter.

--- a/tests/fixtures/mini-vault-prep-chapters/Overview.md
+++ b/tests/fixtures/mini-vault-prep-chapters/Overview.md
@@ -2,7 +2,7 @@
 type: campaign_overview
 canon_status: AUTHORITATIVE
 status: in_progress
-last_session: "[[Session 07 - The Sterile Bay]]"
+last_session: "[[Chapters/Chapter 4 - Calcutta/Sessions/Session 07 - The Sterile Bay]]"
 asOfSession: "Chapter 4, Session 7"
 ---
 

--- a/tests/fixtures/mini-vault-prep-chapters/_World/_flags.md
+++ b/tests/fixtures/mini-vault-prep-chapters/_World/_flags.md
@@ -1,0 +1,10 @@
+---
+type: world_flags
+canon_status: DRAFT
+---
+
+# Flags
+
+## Deferred
+
+The dredger's owner is still unnamed.

--- a/tests/test_vault_utilities.py
+++ b/tests/test_vault_utilities.py
@@ -19,6 +19,9 @@ SCRIPTS = ROOT / "skills" / "shared" / "scripts"
 VAULT = ROOT / "tests" / "fixtures" / "mini-vault"
 SCHEMA_VAULT = ROOT / "tests" / "fixtures" / "mini-vault-schema"
 PREP_VAULT = ROOT / "tests" / "fixtures" / "mini-vault-prep"
+PREP_CHAPTERS_VAULT = ROOT / "tests" / "fixtures" / "mini-vault-prep-chapters"
+PREP_NOLINK_VAULT = (ROOT / "tests" / "fixtures"
+                     / "mini-vault-prep-chapters-nolink")
 
 FAILURES = []
 
@@ -178,6 +181,77 @@ for expect, present, label in [
     ("Fogport, 1923", True, "includes campaign overview"),
 ]:
     check(f"session_context: {label}", [expect in ctx], [present])
+
+# --- session_context.py with per-chapter session numbering (#162) ---
+#
+# Chapter 3 ran to Session 14; Chapter 4 restarted and is at Session 07. A
+# vault-wide max() over session_number picks Vienna S14 and stays there until
+# Calcutta reaches 15, handing back a stale wrap-up as if it were current. Two
+# sessions also share number 7 across chapters, which silently collided on a
+# bare-integer key.
+
+ctx_ch = "\n".join(run("session_context.py", vault=PREP_CHAPTERS_VAULT))
+for expect, present, label in [
+    ("Session 07 - The Sterile Bay", True,
+     "picks the most recently played session, not the highest number"),
+    ("Preparing: session 8", True,
+     "next session is numbered within the current chapter"),
+    ("Chapter 3 - Vienna/Sessions/Session 14.md", False,
+     "the completed chapter's last session is not 'just played'"),
+    ("sterile bay swallowed", True, "pairs the current chapter's wrap-up"),
+    ("Vienna opera burned", False, "stale chapter wrap-up excluded"),
+    ("dredger's manifest inland", True, "finds the upcoming plan in-chapter"),
+]:
+    check(f"session_context chapters: {label}", [expect in ctx_ch], [present])
+
+# Two chapters both hold a Session 07. Picking one silently is the collision
+# itself, so an explicit --session 7 must say which chapter it resolved to.
+# (Asserting only "Calcutta won" would pass today by directory walk order.)
+ctx_s7 = "\n".join(run("session_context.py", "--session", "7",
+                       vault=PREP_CHAPTERS_VAULT))
+check("session_context chapters: --session names the chapter it resolved to",
+      ["resolved to Chapter 4 - Calcutta" in ctx_s7,
+       "also in Chapter 3 - Vienna" in ctx_s7],
+      [True, True])
+
+# A quoted wikilink arrives from the frontmatter reader as a ONE-ITEM LIST
+# (`"[[Note]]"` -> `['[Note]']`, outer brackets eaten as a YAML flow sequence),
+# so anything that reads a wikilink-valued field has to unwrap it. Getting this
+# wrong disables the lookup silently rather than erroring.
+sys.path.insert(0, str(SCRIPTS))
+from session_context import wikilink_target  # noqa: E402
+
+for value, expected, label in [
+    (["[Session 07 - The Sterile Bay]"], "Session 07 - The Sterile Bay",
+     "single-item list from a quoted wikilink"),
+    ("[[Session 07]]", "Session 07", "plain string wikilink"),
+    ("[[Session 07|the bay]]", "Session 07", "alias discarded"),
+    ("[[Session 07#Recap]]", "Session 07", "anchor discarded"),
+    ("Session 07", "Session 07", "bare text passes through"),
+    (None, "", "missing value"),
+    ([], "", "empty list"),
+]:
+    check(f"wikilink_target: {label}", [wikilink_target(value)], [expected])
+
+# When the overview's pointer is stale, saying so beats guessing quietly.
+ctx_nolink = "\n".join(run("session_context.py", vault=PREP_NOLINK_VAULT))
+for expect, present, label in [
+    ("matches no session file", True, "unresolvable last_session is reported"),
+    ("Session 07 - The Sterile Bay", True,
+     "falls back to the most recently played session"),
+]:
+    check(f"session_context stale pointer: {label}",
+          [expect in ctx_nolink], [present])
+
+# Staleness took a vault-wide max() over session_number too, so in a vault that
+# restarts numbering the just-played chapter's drafts read as many sessions old
+# and were told to "promote or delete" (#162). Deleting current content on a
+# miscount is the worst outcome in this file.
+check("vault_check stale-drafts: the live chapter's draft is not stale",
+      run("vault_check.py", "stale-drafts", vault=PREP_CHAPTERS_VAULT),
+      ["## stale-drafts", "# count: 1",
+       "WARNING\t_World/_flags.md\tDRAFT missing createdSession — "
+       "cannot determine staleness; add it or promote"])
 
 # --- vault_check.py changed ---
 

--- a/tests/test_vault_utilities.py
+++ b/tests/test_vault_utilities.py
@@ -253,6 +253,49 @@ check("vault_check stale-drafts: the live chapter's draft is not stale",
        "WARNING\t_World/_flags.md\tDRAFT missing createdSession — "
        "cannot determine staleness; add it or promote"])
 
+# Review findings on #162. Three ways the chapter dimension could still be lost.
+
+# (a) A chapter ref written as a path must key the same as the folder fallback,
+# or one chapter becomes two identities and its own documents stop matching.
+sys.path.insert(0, str(SCRIPTS))
+from schema_rules import chapter_key  # noqa: E402
+
+check("chapter_key: path-form ref matches the folder fallback",
+      [chapter_key("Chapters/Chapter 4 - Calcutta/Sessions/S.md",
+                   {"chapter": ["[Chapters/Chapter 4 - Calcutta]"]})],
+      [chapter_key("Chapters/Chapter 4 - Calcutta/Sessions/S.md", {})])
+
+# (b) last_session is a path-form wikilink in the fixture; it must still resolve.
+# Assert the pointer RESOLVED, not merely that the answer came out right:
+# the recency fallback reaches the same session, so only the absence of the
+# "matches no session file" warning proves the overview path fired.
+_ctx_path = "\n".join(run("session_context.py", vault=PREP_CHAPTERS_VAULT))
+check("session_context: path-form last_session resolves",
+      ["Session 07 - The Sterile Bay" in _ctx_path,
+       "matches no session file" in _ctx_path],
+      [True, False])
+
+# A bare stem must keep working — that is what the reported vault held.
+_stem_vault = Path(tempfile.mkdtemp()) / "v"
+shutil.copytree(PREP_CHAPTERS_VAULT, _stem_vault)
+_ov = _stem_vault / "Overview.md"
+_ov.write_text(_ov.read_text(encoding="utf-8").replace(
+    "[[Chapters/Chapter 4 - Calcutta/Sessions/Session 07 - The Sterile Bay]]",
+    "[[Session 07 - The Sterile Bay]]"), encoding="utf-8")
+check("session_context: bare-stem last_session resolves",
+      ["Session 07 - The Sterile Bay" in "\n".join(
+          run("session_context.py", vault=_stem_vault))],
+      [True])
+shutil.rmtree(_stem_vault.parent, ignore_errors=True)
+
+# (c) A document carrying no chapter must not outrank the chapter's own just
+# because it sorts earlier. Archive_... deliberately sorts before Chapters/.
+_ctx_pref = "\n".join(run("session_context.py", vault=PREP_CHAPTERS_VAULT))
+check("session_context: the chapter's own wrap-up outranks an unfiled one",
+      ["sterile bay swallowed" in _ctx_pref,
+       "unfiled wrap-up carrying no chapter" in _ctx_pref],
+      [True, False])
+
 # --- vault_check.py changed ---
 
 check("changed --since lists session-touched entities",


### PR DESCRIPTION
Two session-prep bugs found in a single live prep pass on Canticle of the
End, fixed together because they surfaced from the same run.

Plugin 1.8.51.

Closes #162
Closes #163

## #162 — the wrong session, presented as authoritative

`session_context.py` chose "just played" with a vault-wide `max()` over
`session_number`. Where numbering restarts per chapter that is not a
campaign-wide ordinal, so Chapter 3's Session 14 beat Chapter 4's Session 07
permanently — and would have until Calcutta reached 15. The bundle returned a
five-month-stale wrap-up, the wrong PC world-state, and "no existing plan for
session 15", all of it reading exactly as authoritative as a correct bundle.

Selection now follows the campaign overview's `last_session`, then the most
recent `play_date`. Sessions are keyed on `(chapter, number)` rather than a
bare integer that two chapters silently collided on depending on directory
walk order, and the wrap-up and plan lookups are scoped to the chosen
chapter. Where the answer is ambiguous — a stale overview pointer, a number
appearing in more than one chapter — the header says so instead of choosing
quietly.

### The overview path was dead on arrival

Worth calling out, because it is invisible and I nearly shipped it. A quoted
wikilink does not arrive as a string: the frontmatter reader treats the outer
brackets of `"[[Note]]"` as a YAML flow sequence and yields `['[Note]']`. The
first implementation of "trust the campaign overview" tested for a string,
got a list, and gave up silently — so the authoritative-metadata path never
ran once, and both fixtures were passing on the recency fallback.

It only showed up because a second fixture was built to discriminate which
path was firing. `wikilink_target` now unwraps the single-item case and is
pinned by seven cases.

### `vault_check stale-drafts` had the same assumption

Flagged in the issue as worth checking, and worse than the reporting bug: it
measured every draft against the vault-wide highest session number, so the
live chapter's newest content read as seven sessions old and was told to
"promote to AUTHORITATIVE or **delete**". Staleness is now measured within a
chapter; a draft naming no chapter in such a vault is reported as undatable
rather than judged against an unrelated chapter's count.

## #163 — a chapter's design never read

Step 10c scanned only `Chapters/{chapter}/Planning/` and categorised by
`plan_type` frontmatter. The reported vault had an empty `Planning/` and 55
files in `_midwife/chapter-4-calcutta/`, including a complete day-by-day
timeline. Prep reported no plans available and generated scene structure that
contradicted that timeline on its first beat. The GM caught it; nothing in
the skill would have.

Discovery is now path-based across both roots — midwife files carry no
frontmatter by design, so widening a `plan_type` scan would still find
nothing — and `timeline.md` is read before scene design rather than
discovered after it.

`vault-structure.md` documented only that `campaign-qa` ignores `_midwife/`.
Correct for an audit, wrong as a general posture, and that omission is what
session-prep inherited. Both halves are now written down. An empty result no
longer becomes a Gap/Action claiming the chapter has no plan entities — that
reads as a finding about the vault when it was a limitation of the scan.
`session-play` had the same gap in its lookup table.

## Testing

Test-first throughout, on two new fixture vaults: one reproducing the
reported shape (two chapters, both holding a Session 07, overview pointing at
the live one) and one with a stale overview pointer to prove the fallback and
its warning. The reproduction was confirmed against the fixture before any
fix was written.

87 assertions in `test_vault_utilities.py`, including the 11 pre-existing
single-chapter ones unchanged — flat vaults behave exactly as before, which
is the behaviour the chapter-less paths are written to preserve. All seven
Python CI files, schema, ontology, benchmark-campaign, and the 1441 publish
tests pass. skill-creator validation run on all four affected skills.