### PR TITLE
Close the GM-content leaks: fences, frontmatter, and per-file publish controls (#166, #167, #168)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.51",
+  "version": "1.8.52",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ Cthulhu campaign with a traitor PC (#166, #167, #168). Publish tool 1.11.24.
 
 ### Fixed
 
+- **Section filtering survives CRLF line endings.** The heading pattern ends in
+  `$` and `.` does not match `\r`, so on a vault authored on Windows (or checked
+  out with `core.autocrlf`) **no heading matched at all** and `exclude_sections`
+  excluded nothing. `processContent` strips `\r` before rendering, which kept
+  the page itself safe and hid the bug — but the published view used for the
+  search index, backlinks and recency does not, so `## GM Notes` prose reached
+  the search index verbatim. Both section filters normalize line endings first.
+- **`publish: stub` reduces a PC's story companion too.** The story is a
+  separate file paired in by the scanner and rendered on its own page, so
+  reducing only the entity page left a stubbed PC publishing its complete story
+  one URL over.
 - **Field exclusion now reaches the derived views** (#166). Frontmatter
   filtering ran *after* backlinks, the search index and the relationship graphs
   had already been built from the raw frontmatter — so excluding a field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.52] — 2026-08-21
+
+Two GM-content leaks onto player-facing sites, both found while publishing a
+live Call of Cthulhu campaign (#168). Publish tool 1.11.24.
+
+### Fixed
+
+- **`<!-- gm-only -->` fences nest.** The markers were tracked with a boolean,
+  so the *first* closer ended the outer block and everything after it
+  published. Wrapping a region that already contained inner fences therefore
+  protected only as far as the first inner `<!-- /gm-only -->` — with balanced
+  markers, no warning, and no way to tell from the source that it had failed.
+  Silent under-protection is the worst failure mode for the one primitive whose
+  whole job is hiding things. An inner block now closes only itself.
+  `<!-- spoiler -->` gets the same fix, from the same shared implementation.
+- **A `<!-- /gm-only -->` with nothing open is reported.** It used to be a
+  silent no-op. It is now counted and warned about at build time, and the
+  unclosed-marker warning says how many blocks were left open — so an
+  unbalanced file is visible instead of quietly publishing or quietly
+  truncating.
+- **`## Reconciliation Context` is written under `## GM Notes`.** Every item in
+  it is Keeper-facing — GM decisions and rationale, unplayed-prep dispositions,
+  and the World Evolution block describing what the factions did off-screen.
+  As a sibling H2 it published; in one vault it revealed an antagonist's
+  position the party had not discovered, across 9 wrap-up files. Adding it to
+  the default `exclude_sections` does not fix this, because a vault that sets
+  its own list keeps that list as written — which is precisely the failure the
+  1.8.3 two-primitive standard was introduced to end. `reconcile.md` now writes
+  it as a `###` under `## GM Notes` (with its subsections demoted to `####`),
+  and the session-plan template does the same. Readers accept both forms, so an
+  un-migrated vault keeps working.
+
+### Changed
+
+- **Migration 1.8.51 → 1.8.52** re-nests existing `## Reconciliation Context`
+  sections under `## GM Notes`, creating the container where absent. A pure
+  structural move, applied after preview confirmation like the 1.8.3
+  re-nesting.
+
+---
+
 ## [1.8.51] — 2026-08-17
 
 Two session-prep bugs found in one live prep pass: the wrong session picked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ live Call of Cthulhu campaign (#168). Publish tool 1.11.24.
   Silent under-protection is the worst failure mode for the one primitive whose
   whole job is hiding things. An inner block now closes only itself.
   `<!-- spoiler -->` gets the same fix, from the same shared implementation.
+- **A marker inside a code example is documentation, not a directive.** Only a
+  line starting with exactly three backticks counted as a code fence, so a
+  `<!-- /gm-only -->` shown inside a `~~~` block, a ` ```` `-length fence, or a
+  fence indented by up to three spaces was obeyed as a real closer — ending the
+  enclosing block early and publishing the rest. Fence tracking now follows
+  CommonMark: a fence closes only on the same character, at least as long as
+  the opener, with nothing but whitespace after it. This repo's own
+  documentation demonstrates these markers inside fenced examples, so it is a
+  shape that occurs in practice.
 - **A `<!-- /gm-only -->` with nothing open is reported.** It used to be a
   silent no-op. It is now counted and warned about at build time, and the
   unclosed-marker warning says how many blocks were left open — so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.52] — 2026-08-21
 
-Two GM-content leaks onto player-facing sites, both found while publishing a
-live Call of Cthulhu campaign (#168). Publish tool 1.11.24.
+GM content reaching player-facing sites, found while publishing a live Call of
+Cthulhu campaign with a traitor PC (#166, #167, #168). Publish tool 1.11.24.
+
+### Added
+
+- **`publish: false` and `publish: stub`** (#167). There was no file-level
+  exclusion at all — `exclude_dirs` works per directory, `exclude_sections` per
+  heading, `exclude_fields` per field, and nothing per file. A wholly
+  Keeper-facing page in an otherwise publishable folder had to be fenced
+  section by section and re-audited after every edit. `publish: false` emits no
+  page in any mode, while still parsing the file so links to it render as plain
+  text rather than breaking. `publish: stub` keeps the page for navigation —
+  the chapter-overview case, where the page is needed but its body is a GM
+  bible — and emits only the sections named in `publish_include_sections`,
+  which defaults to none so a stub opts content *in*.
+- **`publish_exclude_fields`** (#166). Hides named fields on one file, merged
+  over the vault's global `exclude_fields`. Excluding `occupation`
+  campaign-wide to hide one traitor's true allegiance would have stripped it
+  from every honest NPC. A per-file entry is deliberately *not* re-admitted by
+  a config-level `overrides.fields.*.include`: where the two disagree, hiding
+  wins.
+- **`gm_only: true` on a single relationship edge** (#166). Some edges are
+  themselves the secret — a loyal-seeming escort who `serves` the cult leader.
+  The edge is dropped from the page, the relationship graph and the search
+  index.
 
 ### Fixed
+
+- **Field exclusion now reaches the derived views** (#166). Frontmatter
+  filtering ran *after* backlinks, the search index and the relationship graphs
+  had already been built from the raw frontmatter — so excluding a field
+  removed it from the page and left it in every view derived from it.
+  Excluding `relationships` still drew the Connections graph with the secret
+  targets as node labels; excluding `occupation` still shipped it as the
+  search-index subtitle. The published view is now computed once, immediately
+  after the link map, and everything derived is built from that.
 
 - **`<!-- gm-only -->` fences nest.** The markers were tracked with a boolean,
   so the *first* closer ended the outer block and everything after it

--- a/skills/publish-site/references/content-filtering.md
+++ b/skills/publish-site/references/content-filtering.md
@@ -19,6 +19,27 @@ All campaign content falls into three categories:
   of file and prints a build warning.
 - Frontmatter fields in `exclude_fields` (default:
   `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`)
+- Files whose frontmatter says `publish: false` — in **every** mode,
+  including `full`. The file still parses, so links to it render as
+  plain text rather than as a broken link; no page is emitted.
+- Fields named in a file's own `publish_exclude_fields`, on that file
+  only, merged over the global `exclude_fields`.
+- Relationship edges marked `gm_only: true` — removed from the page,
+  its relationship graph, and the search index.
+- On a `publish: stub` file, everything except the sections named in
+  `publish_include_sections`.
+
+### Frontmatter is not covered by the fence
+
+`<!-- gm-only -->` is a **body** primitive. It has no meaning inside
+frontmatter, and it never has had — so a secret that lives in a field
+(`occupation`, `key_traits`) or in a relationship target is not
+protected by fencing the body, and neither are the views derived from
+those fields: the character sheet, the Connections graph, the search
+index. That is what `publish_exclude_fields` and edge-level `gm_only`
+are for. Reach for them whenever the *fact of the field* is the secret
+— a traitor whose `occupation` names their true allegiance, or an edge
+to the cult leader whose existence gives the game away.
 
 ### Always included
 

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -102,9 +102,9 @@ salvageable prep triage. See the shared procedure for the full
 workflow.
 
 **Reconcile-to-Prep handoff:** Reconcile writes
-`## Reconciliation Context` to the Wrap-Up file, capturing
-consequences, salvageable prep, and GM decisions. Steps 7-10
-read this and only gather what's new.
+`### Reconciliation Context` under the Wrap-Up file's
+`## GM Notes`, capturing consequences, salvageable prep, and
+GM decisions. Steps 7-10 read this and only gather what's new.
 
 ## Phase 2: Prep Forward — Context Gathering
 
@@ -176,8 +176,9 @@ Surface items gaining traction:
 whether to act. If they want to resolve, suggest a midwife
 worldbuilding conversation.
 
-If Reconcile ran, steps 7-10 read `## Reconciliation Context` and skip
-what's already established.
+If Reconcile ran, steps 7-10 read `### Reconciliation Context` (under
+`## GM Notes`; also accept a top-level `## Reconciliation Context` in a
+vault not yet migrated) and skip what's already established.
 
 #### Step 10c: Narrative plans
 

--- a/skills/session-prep/references/session-templates.md
+++ b/skills/session-prep/references/session-templates.md
@@ -64,17 +64,23 @@ this session *about* dramatically? Not "the PCs go to the opera" but
 "the investigators make first contact with Viennese high society and get
 their first glimpse of the Brotherhood's influence."
 
-## Reconciliation Context
+## GM Notes
+
+<!-- Keeper-facing. Everything under this heading is hidden from a
+     published player site by the default exclude, so new GM content
+     belongs here rather than in a new top-level section. -->
+
+### Reconciliation Context
 
 [Written by Phase 1 Reconcile. Absent for first sessions.]
 
-### Consequences
+#### Consequences
 [Forward-looking summary of what follows from last session]
 
-### Salvageable Prep
+#### Salvageable Prep
 [Unplayed prep: dropped / recycled / must-happen]
 
-### GM Decisions
+#### GM Decisions
 [Resolved decisions with outcomes, appended one at a time]
 
 ## Prior Prep Review

--- a/skills/shared/entity-schema.md
+++ b/skills/shared/entity-schema.md
@@ -128,6 +128,9 @@ relationships:
     strength: 7           # 1-10 (1-2 weak, 9-10 defining)
     bidirectional: false
     description: "Serves as lieutenant"
+    gm_only: false        # optional; true hides this edge from a published
+                          # site — the page, its relationship graph, and the
+                          # search index
 ```
 
 Extraction defaults:
@@ -135,6 +138,26 @@ Extraction defaults:
 - `tone: neutral` and `strength: 5` when source is ambiguous
 - `bidirectional: false` unless inherently symmetric
 - Include `description` traceable to source text
+- `gm_only` omitted (visible) unless the edge's *existence* is the secret
+
+### Publish control fields
+
+Optional, on any entity. Frontmatter carries no body prose, so
+`<!-- gm-only -->` has no meaning there — these are how a secret in
+frontmatter or a whole GM-facing file is kept off a player site.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `publish` | `false` \| `stub` | `false` — no page is emitted in any mode; the file still parses, so links to it render as plain text rather than as a broken link. `stub` — the page is emitted for navigation but only the sections named in `publish_include_sections` are kept. |
+| `publish_exclude_fields` | array | Field names hidden on **this file only**, merged over the vault's global `exclude_fields`. Use when excluding a field campaign-wide would strip it from every honest entity too. |
+| `publish_include_sections` | array | Only meaningful with `publish: stub`. Section headings to keep. Defaults to none — a stub opts content *in*. |
+
+Absent means "publish normally"; a vault that uses none of these is
+unaffected. An unrecognized `publish:` value is treated as normal
+publication — a typo must not silently unpublish a page, nor silently
+publish one. A `publish_exclude_fields` entry is **not** re-admitted by a
+config-level `overrides.fields.*.include`: the file's own instruction about
+its own secret outranks a campaign-wide default.
 
 ## Core Entity Types
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -607,10 +607,27 @@ was introduced to end.
 
 ### Content
 
-- **None.** Vaults that added `"Reconciliation Context"` to their own
+- **None required.** Vaults that added `"Reconciliation Context"` to their own
   `exclude_sections` as a workaround may leave it there — it is harmless
   once the section is nested, and still protects any file the structural
   pass did not reach.
+- **New optional publish-control fields**, documented in
+  `entity-schema.md` and picked up by Schema Mirror Sync into each vault's
+  `_meta/entity-types.md`. All are absent by default and change nothing for a
+  vault that does not use them:
+  - `publish: false | stub` on any entity — `false` emits no page in any mode
+    (the file still parses, so links to it render as plain text); `stub` emits
+    the page for navigation with only the sections named in
+    `publish_include_sections`.
+  - `publish_exclude_fields` — field names hidden on that file alone, merged
+    over the vault's global `exclude_fields`.
+  - `gm_only: true` on a single `relationships[]` entry — hides that edge from
+    the page, the relationship graph, and the search index.
+
+  Not backfilled and no GM action required. These exist because
+  `<!-- gm-only -->` is a body primitive with no meaning in frontmatter: a
+  secret held in a field, or in the mere existence of an edge, was previously
+  unprotectable without stripping the field campaign-wide.
 
 ### Tooling
 

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -618,6 +618,9 @@ was introduced to end.
   nesting-aware. Previously the first closer ended the outer block, so
   wrapping a region that already contained inner fences published everything
   after that inner closer — with balanced-looking markers and no warning.
-  An inner block now closes only itself. A closer with nothing open no
-  longer silently does nothing: it is counted and reported, and the
-  unclosed-marker warning now says how many blocks were left open.
+  An inner block now closes only itself. Code-fence detection follows
+  CommonMark too, so a marker shown inside a `~~~` block, a longer fence, or
+  an indented fence is read as documentation rather than obeyed as a real
+  closer. A closer with nothing open no longer silently does nothing: it is
+  counted and reported, and the unclosed-marker warning now says how many
+  blocks were left open.

--- a/skills/shared/migrations.md
+++ b/skills/shared/migrations.md
@@ -577,3 +577,47 @@ no sidecar crosswalk.
   nodes. A vault whose entities already exist upstream but lack nodes is
   linked by matching live mobRPG elements by name, never by reading a
   crosswalk.
+
+## Migration: 1.8.51 → 1.8.52
+
+Re-nests `## Reconciliation Context` under `## GM Notes`, and makes the
+`<!-- gm-only -->` fence nesting-aware.
+
+Reconciliation Context is entirely Keeper-facing — GM decisions and their
+rationale, unplayed-prep dispositions, and the World Evolution block
+describing what the factions did while the PCs weren't looking. As a
+top-level H2 it was a sibling of `## GM Notes` rather than a child, so it
+published to player-facing sites. A vault that sets its own
+`exclude_sections` keeps that list as written — a newly-added default never
+reaches it — which is exactly the failure the 1.8.3 two-primitive standard
+was introduced to end.
+
+### Structural
+
+- **`## Reconciliation Context` → `### Reconciliation Context` under
+  `## GM Notes`** in Wrap-Up and session-plan files, creating `## GM Notes`
+  where absent. Its own subsections demote one level with it
+  (`### Consequences` → `#### Consequences`, and likewise Salvageable Prep,
+  GM Decisions, and World Evolution). A pure structural move — nothing is
+  added, removed, or reworded, only relocated and demoted — so it applies
+  automatically after preview confirmation, like the 1.8.3 re-nesting.
+- Readers accept **both** forms. A vault that has not yet migrated keeps
+  working: session-prep looks for the nested heading first and falls back to
+  a top-level `## Reconciliation Context`.
+
+### Content
+
+- **None.** Vaults that added `"Reconciliation Context"` to their own
+  `exclude_sections` as a workaround may leave it there — it is harmless
+  once the section is nested, and still protects any file the structural
+  pass did not reach.
+
+### Tooling
+
+- **Publish tool:** `<!-- gm-only -->` and `<!-- spoiler -->` fences are now
+  nesting-aware. Previously the first closer ended the outer block, so
+  wrapping a region that already contained inner fences published everything
+  after that inner closer — with balanced-looking markers and no warning.
+  An inner block now closes only itself. A closer with nothing open no
+  longer silently does nothing: it is counted and reported, and the
+  unclosed-marker warning now says how many blocks were left open.

--- a/skills/shared/reconcile.md
+++ b/skills/shared/reconcile.md
@@ -90,8 +90,8 @@ For each finding, present the three-state prompt:
   flesh this out?"
 
 One finding at a time. Wait for GM decision before continuing.
-Record each resolution in the `## Reconciliation Context`
-section (step 7).
+Record each resolution in the `### Reconciliation Context`
+subsection under `## GM Notes` (step 7).
 
 ### 3. Walk through conflicts
 
@@ -189,8 +189,8 @@ conversational style as the rest of reconcile.
 - Entity files created or updated use
   `source: "world-evolution"`, with `lastUpdated` and
   `asOfSession` set to the current session
-- Results feed into step 7's `## Reconciliation Context`
-  under `### World Evolution`, containing:
+- Results feed into step 7's `### Reconciliation Context`
+  under `#### World Evolution`, containing:
   - Faction turn summaries (one line per faction: action,
     impact level, what's visible to PCs)
   - Surfaced consequences (trigger, manifestation)
@@ -200,25 +200,41 @@ conversational style as the rest of reconcile.
 
 ### 7. Record decisions
 
-Write a `## Reconciliation Context` section capturing:
+Write a `### Reconciliation Context` subsection capturing:
 - **Consequences** — forward-looking summary of what this
   session established (every claim traceable to vault or
   play notes, no invention)
 - **Salvageable prep** — disposition of each unplayed item
 - **GM decisions** — each conflict resolution with rationale
 - **World evolution** — if step 6.5 ran, include a
-  `### World Evolution` sub-section with faction turn
+  `#### World Evolution` sub-section with faction turn
   summaries, surfaced consequences, foreshadowing and
   discovery state changes, and world state updates
 
 This section provides cross-conversation continuity.
 Session-prep reads it to avoid re-gathering context.
 
-**Where to write it:** Always in the Wrap-Up file under
-`## Reconciliation Context` — session-prep reads this exact
-header. If a Plan file exists, you may append a short pointer
-(`See Wrap-Up for reconciliation context`) but the Wrap-Up
-file is the canonical location.
+**Where to write it:** Always in the Wrap-Up file, as a `###`
+subsection **under that file's `## GM Notes` heading** —
+create `## GM Notes` if the file has none. If a Plan file
+exists, you may append a short pointer (`See Wrap-Up for
+reconciliation context`) but the Wrap-Up file is the canonical
+location.
+
+**Why nested, not a top-level `## Reconciliation Context`:**
+every item in it is Keeper-facing — GM decisions and their
+rationale, unplayed prep, what the factions did while the PCs
+weren't looking. As a sibling H2 it published to player sites,
+because a GM's own `exclude_sections` list is respected as
+written and a newly-added default never reaches a vault that
+set its own. The 1.8.3 standard exists precisely so new GM
+content needs no new exclude entry: put it under `## GM Notes`
+and every config already hides it. Do not "fix" this by adding
+`Reconciliation Context` to an exclude list.
+
+**Reading it back:** accept either form — `###` under
+`## GM Notes` (current) or a top-level `## Reconciliation
+Context` (vaults not yet migrated).
 
 ## Rules
 

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -137,7 +137,7 @@ After filing: "Updates filed. Run campaign-qa to validate,
 or proceed to session prep?"
 
 **When invoked from reconcile:** skip this prompt — results
-flow into reconcile step 7's `## Reconciliation Context`
+flow into reconcile step 7's `### Reconciliation Context`
 under `### World Evolution`. Set `world_evolved` on the
 session index to the current session reference.
 

--- a/skills/ttrpg-expert/world-evolution.md
+++ b/skills/ttrpg-expert/world-evolution.md
@@ -138,7 +138,7 @@ or proceed to session prep?"
 
 **When invoked from reconcile:** skip this prompt — results
 flow into reconcile step 7's `### Reconciliation Context`
-under `### World Evolution`. Set `world_evolved` on the
+under `#### World Evolution`. Set `world_evolved` on the
 session index to the current session reference.
 
 ## Universal Faction Turn

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -321,6 +321,13 @@ function build(options = {}) {
         ? page.frontmatter.publish_include_sections
         : [];
       page.markdown = keepOnlySections(page.markdown || '', include);
+      // A PC's story companion is a SEPARATE file paired in by the scanner and
+      // rendered on its own page. Reducing only page.markdown left a stubbed PC
+      // publishing its complete story — the same content the stub exists to
+      // withhold, one URL over.
+      if (page.storyMarkdown) {
+        page.storyMarkdown = keepOnlySections(page.storyMarkdown, include);
+      }
     }
     const overridesForFile = fieldOverrides[vaultRelPathOf(page)] || {};
     page.frontmatter = publishedFrontmatter(

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { scanVault, buildLinkMap, scanAttachments, pairStoryFiles } = require('./scanner');
 const { optimizeImages, resolveImageConfig } = require('./image-optimize');
 const { resolveBanner, renderBanner, defaultAlt, isSvg } = require('./banners');
-const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, filterFields, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename, encodeHref } = require('./processor');
+const { processContent, extractSections, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, filterFields, publishedFrontmatter, publishMode, keepOnlySections, resolveImageEmbeds, resolveWikiLinks, relativePath, relativeHref, escapeHtml, portraitBasename, encodeHref } = require('./processor');
 const { generateNav, pcTemplate, npcTemplate, creatureTemplate, locationTemplate, itemTemplate, factionTemplate, eventTemplate, heritageTemplate, worldDomainTemplate, wikiTemplate, indexTemplate, landingTemplate, fourOhFourTemplate, DIR_LABELS, getRenderer } = require('./templates/index');
 const { loadPublishConfig } = require('./config');
 const { loadManifest, canonicalPath } = require('./manifest');
@@ -283,8 +283,49 @@ function build(options = {}) {
     console.log(`Manifest filter: ${beforeCount} → ${pages.length} pages`);
   }
 
+  // `publish: false` — the GM said never publish this file. Honoured in EVERY
+  // mode, unlike the auto-exclusions above: those are heuristics about draft
+  // state, this is an explicit instruction, and a flag named "never publish"
+  // that publishes under some setting is worse than no flag at all.
+  //
+  // Dropped before the link map, so links to it resolve to nothing and render
+  // as plain text rather than as a broken href — the file still parses, it
+  // just never becomes a page.
+  const neverPublish = pages.filter(p => publishMode(p.frontmatter) === 'none');
+  if (neverPublish.length > 0) {
+    pages = pages.filter(p => publishMode(p.frontmatter) !== 'none');
+    console.log(`publish: false — skipped ${neverPublish.length} file(s)`);
+  }
+
   const linkMap = buildLinkMap(pages);
   console.log(`Built link map with ${Object.keys(linkMap).length} entries`);
+
+  // Reduce every page's frontmatter to its PUBLISHED view before anything
+  // derived is built from it.
+  //
+  // This used to run ~80 lines further down, after backlinks, the search index
+  // and the relationship graphs had all already read the raw frontmatter — so
+  // excluding a field removed it from the page and left it in every derived
+  // view (#166). Excluding `relationships` still drew the graph, with the
+  // secret targets as node labels; excluding `occupation` still shipped it as
+  // the search-index subtitle. The link map is built above and is what redirect
+  // resolution actually consults, so `aliases`/`canon_status` are safe to strip
+  // from here on.
+  for (const page of pages) {
+    // `publish: stub` — emit the page shell so navigation and links still work,
+    // but keep only the sections the GM explicitly named. Applied to
+    // page.markdown itself, before the published view is computed, so every
+    // downstream reader sees the same reduced body.
+    if (publishMode(page.frontmatter) === 'stub') {
+      const include = Array.isArray(page.frontmatter.publish_include_sections)
+        ? page.frontmatter.publish_include_sections
+        : [];
+      page.markdown = keepOnlySections(page.markdown || '', include);
+    }
+    const overridesForFile = fieldOverrides[vaultRelPathOf(page)] || {};
+    page.frontmatter = publishedFrontmatter(
+      page.frontmatter, excludeFields, overridesForFile);
+  }
 
   const { buildBacklinks } = require('./backlinks');
   const { buildSearchIndex } = require('./search-index');
@@ -363,12 +404,6 @@ function build(options = {}) {
   }
   console.log(`Generated ${Object.keys(entityGraphs).length} relationship graphs`);
   publishConfig._entityGraphs = entityGraphs;
-
-  // Apply field filtering after link map is built (aliases/canon_status needed for redirect resolution)
-  for (const page of pages) {
-    const overridesForFile = fieldOverrides[vaultRelPathOf(page)] || {};
-    page.frontmatter = filterFields(page.frontmatter, excludeFields, overridesForFile);
-  }
 
   // Where the timeline actually lives. Decided after field filtering — so an excluded
   // `in_game_date` can't resurrect a timeline the GM meant to suppress — but before the nav

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -102,6 +102,38 @@ function filterSections(markdown, excludeSections = []) {
   return result.join('\n');
 }
 
+// The inverse of filterSections: keep ONLY the named headings and their
+// content, dropping everything else including any preamble before the first
+// heading. Backs `publish: stub`, where the page must exist for navigation but
+// its body is prep. Defaults to keeping nothing — a stub opts content IN, so a
+// section added later is suppressed until the GM names it, rather than
+// appearing the moment someone writes it.
+function keepOnlySections(markdown, includeSections = []) {
+  const wanted = includeSections
+    .filter(s => typeof s === 'string')
+    .map(s => s.toLowerCase());
+  if (wanted.length === 0) return '';
+  const lines = String(markdown).split('\n');
+  const result = [];
+  let keeping = false;
+  let keepLevel = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const title = headingMatch[2].trim().toLowerCase();
+      if (keeping && level <= keepLevel) keeping = false;
+      if (wanted.includes(title)) {
+        keeping = true;
+        keepLevel = level;
+      }
+    }
+    if (keeping) result.push(line);
+  }
+  return result.join('\n');
+}
+
 function stripDataview(markdown) {
   return markdown.replace(/```dataview[\s\S]*?```/g, '');
 }
@@ -540,4 +572,60 @@ function filterFields(frontmatter, excludeFields = [], overrides = {}) {
   return filtered;
 }
 
-module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, encodeHref, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields };
+// How much of a file to publish, from its own `publish:` frontmatter key.
+// 'all' (default), 'stub' (page shell, body suppressed), 'none' (no page).
+// Absent/true/anything unrecognized means 'all' — a typo must not silently
+// unpublish a page, and must not silently publish one either, so only the two
+// explicit opt-outs are honoured.
+function publishMode(frontmatter) {
+  const raw = frontmatter && frontmatter.publish;
+  if (raw === false || raw === 'false' || raw === 'none') return 'none';
+  if (raw === 'stub') return 'stub';
+  return 'all';
+}
+
+// The GM-only marker on a single relationship edge. Frontmatter carries no
+// body prose, so `<!-- gm-only -->` has no meaning here — an edge whose very
+// existence is the secret (a "loyal escort" who `serves` the cult leader)
+// needs its own flag.
+function isGmOnlyEdge(rel) {
+  return !!(rel && (rel.gm_only === true || rel.gm_only === 'true'));
+}
+
+// One page's frontmatter as a reader may see it. Everything derived from
+// frontmatter — the relationship graph, backlinks, the search index, sheet
+// meta rows — must be built from THIS, never from the raw frontmatter.
+//
+// Three layers, in order:
+//   1. edges marked `gm_only: true` are dropped
+//   2. the file's own `publish_exclude_fields` is merged over the global
+//      `exclude_fields` — per-file, because excluding `occupation` campaign-
+//      wide to hide one traitor strips it from every honest NPC too
+//   3. the existing per-file `include` override can re-admit a field
+function publishedFrontmatter(frontmatter, excludeFields = [], overrides = {}) {
+  const fm = { ...frontmatter };
+
+  if (Array.isArray(fm.relationships)) {
+    const visible = fm.relationships.filter(r => !isGmOnlyEdge(r));
+    if (visible.length > 0) fm.relationships = visible;
+    else delete fm.relationships;
+  }
+
+  const filtered = filterFields(fm, excludeFields, overrides);
+
+  // Applied AFTER, and deliberately not subject to `overrides.include`: the
+  // file's own "hide this" outranks a config-level re-include. The config is a
+  // campaign-wide default; the frontmatter is the GM saying it about this
+  // specific secret. Where they disagree, hiding wins.
+  const perFile = Array.isArray(fm.publish_exclude_fields) ? fm.publish_exclude_fields : [];
+  for (const field of perFile) {
+    if (typeof field === 'string') delete filtered[field];
+  }
+  // The control fields are bookkeeping, never reader-facing.
+  delete filtered.publish;
+  delete filtered.publish_exclude_fields;
+  delete filtered.publish_include_sections;
+  return filtered;
+}
+
+module.exports = { processContent, extractSections, resolveWikiLinks, filterSections, stripDataview, stripGmOnly, stripSpoiler, stripCallouts, stripHtmlComments, stripLeadingH1, renderRelationships, relativePath, relativeHref, humanizeName, parseWikiRef, escapeHtml, resolveImageEmbeds, encodeImageUrl, encodeHref, publishedSource, renderMetaValue, plainMetaValue, portraitBasename, filterFields, publishedFrontmatter, publishMode, isGmOnlyEdge, keepOnlySections };

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -69,8 +69,13 @@ function resolveWikiLinks(markdown, linkMap, currentOutputPath) {
   });
 }
 
+// Line endings are normalized first: the heading pattern below ends in `$`,
+// and `.` does not match `\r`, so on a CRLF vault NO heading matched and
+// nothing was ever excluded. processContent strips \r before rendering, which
+// kept the page itself safe and hid the bug — but publishedMarkdown does not,
+// and that is what feeds the search index, backlinks and recency.
 function filterSections(markdown, excludeSections = []) {
-  const lines = markdown.split('\n');
+  const lines = String(markdown).replace(/\r\n?/g, '\n').split('\n');
   const result = [];
   let excluding = false;
   let excludeLevel = 0;
@@ -113,7 +118,7 @@ function keepOnlySections(markdown, includeSections = []) {
     .filter(s => typeof s === 'string')
     .map(s => s.toLowerCase());
   if (wanted.length === 0) return '';
-  const lines = String(markdown).split('\n');
+  const lines = String(markdown).replace(/\r\n?/g, '\n').split('\n');
   const result = [];
   let keeping = false;
   let keepLevel = 0;

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -126,16 +126,43 @@ function stripMarkedBlocks(markdown, markerName) {
   const warnings = [];
   let depth = 0;
   let orphanClosers = 0;
-  let inCodeFence = false;
+  // The open fence's delimiter, or null outside a fence. Tracking the actual
+  // delimiter — not a boolean — is what makes ``` inside a ~~~ block (and vice
+  // versa) inert, per CommonMark: a fence closes only on the same character,
+  // at least as long as the opener, with nothing but whitespace after it.
+  //
+  // Only ^``` used to count as a fence, so a marker shown inside a ~~~ block,
+  // a ````-long fence, or an indented fence was obeyed as a real directive —
+  // ending the enclosing block early and publishing the rest. This repo's own
+  // docs demonstrate these markers inside fenced examples, so it is a shape
+  // that actually occurs. Getting this wrong leaks in BOTH directions: miss a
+  // fence and an example closer is obeyed; invent one and a real opener is
+  // ignored. Hence matching CommonMark rather than loosening the pattern.
+  let fenceDelim = null;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    if (/^```/.test(line)) {
-      inCodeFence = !inCodeFence;
+    // up to 3 leading spaces; 4+ would be an indented code block, not a fence
+    const fence = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    let isFenceLine = false;
+    if (fence) {
+      const [, delim, info] = fence;
+      if (fenceDelim === null) {
+        // A backtick fence's info string may not contain a backtick.
+        if (delim[0] !== '`' || !info.includes('`')) {
+          fenceDelim = delim;
+          isFenceLine = true;
+        }
+      } else if (delim[0] === fenceDelim[0]
+                 && delim.length >= fenceDelim.length
+                 && /^\s*$/.test(info)) {
+        fenceDelim = null;
+        isFenceLine = true;
+      }
     }
 
-    if (inCodeFence) {
+    if (fenceDelim !== null || isFenceLine) {
       if (depth === 0) result.push(line);
       continue;
     }

--- a/tools/publish/lib/processor.js
+++ b/tools/publish/lib/processor.js
@@ -110,13 +110,22 @@ function stripDataview(markdown) {
 // <!-- gm-only -->...<!-- /gm-only -->). Shared implementation behind
 // stripGmOnly and stripSpoiler — same stripping behavior, different marker
 // name, so a marker of one name never strips a block of the other name.
+//
+// Nesting-aware by depth, NOT a boolean (#168). With a boolean, the first
+// closer ended the outer block, so wrapping a region that already contained
+// inner fences published everything after that inner closer. The markers looked
+// balanced, so the author had no reason to doubt the region was covered, and
+// nothing warned. Silent under-protection is the worst possible failure of the
+// one primitive whose entire job is hiding things — so an inner block now
+// closes only itself, and the outer block survives it.
 function stripMarkedBlocks(markdown, markerName) {
   const openRe = new RegExp(`^<!--\\s*${markerName}\\s*-->`);
   const closeRe = new RegExp(`^<!--\\s*/${markerName}\\s*-->`);
   const lines = markdown.split('\n');
   const result = [];
   const warnings = [];
-  let excluding = false;
+  let depth = 0;
+  let orphanClosers = 0;
   let inCodeFence = false;
 
   for (let i = 0; i < lines.length; i++) {
@@ -127,28 +136,41 @@ function stripMarkedBlocks(markdown, markerName) {
     }
 
     if (inCodeFence) {
-      if (!excluding) result.push(line);
+      if (depth === 0) result.push(line);
       continue;
     }
 
     if (openRe.test(line.trim())) {
-      excluding = true;
-      result.push('');
+      depth += 1;
+      if (depth === 1) result.push('');   // one blank stands in for the whole block
       continue;
     }
 
     if (closeRe.test(line.trim())) {
-      excluding = false;
+      if (depth === 0) {
+        // A closer with nothing open. Don't let it drive depth negative — that
+        // would make a LATER opener fail to strip. Count it and warn instead.
+        orphanClosers += 1;
+        continue;
+      }
+      depth -= 1;
       continue;
     }
 
-    if (!excluding) {
+    if (depth === 0) {
       result.push(line);
     }
   }
 
-  if (excluding) {
-    warnings.push(`unclosed <!-- ${markerName} --> marker — content stripped to end of file`);
+  if (depth > 0) {
+    warnings.push(
+      `unclosed <!-- ${markerName} --> marker (${depth} block${depth === 1 ? '' : 's'} still open) `
+      + '— content stripped to end of file');
+  }
+  if (orphanClosers > 0) {
+    warnings.push(
+      `${orphanClosers} <!-- /${markerName} --> marker${orphanClosers === 1 ? '' : 's'} `
+      + `without a matching <!-- ${markerName} --> — check the block boundaries`);
   }
 
   const text = result.join('\n');

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.23",
+  "version": "1.11.24",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/fixtures/with-gm-only-markers/Locations/Catacombs.md
+++ b/tools/publish/test/fixtures/with-gm-only-markers/Locations/Catacombs.md
@@ -1,0 +1,32 @@
+---
+type: location
+location_type: Underground
+atmosphere: Damp
+canon_status: AUTHORITATIVE
+aliases: []
+tags: []
+---
+
+## Description
+
+Ossuary tunnels beneath the cathedral.
+
+<!-- gm-only -->
+## Keeper Briefing
+
+The ossuary is a cult site.
+
+<!-- gm-only -->
+The high priest is Malachar.
+<!-- /gm-only -->
+
+The relic is buried beneath the third alcove.
+
+### The Climax
+
+Vaskorrin manifests here in the final scene.
+<!-- /gm-only -->
+
+## Public Access
+
+Guided tours run on feast days.

--- a/tools/publish/test/fixtures/with-publish-controls/Chapters/Chapter_4_Overview.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Chapters/Chapter_4_Overview.md
@@ -1,0 +1,21 @@
+---
+type: chapter
+publish: stub
+publish_include_sections: [Synopsis]
+---
+
+# Chapter 4 - Calcutta
+
+Prep preamble that must not publish.
+
+## Synopsis
+
+The party arrives in Calcutta at the height of the hot season.
+
+## Key NPCs
+
+Havildar Singh is the traitor.
+
+## The Climax
+
+The cult completes the rite beneath the ossuary.

--- a/tools/publish/test/fixtures/with-publish-controls/Characters/NPCs/Acharya_Devendra_Ghosh.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Characters/NPCs/Acharya_Devendra_Ghosh.md
@@ -1,0 +1,11 @@
+---
+type: npc
+occupation: Cult Leader
+status: alive
+---
+
+# Acharya Devendra Ghosh
+
+## Description
+
+A respected scholar of the old texts.

--- a/tools/publish/test/fixtures/with-publish-controls/Characters/NPCs/Havildar_Singh.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Characters/NPCs/Havildar_Singh.md
@@ -1,0 +1,19 @@
+---
+type: npc
+occupation: "Havildar, 67th Bengal Native Infantry (cover) / Thuggee Operative (true)"
+key_traits: ["Impeccable military bearing", "Devout servant of Kali"]
+status: alive
+publish_exclude_fields: [occupation, key_traits]
+relationships:
+  - target: "[[Party_Escort_Duty]]"
+    type: knows
+  - target: "[[Acharya_Devendra_Ghosh]]"
+    type: serves
+    gm_only: true
+---
+
+# Havildar Singh
+
+## Description
+
+A steady escort assigned to the party in Calcutta.

--- a/tools/publish/test/fixtures/with-publish-controls/Characters/NPCs/Innkeeper.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Characters/NPCs/Innkeeper.md
@@ -1,0 +1,14 @@
+---
+type: npc
+occupation: Publican
+status: alive
+relationships:
+  - target: "[[Party_Escort_Duty]]"
+    type: knows
+---
+
+# Innkeeper
+
+## Description
+
+Runs the rest house on the Grand Trunk Road.

--- a/tools/publish/test/fixtures/with-publish-controls/Characters/PCs/Mira_Chandra.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Characters/PCs/Mira_Chandra.md
@@ -1,0 +1,20 @@
+---
+type: pc
+player_name: Sam
+occupation: Surveyor
+status: active
+publish: stub
+publish_include_sections: [Overview]
+---
+
+# Mira Chandra
+
+Prep preamble on the PC page.
+
+## Overview
+
+A surveyor attached to the Calcutta expedition.
+
+## Secret History
+
+Mira has been feeding the cult information since Bombay.

--- a/tools/publish/test/fixtures/with-publish-controls/Characters/PCs/Mira_Chandra_Story.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Characters/PCs/Mira_Chandra_Story.md
@@ -1,0 +1,12 @@
+---
+type: character-story
+character: "[[Mira_Chandra]]"
+---
+
+## Overview
+
+Mira's public arc across the expedition.
+
+## Session 3
+
+Mira met her cult handler behind the customs house.

--- a/tools/publish/test/fixtures/with-publish-controls/Locations/Fort_William.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Locations/Fort_William.md
@@ -1,0 +1,15 @@
+---
+type: location
+location_type: Fortress
+publish: false
+---
+
+# Fort William
+
+## Description
+
+The Company seat in Calcutta.
+
+## Infiltration
+
+Sepoys 3, 7 and 11 are cult impostors.

--- a/tools/publish/test/fixtures/with-publish-controls/Locations/Grand_Trunk_Road.md
+++ b/tools/publish/test/fixtures/with-publish-controls/Locations/Grand_Trunk_Road.md
@@ -1,0 +1,10 @@
+---
+type: location
+location_type: Road
+---
+
+# Grand Trunk Road
+
+## Description
+
+The road runs west from [[Fort_William]] toward the interior.

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -1577,3 +1577,93 @@ describe('build integration', () => {
     });
   });
 });
+
+describe('publish controls (#166, #167)', () => {
+  const fixturesDir = path.join(__dirname, '..', 'fixtures');
+  let outputDir;
+  let configPath;
+
+  before(() => {
+    outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-pubctl-'));
+    configPath = path.join(outputDir, 'config.json');
+    const config = {
+      vaultPath: path.join(fixturesDir, 'with-publish-controls'),
+      outputDir: path.join(outputDir, 'docs'),
+      attachmentsDir: '_attachments',
+      siteTitle: 'Publish Controls Test',
+      siteUrl: 'https://example.github.io/test-pubctl',
+      excludeDirs: ['_meta'],
+      excludeSections: [],
+      folderMap: {
+        'Characters/NPCs': 'characters/npcs',
+        'Locations': 'locations',
+        'Chapters': 'chapters',
+      },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    build({ configPath });
+  });
+
+  after(() => {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  const read = (...p) => fs.readFileSync(path.join(outputDir, 'docs', ...p), 'utf-8');
+  const exists = (...p) => fs.existsSync(path.join(outputDir, 'docs', ...p));
+
+  it('publish: false emits no page at all', () => {
+    assert.ok(!exists('locations', 'fort-william.html'));
+  });
+
+  it('publish: false keeps its body out of the search index', () => {
+    const idx = read('search-index.json').toLowerCase();
+    assert.ok(!idx.includes('impostors'));
+    assert.ok(!idx.includes('fort william'));
+  });
+
+  it('a link to a publish: false page renders as plain text, not a broken href', () => {
+    const html = read('locations', 'grand-trunk-road.html');
+    assert.ok(html.includes('Fort William'));            // still readable prose
+    assert.ok(!html.includes('fort-william.html'));      // but not a link
+  });
+
+  it('publish: stub keeps the page for navigation', () => {
+    assert.ok(exists('chapters', 'chapter-4-overview.html'));
+  });
+
+  it('publish: stub emits only the named sections', () => {
+    const html = read('chapters', 'chapter-4-overview.html');
+    assert.ok(html.includes('hot season'));              // the included Synopsis
+    assert.ok(!html.includes('Prep preamble'));
+    assert.ok(!html.includes('Key NPCs'));
+    assert.ok(!html.includes('is the traitor'));
+    assert.ok(!html.includes('The Climax'));
+    assert.ok(!html.includes('beneath the ossuary'));
+  });
+
+  it('publish_exclude_fields hides the fields on that file only', () => {
+    const singh = read('characters', 'npcs', 'havildar-singh.html');
+    assert.ok(!singh.includes('Thuggee'));
+    assert.ok(!singh.includes('Devout servant'));
+    const innkeeper = read('characters', 'npcs', 'innkeeper.html');
+    assert.ok(innkeeper.includes('Publican'));           // every other NPC unaffected
+  });
+
+  it('a gm_only relationship edge does not reach the page or its graph', () => {
+    const singh = read('characters', 'npcs', 'havildar-singh.html');
+    assert.ok(!singh.includes('Acharya'));
+    assert.ok(!singh.includes('Devendra'));
+  });
+
+  // No reverse-direction assertion here on purpose. The target page carries no
+  // backlink or graph markup for an inbound frontmatter edge in this
+  // configuration, so `!cultist.includes('Havildar')` passes whether or not
+  // the filtering works — it reads as coverage while proving nothing. The
+  // forward surface above is the one that actually regressed.
+
+  it('excluded fields and gm_only targets stay out of the search index', () => {
+    const idx = read('search-index.json').toLowerCase();
+    assert.ok(!idx.includes('thuggee'));
+    assert.ok(!idx.includes('devout servant'));
+  });
+});

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -1186,6 +1186,27 @@ describe('build integration', () => {
       assert.ok(!html.includes('Secret Chamber'));
       assert.ok(!html.includes('treasure'));
     });
+
+    // #168: an inner gm-only block used to close the OUTER one, so everything
+    // between the inner closer and the outer closer published. Balanced
+    // markers, no warning — the author had no way to see it had failed.
+    it('a nested gm-only block does not end the enclosing block', () => {
+      const html = fs.readFileSync(path.join(outputDir, 'docs', 'locations', 'catacombs.html'), 'utf-8');
+      assert.ok(html.includes('Ossuary tunnels'));       // public lede survives
+      assert.ok(html.includes('Guided tours'));          // public tail survives
+      assert.ok(!html.includes('Malachar'));             // inner block
+      assert.ok(!html.includes('third alcove'));         // AFTER the inner closer
+      assert.ok(!html.includes('Vaskorrin'));           // after it too
+      assert.ok(!html.includes('Keeper Briefing'));
+      assert.ok(!html.includes('The Climax'));
+    });
+
+    it('keeps nested gm-only content out of search-index.json', () => {
+      const indexJson = fs.readFileSync(path.join(outputDir, 'docs', 'search-index.json'), 'utf-8').toLowerCase();
+      assert.ok(!indexJson.includes('malachar'));
+      assert.ok(!indexJson.includes('third alcove'));
+      assert.ok(!indexJson.includes('vaskorrin'));
+    });
   });
 
   describe('excludeCallouts (issue #137)', () => {

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -1596,6 +1596,7 @@ describe('publish controls (#166, #167)', () => {
       excludeSections: [],
       folderMap: {
         'Characters/NPCs': 'characters/npcs',
+        'Characters/PCs': 'characters/pcs',
         'Locations': 'locations',
         'Chapters': 'chapters',
       },
@@ -1660,6 +1661,22 @@ describe('publish controls (#166, #167)', () => {
   // configuration, so `!cultist.includes('Havildar')` passes whether or not
   // the filtering works — it reads as coverage while proving nothing. The
   // forward surface above is the one that actually regressed.
+
+  it('publish: stub reduces the PC story companion too', () => {
+    // The story is a SEPARATE file rendered on its own page. Reducing only the
+    // PC page left a stubbed PC publishing its complete story one URL over.
+    const story = read('story', 'characters', 'mira-chandra.html');
+    assert.ok(story.includes('public arc'));          // the included Overview
+    assert.ok(!story.includes('cult handler'));
+    assert.ok(!story.includes('Session 3'));
+  });
+
+  it('publish: stub reduces the PC page itself', () => {
+    const pc = read('characters', 'pcs', 'mira-chandra.html');
+    assert.ok(!pc.includes('Prep preamble'));
+    assert.ok(!pc.includes('Secret History'));
+    assert.ok(!pc.includes('feeding the cult'));
+  });
 
   it('excluded fields and gm_only targets stay out of the search index', () => {
     const idx = read('search-index.json').toLowerCase();

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -232,6 +232,72 @@ describe('stripGmOnly', () => {
     assert.ok(warnings[0].includes('without a matching'));
   });
 
+  // A marker inside a code example is documentation, not a directive. Only
+  // ``` was recognised, so a closer shown inside a ~~~ block, a longer fence,
+  // or an indented fence was obeyed — ending the real block early and
+  // publishing everything after it. This repo's own docs demonstrate the
+  // markers inside fenced examples, so it is a live shape.
+  it('ignores markers inside a ~~~ fence', () => {
+    const md = [
+      '<!-- gm-only -->',
+      'secret one',
+      '~~~markdown',
+      '<!-- /gm-only -->',
+      '~~~',
+      'secret two',
+      '<!-- /gm-only -->',
+      'public',
+    ].join('\n');
+    assert.strictEqual(stripGmOnly(md), '\npublic');
+  });
+
+  it('ignores markers inside a fence longer than three backticks', () => {
+    const md = [
+      '<!-- gm-only -->',
+      '````',
+      '```',
+      '<!-- /gm-only -->',
+      '```',
+      '````',
+      'secret tail',
+      '<!-- /gm-only -->',
+      'public',
+    ].join('\n');
+    assert.strictEqual(stripGmOnly(md), '\npublic');
+  });
+
+  it('ignores markers inside a fence indented up to three spaces', () => {
+    const md = [
+      '<!-- gm-only -->',
+      '   ```',
+      '<!-- /gm-only -->',
+      '   ```',
+      'secret tail',
+      '<!-- /gm-only -->',
+      'public',
+    ].join('\n');
+    assert.strictEqual(stripGmOnly(md), '\npublic');
+  });
+
+  it('a ``` line does not close a ~~~ fence', () => {
+    const md = [
+      '<!-- gm-only -->',
+      '~~~',
+      '```',
+      '<!-- /gm-only -->',
+      '~~~',
+      'secret tail',
+      '<!-- /gm-only -->',
+      'public',
+    ].join('\n');
+    assert.strictEqual(stripGmOnly(md), '\npublic');
+  });
+
+  it('still publishes a fenced code example that sits outside any block', () => {
+    const md = 'Intro\n~~~markdown\n<!-- gm-only -->\nexample\n<!-- /gm-only -->\n~~~\nAfter';
+    assert.strictEqual(stripGmOnly(md), md);
+  });
+
   it('reports how many blocks were left open at EOF', () => {
     const md = '<!-- gm-only -->\na\n<!-- gm-only -->\nb';
     const { text, warnings } = stripGmOnly(md);

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { escapeHtml, relativePath, relativeHref, parseWikiRef, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, stripSpoiler, stripCallouts, filterFields, renderRelationships } = require('../../lib/processor');
+const { escapeHtml, relativePath, relativeHref, parseWikiRef, resolveWikiLinks, filterSections, stripDataview, stripLeadingH1, stripGmOnly, stripSpoiler, stripCallouts, filterFields, renderRelationships, publishMode, keepOnlySections, publishedFrontmatter } = require('../../lib/processor');
 
 describe('escapeHtml', () => {
   it('escapes angle brackets', () => {
@@ -585,5 +585,109 @@ describe('resolveWikiLinks on non-image transclusions (review regression)', () =
   it('still resolves an ordinary wikilink', () => {
     const out = resolveWikiLinks('[[Backstory]]', { Backstory: 'docs/backstory.html' }, 'x.html');
     assert.strictEqual(out, '[Backstory](docs/backstory.html)');
+  });
+});
+
+describe('publishMode (#167)', () => {
+  it('defaults to all when the key is absent', () => {
+    assert.strictEqual(publishMode({}), 'all');
+  });
+
+  it('reads false, "false" and "none" as none', () => {
+    assert.strictEqual(publishMode({ publish: false }), 'none');
+    assert.strictEqual(publishMode({ publish: 'false' }), 'none');
+    assert.strictEqual(publishMode({ publish: 'none' }), 'none');
+  });
+
+  it('reads stub', () => {
+    assert.strictEqual(publishMode({ publish: 'stub' }), 'stub');
+  });
+
+  // A typo must not silently unpublish a page — nor silently publish one that
+  // was meant to be hidden. Only the explicit opt-outs count.
+  it('treats anything unrecognized as all', () => {
+    assert.strictEqual(publishMode({ publish: 'no' }), 'all');
+    assert.strictEqual(publishMode({ publish: true }), 'all');
+    assert.strictEqual(publishMode({ publish: 'yes' }), 'all');
+  });
+});
+
+describe('keepOnlySections (#167)', () => {
+  const md = '# Title\n\npreamble\n\n## Overview\n\npublic\n\n## The Climax\n\nsecret\n';
+
+  it('keeps nothing by default', () => {
+    assert.strictEqual(keepOnlySections(md, []), '');
+  });
+
+  it('keeps only the named section, dropping preamble and everything else', () => {
+    const out = keepOnlySections(md, ['Overview']);
+    assert.ok(out.includes('## Overview'));
+    assert.ok(out.includes('public'));
+    assert.ok(!out.includes('preamble'));
+    assert.ok(!out.includes('The Climax'));
+    assert.ok(!out.includes('secret'));
+  });
+
+  it('matches heading titles case-insensitively', () => {
+    assert.ok(keepOnlySections(md, ['overview']).includes('public'));
+  });
+
+  it('ends a kept section at the next same-or-higher heading', () => {
+    const nested = '## Keep\n\na\n\n### Child\n\nb\n\n## Drop\n\nc\n';
+    const out = keepOnlySections(nested, ['Keep']);
+    assert.ok(out.includes('a') && out.includes('b'));   // child rides along
+    assert.ok(!out.includes('c'));
+  });
+});
+
+describe('publishedFrontmatter (#166)', () => {
+  it('drops relationship edges marked gm_only', () => {
+    const fm = { relationships: [
+      { target: '[[Innkeeper]]', type: 'knows' },
+      { target: '[[Cult_Leader]]', type: 'serves', gm_only: true },
+    ] };
+    const out = publishedFrontmatter(fm, [], {});
+    assert.strictEqual(out.relationships.length, 1);
+    assert.strictEqual(out.relationships[0].target, '[[Innkeeper]]');
+  });
+
+  it('removes the relationships key entirely when every edge is gm_only', () => {
+    const fm = { relationships: [{ target: '[[X]]', type: 'serves', gm_only: true }] };
+    assert.ok(!('relationships' in publishedFrontmatter(fm, [], {})));
+  });
+
+  it('applies the file own publish_exclude_fields on top of the global list', () => {
+    const fm = { occupation: 'Thuggee Operative', age: 40, publish_exclude_fields: ['occupation'] };
+    const out = publishedFrontmatter(fm, [], {});
+    assert.ok(!('occupation' in out));
+    assert.strictEqual(out.age, 40);          // untouched for every other NPC
+  });
+
+  // The config is a campaign-wide default; the frontmatter is the GM saying it
+  // about this specific secret. Where they disagree, hiding wins.
+  it('does not let a config include re-admit a per-file exclusion', () => {
+    const fm = { occupation: 'secret', publish_exclude_fields: ['occupation'] };
+    const out = publishedFrontmatter(fm, ['occupation'], { include: ['occupation'] });
+    assert.ok(!('occupation' in out));
+  });
+
+  it('still honours a config include against the global list alone', () => {
+    const fm = { occupation: 'Publican' };
+    const out = publishedFrontmatter(fm, ['occupation'], { include: ['occupation'] });
+    assert.strictEqual(out.occupation, 'Publican');
+  });
+
+  it('strips its own control fields', () => {
+    const fm = { publish: 'stub', publish_exclude_fields: ['x'], publish_include_sections: ['y'] };
+    const out = publishedFrontmatter(fm, [], {});
+    assert.ok(!('publish' in out));
+    assert.ok(!('publish_exclude_fields' in out));
+    assert.ok(!('publish_include_sections' in out));
+  });
+
+  it('leaves a vault with none of the new keys unchanged', () => {
+    const fm = { occupation: 'Publican', relationships: [{ target: '[[A]]', type: 'knows' }] };
+    const out = publishedFrontmatter(fm, [], {});
+    assert.deepStrictEqual(out, fm);
   });
 });

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -187,6 +187,59 @@ describe('stripGmOnly', () => {
     const result = stripGmOnly(md);
     assert.strictEqual(result, 'Public\n\nMore');
   });
+
+  // #168: fences were matched with a boolean, so the FIRST closer ended the
+  // outer block and everything after it published. A GM who wrapped a region
+  // that already contained inner fences saw balanced markers and reasonably
+  // assumed the whole region was covered. Silent under-protection is the worst
+  // failure mode for the one feature whose job is hiding things.
+  it('nests: an inner block does not end the outer block', () => {
+    const md = [
+      '<!-- gm-only -->',
+      '## Premise',
+      '<!-- gm-only -->',
+      'secret A',
+      '<!-- /gm-only -->',
+      'still secret',
+      '<!-- /gm-only -->',
+      'public tail',
+    ].join('\n');
+    const result = stripGmOnly(md);
+    // one blank stands in for the whole outer block, inner markers add none
+    assert.strictEqual(result, '\npublic tail');
+    assert.ok(!String(result).includes('still secret'));
+    assert.ok(!String(result).includes('Premise'));
+  });
+
+  it('nests three deep', () => {
+    const md = [
+      '<!-- gm-only -->', 'a',
+      '<!-- gm-only -->', 'b',
+      '<!-- gm-only -->', 'c',
+      '<!-- /gm-only -->', 'd',
+      '<!-- /gm-only -->', 'e',
+      '<!-- /gm-only -->',
+      'public',
+    ].join('\n');
+    assert.strictEqual(stripGmOnly(md), '\npublic');
+  });
+
+  it('warns on a closer that never opened, and keeps publishing after it', () => {
+    const md = 'A\n<!-- gm-only -->\nsecret\n<!-- /gm-only -->\nB\n<!-- /gm-only -->\nC';
+    const { text, warnings } = stripGmOnly(md);
+    assert.strictEqual(text, 'A\n\nB\nC');
+    assert.strictEqual(warnings.length, 1);
+    assert.ok(warnings[0].includes('without a matching'));
+  });
+
+  it('reports how many blocks were left open at EOF', () => {
+    const md = '<!-- gm-only -->\na\n<!-- gm-only -->\nb';
+    const { text, warnings } = stripGmOnly(md);
+    assert.strictEqual(text, '');
+    assert.strictEqual(warnings.length, 1);
+    assert.ok(warnings[0].includes('unclosed'));
+    assert.ok(warnings[0].includes('2'));
+  });
 });
 
 describe('stripSpoiler', () => {

--- a/tools/publish/test/unit/processor.test.js
+++ b/tools/publish/test/unit/processor.test.js
@@ -691,3 +691,30 @@ describe('publishedFrontmatter (#166)', () => {
     assert.deepStrictEqual(out, fm);
   });
 });
+
+describe('CRLF line endings', () => {
+  // A vault authored on Windows (or checked out with core.autocrlf) arrives
+  // with \r\n. The heading pattern ends in `$`, and `.` does not match `\r`,
+  // so NO heading matched and `## GM Notes` was never excluded. processContent
+  // strips \r before rendering, so the page itself was safe — but
+  // publishedMarkdown does not, and that is what feeds the search index,
+  // backlinks and recency. GM prose reached the search index verbatim.
+  const crlf = '## Public\r\npublic body\r\n\r\n## GM Notes\r\nSECRET PROSE\r\n';
+
+  it('filterSections still excludes a section on CRLF input', () => {
+    const out = filterSections(crlf, ['GM Notes']);
+    assert.ok(!out.includes('SECRET PROSE'));
+    assert.ok(out.includes('public body'));
+  });
+
+  it('keepOnlySections still finds its heading on CRLF input', () => {
+    const out = keepOnlySections(crlf, ['Public']);
+    assert.ok(out.includes('public body'));
+    assert.ok(!out.includes('SECRET PROSE'));
+  });
+
+  it('handles a lone CR as well', () => {
+    const cr = '## Public\rpublic body\r\r## GM Notes\rSECRET\r';
+    assert.ok(!filterSections(cr, ['GM Notes']).includes('SECRET'));
+  });
+});


### PR DESCRIPTION
GM content reaching player-facing sites, all found while publishing a live Call
of Cthulhu campaign containing a traitor PC. Plugin 1.8.52, publish tool
1.11.24.

Three issues, one root problem: the GM-only story stopped at body prose. Fences
under-protected in two ways, and frontmatter — plus everything derived from it —
had no protection mechanism at all.

---

## 1. `<!-- gm-only -->` fences did not nest (#168)

The markers were tracked with a boolean, so the **first** closer ended the outer
block and everything after it published:

```markdown
<!-- gm-only -->
## Keeper Briefing
<!-- gm-only -->
inner secret
<!-- /gm-only -->      <-- outer block ended HERE
everything from here published
<!-- /gm-only -->
```

Balanced markers, no warning, nothing in the source to suggest it had failed.
Silent under-protection is the worst failure mode for the one primitive whose
whole job is hiding things. Fences are depth-counted now — an inner block closes
only itself. `<!-- spoiler -->` inherits the fix from the same implementation.

## 2. Only ` ``` ` counted as a code fence (#168, found in review)

A marker shown inside a `~~~` block, a ` ```` `-length fence, or a fence
indented up to three spaces was obeyed as a *real* directive, ending the
enclosing block early. **This repo's own docs demonstrate these markers inside
fenced examples**, so it is a shape GMs are likely to copy into vault notes.

Fence tracking now follows CommonMark: same delimiter character, at least as
long as the opener, nothing but whitespace after. Not simply a looser regex —
this leaks in both directions. Miss a fence and an example closer gets obeyed;
invent one and a *real* opener gets ignored and nothing is stripped.

## 3. `## Reconciliation Context` published (#168)

Everything in it is Keeper-facing — GM decisions and rationale, unplayed-prep
dispositions, and the World Evolution block describing what the factions did
off-screen. As a sibling H2 of `## GM Notes` rather than a child, it published;
in the reporting vault it revealed an antagonist's position the party had not
discovered, across 9 wrap-up files.

Adding it to the default `exclude_sections` does **not** fix this — it has been
in the defaults for some time. A vault that sets its own `exclude_sections`
keeps that list as written, so a newly-added default never reaches it (the
behaviour settled in #159). It is now written as a `###` under `## GM Notes`,
which every config already hides — the point of the 1.8.3 two-primitive
standard. Readers accept both forms, so an un-migrated vault keeps working.

## 4. Frontmatter and derived views had no protection (#166)

`<!-- gm-only -->` is a **body** primitive with no meaning in frontmatter. A
secret held in a field, or in the mere existence of an edge, could not be hidden
without stripping the field campaign-wide. Added:

- **`publish_exclude_fields`** — field names hidden on that file alone, merged
  over the global `exclude_fields`. Excluding `occupation` campaign-wide to hide
  one traitor would strip it from every honest NPC.
- **`gm_only: true` on a single `relationships[]` entry** — some edges *are* the
  secret. Dropped from the page, the graph and the search index.

A per-file exclusion is deliberately **not** re-admitted by a config-level
`overrides.fields.*.include`: the config is a campaign-wide default, the
frontmatter is the GM speaking about this specific secret. Hiding wins.

### The bug underneath it

Frontmatter filtering ran *after* backlinks, the search index and the
relationship graphs had already been built from the raw frontmatter. Excluding
`relationships` still drew the Connections graph with the secret targets as node
labels; excluding `occupation` still shipped it as the search-index subtitle —
so `exclude_fields` did not work for derived views even globally. The published
view is now computed once, immediately after the link map, and everything
derived is built from it.

## 5. No file-level exclusion existed (#167)

`exclude_dirs` works per directory, `exclude_sections` per heading,
`exclude_fields` per field — and nothing per file. A wholly Keeper-facing page
in an otherwise publishable folder had to be fenced section by section and
re-audited after every edit.

- **`publish: false`** — no page emitted, in **every** mode including `full`. A
  flag named "never publish" that publishes under some setting is worse than no
  flag. The file still parses, so links to it render as plain text rather than
  breaking.
- **`publish: stub`** — the chapter-overview case: page kept for navigation,
  body reduced to the sections named in `publish_include_sections`, which
  **defaults to none**. A stub opts content *in*, so a section added later stays
  hidden until the GM names it.

Note `exclude_dirs` defaults to `['_meta', '_Templates']`, so `Planning/`
publishes — whole session plans, Contingency Scenes and all. `publish: false`
now gives a way to handle that per file.

---

## Migration

`1.8.51 → 1.8.52` re-nests existing `## Reconciliation Context` under
`## GM Notes` — a pure structural move applied after preview confirmation,
modelled on the 1.8.3 re-nesting. The three new frontmatter fields are optional
and absent by default; nothing is backfilled and a vault that uses none of them
is unaffected.

Closes #166
Closes #167
Closes #168

## Verification

- `tools/publish` — 1475/1475 (34 new)
- **Mutation-tested.** Reverting each behaviour in turn fails the tests that
  cover it: 5 for fence nesting, 5 for fence recognition, 11 for the publish
  controls. All pass restored.
- schema + ontology validation, benchmark-campaign, filtering rules — pass
- 9 python test files from `lint.yml` — pass
- skill-creator validation on `session-prep`, `ttrpg-expert`, `publish-site`
- markdownlint on every changed file — clean

One integration assertion was **removed rather than kept**: a check that a
`gm_only` edge stays out of the *target* page's backlinks passed even with
filtering disabled, because that page carries no inbound-edge markup in this
configuration. It read as coverage while proving nothing. The forward surface,
which is what actually regressed, is covered.
