### PR TITLE
Make the landing page configurable and pinnable (#169)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.8.52",
+  "version": "1.8.53",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.53] — 2026-08-22
+
+Landing page selection: the config that controlled it did nothing, and the
+scoring it fell back on could not be steered (#169). Publish tool 1.11.25.
+
+### Fixed
+
+- **`publish.landing.*` is read at last.** `build.js` has always consulted
+  `publishConfig.landing`, but `loadPublishConfig` built its result from a key
+  whitelist that `landing` was not on — so the key was permanently `undefined`
+  and every knob under it was silently ignored. The landing page was fixed at 6
+  NPCs / 4 locations / window 3 regardless of what the GM configured, in either
+  `_meta/vault-config.md` or `vault.config.json`. It now merges per key, publish
+  block first, so setting one value does not reset the others. This also
+  revives `max_events` and `explore_descriptions`, which the landing template
+  read from the same dead key.
+- **Landing ties break deterministically.** The sort had no secondary key, and
+  `Array.prototype.sort` is stable, so equally-scoring entities kept vault scan
+  order — meaning which ones survived the cut was decided by where their files
+  sat on disk. Invisible to the GM and unchangeable by anything they could
+  author. Ties now break by title: not more "relevant", but explainable, and
+  `featured_*` is the supported way to override it.
+
+### Added
+
+- **`featured_npcs`, `featured_locations`, `quick_links`.** Pinned entries lead
+  their section in the order given, with recency filling the remaining slots. A
+  pinned entity appears even if it scores nothing, so an NPC no session has
+  mentioned yet is still featurable. A name that resolves to no published page
+  prints a build warning rather than vanishing — silence there would repeat the
+  exact complaint this fixes. `quick_links` renders a short row of pinned
+  destinations near the top of the landing page.
+
+### Note
+
+The same issue reported that recency scoring compares an entity's **H1 title**
+against wiki-link targets, so entities whose display title differs from their
+filename can never be featured. That does not reproduce: `scanner.js` sets
+`page.title` to the **filename base** (the H1 goes to `displayTitle`, which
+recency never reads), and the mention pattern already stops its capture at the
+`|`. An NPC filed as `Margaret_Cavendish.md` with H1 `Margaret "Meg" Cavendish`,
+referenced only as `[[Margaret_Cavendish|Meg]]`, scores and is returned. The
+scoring path was left alone; the two fixes above are what actually produced the
+reported symptom.
+
+---
+
 ## [1.8.52] — 2026-08-21
 
 GM content reaching player-facing sites, found while publishing a live Call of

--- a/skills/publish-site/references/configuration.md
+++ b/skills/publish-site/references/configuration.md
@@ -18,6 +18,12 @@ each other — see § Precedence.
 | Excluded callouts | `publish.exclude_callouts` | Strip Obsidian callouts (`> [!type]`): `true` for all, or an array of types (default: `false`; scaffolded sites set `true`) |
 | Excluded fields | `publish.exclude_fields` | Frontmatter fields to strip (default: `["secrets", "current_plan", "plan_progress", "gm_notes", "prep_notes"]`) |
 | Excluded directories | `publish.exclude_dirs` | Vault directories to skip (default: `["_meta", "_Templates"]`) |
+| Landing NPC count | `publish.landing.max_npcs` | Cards in "NPCs in Play" (default: `6`) |
+| Landing location count | `publish.landing.max_locations` | Cards in "Latest Locations" (default: `4`) |
+| Landing recency window | `publish.landing.recency_window` | How many recent sessions feed the scoring (default: `3`) |
+| Featured NPCs | `publish.landing.featured_npcs` | Pin NPCs to the front of their section, in order (see § Pinning landing entries) |
+| Featured locations | `publish.landing.featured_locations` | Same, for locations |
+| Quick links | `publish.landing.quick_links` | A short row of pinned links near the top of the landing page |
 | Campaign image | `publish.theme.campaign_image` | Vault-relative path to hero image |
 | Theme palette | `publish.theme.palette` | Colour scheme (primary, accent, background, text) |
 | Theme fonts | `publish.theme.fonts` | Heading and body font families |
@@ -146,6 +152,36 @@ scaffolding above the pivot (the Republic, the Sector) is demoted to a
 small context caption rather than rendered as tree rows. Grouping is
 skipped — falling back to the flat view — when fewer than two locations
 match the pivot, since one section is not a grouping.
+
+### Pinning landing entries
+
+The landing page picks NPCs and locations by a recency score — how often
+an entity appears in the last few sessions. That is a reasonable default
+and a poor editor: a GM who knows which five NPCs matter this session
+cannot express it, and entities tied on score are separated by nothing
+more meaningful than where their files sit on disk.
+
+`featured_npcs` / `featured_locations` pin entries to the front of their
+section, in the order listed, with recency filling whatever slots remain
+up to `max_npcs` / `max_locations`. A pinned entity appears even if it
+scores nothing — an NPC no session has mentioned yet is still featurable.
+
+```yaml
+publish:
+  landing:
+    max_npcs: 6
+    featured_npcs: ["Hugh_Cavendish", "Margaret_Cavendish"]
+    featured_locations: ["Cavendish_Compound"]
+    quick_links: ["Calcutta_City_Map", "Calcutta_Season_Calendar"]
+```
+
+Name entities the same way a wiki-link does — the filename form, not the
+display title. A name that resolves to no published page prints a build
+warning rather than being dropped in silence; if it is spelled right, the
+page is probably excluded from the site.
+
+Entities left unpinned still sort by score, and ties now break by title,
+so the selection is at least reproducible and explainable.
 
 ### Per-file field overrides
 

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -1089,6 +1089,31 @@ tr:nth-child(even) {
   gap: 0.75rem;
 }
 
+/* Quick links — a short GM-pinned row, so a wrapping flex line rather than a
+   card grid: these are destinations, not entities to browse. */
+.quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-link {
+  display: inline-block;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.15));
+  border-radius: 999px;
+  background: var(--color-surface, transparent);
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.quick-link:hover,
+.quick-link:focus-visible {
+  border-color: var(--color-accent, currentColor);
+  text-decoration: none;
+}
+
 /* Location grid */
 .location-grid {
   display: grid;

--- a/tools/publish/lib/build.js
+++ b/tools/publish/lib/build.js
@@ -373,21 +373,74 @@ function build(options = {}) {
   const landingConfig = (publishConfig.landing || {});
   const recencyWindow = landingConfig.recency_window || 3;
 
-  const recentNPCs = scoreByRecency(npcs, sessions, chapters, {
-    window: recencyWindow,
-    max: landingConfig.max_npcs || 6,
-    type: 'npc',
-    wrapUps,
-  });
+  // Pinned entries come first, in the order the GM listed them; recency fills
+  // whatever slots are left. This is the supported way to override the scoring
+  // heuristic — without it a GM who knows which entities matter this session
+  // has to reverse-engineer a score to feature them, and cannot break a tie at
+  // all. Named by the same form a wiki-link uses (the filename), so a name that
+  // can be linked can be pinned.
+  function withFeatured(scored, candidates, featured, max, label) {
+    const names = Array.isArray(featured) ? featured.filter(n => typeof n === 'string') : [];
+    if (names.length === 0) return scored.slice(0, max);
+    const byName = new Map(candidates.map(p => [canonicalNfc(p.title), p]));
+    const pinned = [];
+    const seen = new Set();
+    for (const name of names) {
+      const page = byName.get(canonicalNfc(name));
+      if (!page) {
+        // Silence here would repeat the very complaint this fixes: config that
+        // looks applied and does nothing.
+        console.warn(`  WARNING: landing.${label} names "${name}", which is not a published ${label.replace('featured_', '').replace(/s$/, '')} — check spelling, or it may be excluded from the site`);
+        continue;
+      }
+      if (seen.has(page.outputPath)) continue;
+      seen.add(page.outputPath);
+      pinned.push({ page, score: Infinity, pinned: true });
+    }
+    const rest = scored.filter(s => !seen.has(s.page.outputPath));
+    return [...pinned, ...rest].slice(0, max);
+  }
 
-  const recentLocations = scoreByRecency(locations, sessions, chapters, {
-    window: recencyWindow,
-    max: landingConfig.max_locations || 4,
-    type: 'location',
-    wrapUps,
-  });
+  const maxNPCs = landingConfig.max_npcs || 6;
+  const maxLocations = landingConfig.max_locations || 4;
 
-  console.log(`Recency: ${recentNPCs.length} NPCs, ${recentLocations.length} locations`);
+  const recentNPCs = withFeatured(
+    scoreByRecency(npcs, sessions, chapters, {
+      window: recencyWindow, max: maxNPCs, type: 'npc', wrapUps,
+    }),
+    npcs, landingConfig.featured_npcs, maxNPCs, 'featured_npcs');
+
+  const recentLocations = withFeatured(
+    scoreByRecency(locations, sessions, chapters, {
+      window: recencyWindow, max: maxLocations, type: 'location', wrapUps,
+    }),
+    locations, landingConfig.featured_locations, maxLocations, 'featured_locations');
+
+  // Quick links: a short GM-curated row of "go here first" pages — a map, a
+  // calendar, a house-rules page. Resolved here rather than in the template so
+  // an unresolvable name warns once, in the same place as the featured_* names.
+  const quickLinks = [];
+  {
+    const names = Array.isArray(landingConfig.quick_links)
+      ? landingConfig.quick_links.filter(n => typeof n === 'string')
+      : [];
+    const byName = new Map(pages.map(p => [canonicalNfc(p.title), p]));
+    const seen = new Set();
+    for (const name of names) {
+      const page = byName.get(canonicalNfc(name));
+      if (!page) {
+        console.warn(`  WARNING: landing.quick_links names "${name}", which is not a published page — check spelling, or it may be excluded from the site`);
+        continue;
+      }
+      if (seen.has(page.outputPath)) continue;
+      seen.add(page.outputPath);
+      quickLinks.push(page);
+    }
+  }
+  publishConfig._quickLinks = quickLinks;
+
+  console.log(`Recency: ${recentNPCs.length} NPCs, ${recentLocations.length} locations`
+    + (quickLinks.length ? `, ${quickLinks.length} quick links` : ''));
 
   // Search index (skip if searchEnabled explicitly set to false in config)
   const searchEnabled = config.searchEnabled !== false;

--- a/tools/publish/lib/config.js
+++ b/tools/publish/lib/config.js
@@ -16,6 +16,24 @@ const PUBLISH_DEFAULTS = {
   exclude_sections: ['GM Notes', 'DM Notes', 'Player Notes', 'Source References', 'Reconciliation Context', 'Handoff to Reconcile'],
   exclude_fields: ['secrets', 'current_plan', 'plan_progress', 'gm_notes', 'prep_notes'],
   exclude_dirs: ['_meta', '_Templates'],
+  // Landing page selection. build.js has always read publishConfig.landing.*,
+  // but `landing` was missing from the whitelist that builds `merged`, so the
+  // key was permanently undefined and every knob here was silently ignored —
+  // the page was fixed at 6 NPCs / 4 locations / window 3 no matter what the
+  // GM configured (#169).
+  //
+  // featured_* pin entities to the front of their section, in the order given,
+  // with recency filling whatever slots remain. They are the escape hatch from
+  // the scoring heuristic: a GM who knows which five NPCs matter this session
+  // should not have to reverse-engineer a score to feature them.
+  landing: {
+    recency_window: 3,
+    max_npcs: 6,
+    max_locations: 4,
+    featured_npcs: [],
+    featured_locations: [],
+    quick_links: [],
+  },
   theme: {
     genre: null,
     palette: {
@@ -199,6 +217,14 @@ function loadPublishConfig(vaultPath, jsonConfigFallback = {}) {
       jsonConfigFallback.excludeDirs,
       PUBLISH_DEFAULTS.exclude_dirs,
     ),
+    // Per-key merge, not a whole-block replace: setting only max_npcs must not
+    // silently drop recency_window back to nothing. Publish block wins, then
+    // vault.config.json, then the defaults.
+    landing: {
+      ...PUBLISH_DEFAULTS.landing,
+      ...(jsonConfigFallback.landing || {}),
+      ...(publish.landing || {}),
+    },
     theme: {
       ...PUBLISH_DEFAULTS.theme,
       ...publish.theme,

--- a/tools/publish/lib/recency.js
+++ b/tools/publish/lib/recency.js
@@ -111,7 +111,14 @@ function scoreByRecency(entities, sessions, chapters, options = {}) {
 
   return scored
     .filter(s => s.score > 0)
-    .sort((a, b) => b.score - a.score)
+    // Title is a real secondary key, not decoration. Array.prototype.sort is
+    // stable, so with score alone a cluster of equally-scoring entities kept
+    // vault scan order — meaning `.slice(0, max)` below chose by where the
+    // files happened to sit on disk. Deterministic, but invisible to the GM and
+    // unchangeable by anything they could author (#169). Alphabetical is not
+    // more "relevant", but it is explainable, and `featured_*` is the supported
+    // way to override it.
+    .sort((a, b) => b.score - a.score || a.page.title.localeCompare(b.page.title))
     .slice(0, max);
 }
 

--- a/tools/publish/lib/templates/landing.js
+++ b/tools/publish/lib/templates/landing.js
@@ -256,7 +256,18 @@ function landingTemplate(pages, navFor, config, publishConfig, imageMap, corpus)
 </div>`
     : '';
 
-  const content = [heroZone, recapZone, teamZone, memoriamZone, npcZone, locationZone, eventZone, timelineZone, exploreZone]
+  // --- Quick Links (GM-pinned; resolved in build.js so unknown names warn there) ---
+  const quickLinks = (publishConfig && publishConfig._quickLinks) || [];
+  const quickLinkZone = quickLinks.length > 0
+    ? `<div class="dashboard-section">
+  <h2>Quick Links</h2>
+  <div class="quick-links">${quickLinks.map(page =>
+    `<a class="quick-link" href="${escapeHtml(encodeHref(page.outputPath))}">${escapeHtml(page.displayTitle)}</a>`
+  ).join('\n')}</div>
+</div>`
+    : '';
+
+  const content = [heroZone, recapZone, teamZone, memoriamZone, quickLinkZone, npcZone, locationZone, eventZone, timelineZone, exploreZone]
     .filter(Boolean)
     .join('\n');
 

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.24",
+  "version": "1.11.25",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Adam_Npc.md
+++ b/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Adam_Npc.md
@@ -1,0 +1,11 @@
+---
+type: npc
+occupation: Townsfolk
+status: alive
+---
+
+# Adam_Npc
+
+## Description
+
+An NPC.

--- a/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Brody_Npc.md
+++ b/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Brody_Npc.md
@@ -1,0 +1,11 @@
+---
+type: npc
+occupation: Townsfolk
+status: alive
+---
+
+# Brody_Npc
+
+## Description
+
+An NPC.

--- a/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Mabel_Npc.md
+++ b/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Mabel_Npc.md
@@ -1,0 +1,11 @@
+---
+type: npc
+occupation: Townsfolk
+status: alive
+---
+
+# Mabel_Npc
+
+## Description
+
+An NPC.

--- a/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Zed_Npc.md
+++ b/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Zed_Npc.md
@@ -1,0 +1,11 @@
+---
+type: npc
+occupation: Townsfolk
+status: alive
+---
+
+# Zed_Npc
+
+## Description
+
+An NPC.

--- a/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Zenobia_Marr.md
+++ b/tools/publish/test/fixtures/with-landing-config/Characters/NPCs/Zenobia_Marr.md
@@ -1,0 +1,11 @@
+---
+type: npc
+occupation: Archivist
+status: alive
+---
+
+# Zenobia Marr
+
+## Description
+
+Never mentioned in any session, but the GM wants her featured.

--- a/tools/publish/test/fixtures/with-landing-config/Locations/Calcutta_City_Map.md
+++ b/tools/publish/test/fixtures/with-landing-config/Locations/Calcutta_City_Map.md
@@ -1,0 +1,10 @@
+---
+type: location
+location_type: Map
+---
+
+# Calcutta City Map
+
+## Description
+
+The city plan.

--- a/tools/publish/test/fixtures/with-landing-config/Sessions/Session_01.md
+++ b/tools/publish/test/fixtures/with-landing-config/Sessions/Session_01.md
@@ -1,0 +1,10 @@
+---
+type: session
+status: played
+session_number: 1
+play_date: 2026-08-01
+---
+
+# Session 01
+
+Met [[Zed_Npc]], [[Adam_Npc]], [[Brody_Npc]] and [[Mabel_Npc]] near the [[Calcutta_City_Map]].

--- a/tools/publish/test/fixtures/with-landing-config/_meta/vault-config.md
+++ b/tools/publish/test/fixtures/with-landing-config/_meta/vault-config.md
@@ -1,0 +1,11 @@
+---
+publish:
+  mode: player
+  landing:
+    max_npcs: 3
+    max_locations: 2
+    featured_npcs: ["Zenobia_Marr", "Ghost_Npc"]
+    quick_links: ["Calcutta_City_Map", "Nonexistent_Page"]
+---
+
+# Campaign Config

--- a/tools/publish/test/integration/build.test.js
+++ b/tools/publish/test/integration/build.test.js
@@ -1684,3 +1684,81 @@ describe('publish controls (#166, #167)', () => {
     assert.ok(!idx.includes('devout servant'));
   });
 });
+
+describe('landing config and pinning (#169)', () => {
+  const fixturesDir = path.join(__dirname, '..', 'fixtures');
+  let outputDir;
+  let configPath;
+  let warnings;
+
+  before(() => {
+    outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-publish-test-landing-'));
+    configPath = path.join(outputDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      vaultPath: path.join(fixturesDir, 'with-landing-config'),
+      outputDir: path.join(outputDir, 'docs'),
+      attachmentsDir: '_attachments',
+      siteTitle: 'Landing Test',
+      siteUrl: 'https://example.github.io/landing',
+      excludeDirs: ['_meta'],
+      excludeSections: [],
+      folderMap: {
+        'Characters/NPCs': 'characters/npcs',
+        'Locations': 'locations',
+        'Sessions': 'sessions',
+      },
+    }, null, 2));
+
+    warnings = [];
+    const realWarn = console.warn;
+    console.warn = (...args) => { warnings.push(args.join(' ')); };
+    try {
+      build({ configPath });
+    } finally {
+      console.warn = realWarn;
+    }
+  });
+
+  after(() => {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  const landing = () => fs.readFileSync(path.join(outputDir, 'docs', 'index.html'), 'utf-8');
+
+  it('honours max_npcs from the vault config', () => {
+    // The whole point of #169: this key was read by build.js but never
+    // populated by loadPublishConfig, so it did nothing at all.
+    // Four NPCs score and one more is pinned, so a working cap is the only
+    // thing that can produce three cards. With the config dead the default of
+    // six applies and all four scorers render.
+    const html = landing();
+    const cards = (html.match(/class="npc-card"/g) || []).length;
+    assert.strictEqual(cards, 3);
+  });
+
+  it('features a pinned NPC that no session mentions', () => {
+    // Zenobia scores zero — recency alone could never surface her.
+    assert.ok(landing().includes('Zenobia Marr'));
+  });
+
+  it('puts pinned entries before recency-scored ones, which then sort deterministically', () => {
+    // Scoped to the NPC zone: these names also appear in other zones earlier in
+    // the page, so a whole-document indexOf would compare the wrong occurrences.
+    const html = landing();
+    const zone = html.slice(html.indexOf('NPCs in Play'));
+    const order = [...zone.matchAll(/class="npc-card"[\s\S]*?<h4>([^<]+)<\/h4>/g)].map(m => m[1]);
+    assert.deepStrictEqual(order.slice(0, 3), ['Zenobia Marr', 'Adam Npc', 'Brody Npc']);
+  });
+
+  it('warns about a featured name that resolves to nothing', () => {
+    assert.ok(warnings.some(w => w.includes('featured_npcs') && w.includes('Ghost_Npc')));
+  });
+
+  it('renders quick links for resolvable names only, and warns about the rest', () => {
+    const html = landing();
+    assert.ok(html.includes('class="quick-link"'));
+    assert.ok(html.includes('Calcutta City Map'));
+    assert.ok(!html.includes('Nonexistent_Page'));
+    assert.ok(warnings.some(w => w.includes('quick_links') && w.includes('Nonexistent_Page')));
+  });
+});

--- a/tools/publish/test/unit/config.test.js
+++ b/tools/publish/test/unit/config.test.js
@@ -569,3 +569,68 @@ describe('malformed publish.overrides blocks', () => {
     assert.deepStrictEqual(warns.filter(w => w.includes('overrides')), []);
   });
 });
+
+describe('landing config (#169)', () => {
+  const withVaultConfig = (yaml) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-landing-'));
+    const metaDir = path.join(tmpDir, '_meta');
+    fs.mkdirSync(metaDir);
+    fs.writeFileSync(path.join(metaDir, 'vault-config.md'), yaml);
+    return tmpDir;
+  };
+
+  it('ships defaults so the key is never undefined', () => {
+    // build.js reads publishConfig.landing.*; loadPublishConfig never set the
+    // key at all, so every knob was silently ignored and the landing page was
+    // permanently 6 NPCs / 4 locations / window 3.
+    const config = loadPublishConfig('/nonexistent/path');
+    assert.strictEqual(config.landing.recency_window, 3);
+    assert.strictEqual(config.landing.max_npcs, 6);
+    assert.strictEqual(config.landing.max_locations, 4);
+    assert.deepStrictEqual(config.landing.featured_npcs, []);
+    assert.deepStrictEqual(config.landing.featured_locations, []);
+    assert.deepStrictEqual(config.landing.quick_links, []);
+  });
+
+  it('reads landing from a vault-config.md publish block', () => {
+    const dir = withVaultConfig(
+      '---\npublish:\n  landing:\n    recency_window: 1\n    max_npcs: 8\n    max_locations: 6\n---\n');
+    const config = loadPublishConfig(dir);
+    assert.strictEqual(config.landing.recency_window, 1);
+    assert.strictEqual(config.landing.max_npcs, 8);
+    assert.strictEqual(config.landing.max_locations, 6);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('falls back to vault.config.json when the publish block has no landing', () => {
+    const config = loadPublishConfig('/nonexistent/path', { landing: { max_npcs: 9 } });
+    assert.strictEqual(config.landing.max_npcs, 9);
+    assert.strictEqual(config.landing.max_locations, 4);   // untouched keys keep defaults
+  });
+
+  it('lets the publish block win over vault.config.json', () => {
+    const dir = withVaultConfig('---\npublish:\n  landing:\n    max_npcs: 8\n---\n');
+    const config = loadPublishConfig(dir, { landing: { max_npcs: 2 } });
+    assert.strictEqual(config.landing.max_npcs, 8);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('merges per key rather than replacing the whole block', () => {
+    const dir = withVaultConfig('---\npublish:\n  landing:\n    max_npcs: 8\n---\n');
+    const config = loadPublishConfig(dir);
+    assert.strictEqual(config.landing.max_npcs, 8);
+    assert.strictEqual(config.landing.recency_window, 3);  // default survives
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads the pinning lists', () => {
+    const dir = withVaultConfig(
+      '---\npublish:\n  landing:\n    featured_npcs: ["Hugh_Cavendish", "Margaret_Cavendish"]\n'
+      + '    featured_locations: ["Cavendish_Compound"]\n    quick_links: ["Calcutta_City_Map"]\n---\n');
+    const config = loadPublishConfig(dir);
+    assert.deepStrictEqual(config.landing.featured_npcs, ['Hugh_Cavendish', 'Margaret_Cavendish']);
+    assert.deepStrictEqual(config.landing.featured_locations, ['Cavendish_Compound']);
+    assert.deepStrictEqual(config.landing.quick_links, ['Calcutta_City_Map']);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tools/publish/test/unit/recency.test.js
+++ b/tools/publish/test/unit/recency.test.js
@@ -142,3 +142,42 @@ describe('scoreByRecency — play_date recency, wrap-ups, terminal status', () =
     assert.ok(!titles.includes('Wrong_NPC'), 'ignores the same-numbered wrap-up from another chapter');
   });
 });
+
+describe('scoreByRecency tie-break (#169)', () => {
+  // Equal scores used to fall back to vault scan order, because the sort had no
+  // secondary key and Array.prototype.sort is stable. Which entities survived
+  // `.slice(0, max)` was therefore decided by where the files sat on disk —
+  // invisible to the GM and unchangeable by anything they could author.
+  const mkSession = (md) => ({
+    title: 'Session_01', displayTitle: 'Session 01',
+    frontmatter: { type: 'session', status: 'played', play_date: '2026-08-01' },
+    markdown: md,
+  });
+  const mkNpc = (title) => ({
+    title, displayTitle: title, frontmatter: { type: 'npc', status: 'alive' }, markdown: '',
+  });
+
+  it('breaks ties by title so the selection is deterministic and explainable', () => {
+    const session = mkSession('Met [[Zed_Npc]], [[Adam_Npc]] and [[Mabel_Npc]].');
+    // deliberately reversed relative to the wanted output
+    const entities = [mkNpc('Zed_Npc'), mkNpc('Mabel_Npc'), mkNpc('Adam_Npc')];
+    const scored = scoreByRecency(entities, [session], [], { window: 3, max: 10, type: 'npc' });
+    assert.deepStrictEqual(scored.map(s => s.page.title), ['Adam_Npc', 'Mabel_Npc', 'Zed_Npc']);
+  });
+
+  it('keeps score as the primary key', () => {
+    const session = mkSession('Met [[Zed_Npc]] twice: [[Zed_Npc]]. Also [[Adam_Npc]].');
+    const chapter = { title: 'Ch', displayTitle: 'Ch', frontmatter: { type: 'chapter' },
+      markdown: 'Featuring [[Zed_Npc]].' };
+    const entities = [mkNpc('Adam_Npc'), mkNpc('Zed_Npc')];
+    const scored = scoreByRecency(entities, [session], [chapter], { window: 3, max: 10, type: 'npc' });
+    assert.strictEqual(scored[0].page.title, 'Zed_Npc');   // higher score wins over alphabetical
+  });
+
+  it('cuts at max by the same deterministic order', () => {
+    const session = mkSession('Met [[Zed_Npc]], [[Adam_Npc]] and [[Mabel_Npc]].');
+    const entities = [mkNpc('Zed_Npc'), mkNpc('Mabel_Npc'), mkNpc('Adam_Npc')];
+    const scored = scoreByRecency(entities, [session], [], { window: 3, max: 2, type: 'npc' });
+    assert.deepStrictEqual(scored.map(s => s.page.title), ['Adam_Npc', 'Mabel_Npc']);
+  });
+});


### PR DESCRIPTION
The landing page could not be steered: the config controlling it was never
read, and the scoring it fell back on had no tie-break and no override. Plugin
1.8.53, publish tool 1.11.25.

## 1. `publish.landing.*` was dead config

`build.js` has always read `publishConfig.landing`, but `loadPublishConfig`
builds its result from a key whitelist that `landing` was not on. The key was
permanently `undefined`, so every knob under it was silently ignored and the
landing page was fixed at 6 NPCs / 4 locations / window 3 — whether set in
`_meta/vault-config.md` or `vault.config.json`.

Now merged **per key** (publish block → `vault.config.json` → defaults), so
setting `max_npcs` alone does not reset `recency_window`. This also revives
`max_events` and `explore_descriptions`, which the landing template read from
the same dead key.

## 2. Ties were broken by where files sit on disk

The sort was `b.score - a.score` with no secondary key, and
`Array.prototype.sort` is stable — so a cluster of equally-scoring entities
kept vault scan order, and which of them survived `.slice(0, max)` came down to
directory order. Deterministic, but invisible to the GM and unchangeable by
anything they could author.

Ties now break by title. Not more "relevant" — but explainable, and `featured_*`
is the supported way to override it.

## 3. No way to pin what matters

Added `featured_npcs`, `featured_locations` and `quick_links`:

```yaml
publish:
  landing:
    max_npcs: 6
    featured_npcs: ["Hugh_Cavendish", "Margaret_Cavendish"]
    featured_locations: ["Cavendish_Compound"]
    quick_links: ["Calcutta_City_Map", "Calcutta_Season_Calendar"]
```

Pinned entries lead their section in the order given, recency fills the rest. A
pinned entity appears **even if it scores nothing**, so an NPC no session has
mentioned yet is still featurable. Names use the wiki-link form (the filename),
and a name that resolves to no published page prints a build warning rather than
disappearing — silence there would repeat the exact complaint this fixes.

---

## What I did NOT change, and why

The issue's part 2 says recency compares an entity's **H1 title** against
wiki-link targets, so entities whose display title differs from their filename
can never be featured, and proposes resolving mentions through `linkMap`.

That does not reproduce:

- `scanner.js` sets `page.title` to the **filename base**. The H1 /
  `frontmatter.title` goes to `page.displayTitle`, which recency never reads.
- `extractMentions` uses `/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g`, whose capture
  already stops at the `|`.

Both sides are the filename form. Probed with the reported shape — an NPC filed
as `Margaret_Cavendish.md`, H1 `Margaret "Meg" Cavendish`, referenced only as
`[[Margaret_Cavendish|Meg]]` — it scores 6 and is returned. The suggested
`aliases` workaround is not needed either.

So the scoring path is untouched. Rewriting it would have rebuilt something that
works, on a diagnosis that does not hold. The two fixes above are what actually
produced the reported symptom: the cap was stuck at 6, and ties were settled by
directory order.

Reasoning posted on the issue as well, so it is on the record there.

Closes #169

## Verification

- `tools/publish` — 1494/1494 (14 new)
- **Mutation-tested.** Disabling the config merge, the tie-break and the pinning
  in turn fails 11 of them; all pass restored.
- schema + ontology validation, 9 python test files from `lint.yml` — pass
- skill-creator validation on `publish-site` — valid
- markdownlint on every changed file — clean

One test needed strengthening rather than trusting: the `max_npcs` assertion
originally passed even with the config disabled, because three NPCs happened to
score and the count matched by coincidence. The fixture now has four scoring
NPCs plus a pinned one, so a working cap is the only thing that can produce
three cards.
