### PR TITLE
Escape vault text in the reified-Event blurb

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.1] — 2026-08-23
+
+### Fixed
+
+- **`mobrpg suggest` no longer ships unescaped vault text inside the reified-Event
+  blurb.** The one-line description on a reified relationship Event is one of the
+  two descriptions the CLI hand-builds as HTML (the other is the empty-description
+  stub); it interpolated a vault-authored `description:` straight into `<p>…</p>`
+  with no escaping. An edge described as `Ran the docks & bar` shipped an undefined
+  HTML entity, and anything angle-bracketed was swallowed as a tag by the renderer.
+  The text is now escaped before interpolation.
+
+---
+
 ## [1.9.0] — 2026-07-26
 
 Graduates the mobRPG integration CLI (`tools/mobrpg/`) into the repo as a

--- a/tools/mobrpg/mobrpg/commands/suggest.py
+++ b/tools/mobrpg/mobrpg/commands/suggest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import glob
+import html as _html
 import json
 import os
 import re
@@ -510,7 +511,11 @@ def relationship_items(entity, mp, entity_ref, ent_id_by_key, linked_triples,
             items.append(rel_item)
             continue
         eref = f"{ref_seed}v{n}"; n += 1
-        desc = f"<p>{rel.get('desc') or pred}</p>"
+        # Escape before interpolating: this is one of the two descriptions the CLI
+        # hand-builds as HTML (see skill/references/push.md), and the text inside it
+        # is vault-authored. An unescaped `&` shipped as an undefined entity and an
+        # unescaped `<` was swallowed as a tag by the renderer.
+        desc = f"<p>{_html.escape(rel.get('desc') or pred)}</p>"
         # The rel/ ref is the edge's identity across re-pushes — keyed on the
         # authored predicate and target, never on the emitted name, so renaming
         # an event can't make it re-file as net-new.

--- a/tools/mobrpg/tests/test_suggest_affiliation.py
+++ b/tools/mobrpg/tests/test_suggest_affiliation.py
@@ -464,3 +464,34 @@ def test_node_kind_index_reads_canon_kinds_and_aliases(tmp_path):
     kinds = suggest.node_kind_index(str(tmp_path))
     assert kinds[suggest._key("Corvid Financial")] == "Organization"
     assert kinds[suggest._key("Corvid")] == "Organization"
+
+
+def test_event_blurb_escapes_vault_text_into_its_html_wrapper(tmp_path):
+    """The reified-Event blurb is one of the two descriptions the CLI hand-builds
+    as HTML (see skill/references/push.md). It interpolates a vault-authored
+    `description:` into `<p>...</p>`, so any `&`, `<` or `>` the GM wrote shipped
+    as markup: "Ran the docks & bar" became an undefined entity, and anything
+    angle-bracketed was swallowed as a tag by the renderer."""
+    ent = {"path": str(tmp_path / "Characters/NPCs/Rusa Vetch.md"),
+           "name": "Rusa Vetch", "kind": "npc",
+           "relationships": [{"target": "[[Dock 9]]", "predicate": "serves",
+                              "desc": "Ran the docks & bar <the good one>"}]}
+    idx = {suggest._key("Dock 9"): "dock9-id"}
+    kinds = {suggest._key("Rusa Vetch"): "Person",
+             suggest._key("Dock 9"): "Political"}
+    items, _ = _rel_items(tmp_path, ent, idx, kinds)
+    ev = [i for i in items if i["operation"] == "CreateElement"][0]
+    assert ev["payload"]["description"] == (
+        "<p>Ran the docks &amp; bar &lt;the good one&gt;</p>")
+
+
+def test_event_blurb_falls_back_to_the_predicate_and_still_escapes(tmp_path):
+    ent = {"path": str(tmp_path / "Characters/NPCs/Rusa Vetch.md"),
+           "name": "Rusa Vetch", "kind": "npc",
+           "relationships": [{"target": "[[Dock 9]]", "predicate": "serves", "desc": ""}]}
+    idx = {suggest._key("Dock 9"): "dock9-id"}
+    kinds = {suggest._key("Rusa Vetch"): "Person",
+             suggest._key("Dock 9"): "Political"}
+    items, _ = _rel_items(tmp_path, ent, idx, kinds)
+    ev = [i for i in items if i["operation"] == "CreateElement"][0]
+    assert ev["payload"]["description"] == "<p>serves</p>"


### PR DESCRIPTION
Found while tracing a separate mobRPG rendering bug (the `<p><span>` wrapper on accepted suggestions — that one is fixed in tdennis/game#66, not here).

`mobrpg suggest` sends almost every description as raw Markdown with `descriptionType: "Markdown"` since #150. Two descriptions are still HTML fragments the CLI hand-builds itself: the empty-description stub `<p></p>`, and the one-line blurb on a reified relationship Event. The second one interpolated vault-authored text straight into markup with no escaping:

```python
desc = f"<p>{rel.get('desc') or pred}</p>"
```

A relationship authored as:

```yaml
- target: "[[Dock 9]]"
  type: serves
  description: "Ran the docks & bar <the good one>"
```

shipped `<p>Ran the docks & bar <the good one></p>` — a bare `&` is an undefined HTML entity, and the angle-bracketed span is swallowed as a tag by the renderer. `descriptionType` is unset on this payload, so the backend stores it as Html and the text is rendered as markup.

## Fix

`html.escape()` before interpolation. The blurb stays an Html fragment — that is the documented design in `skill/references/push.md`, and neither hand-built fragment carries authored prose that a Markdown round-trip would benefit.

Round-trip is lossless on the way back: `md.html_to_md` parses with `convert_charrefs=True`, so `<p>Ran the docks &amp; bar &lt;the good one&gt;</p>` pulls back down to `Ran the docks & bar <the good one>`.

## Tests

Two added to `tests/test_suggest_affiliation.py`, the first failing before the change:

- an edge description containing `&`, `<` and `>` is escaped into the wrapper
- the predicate fallback (empty `description:`) still produces `<p>serves</p>`

`495 passed`; `scripts/validate_schema.py` clean (41 files); markdownlint clean on `CHANGELOG.md`. No skill files touched, so no `skill-creator` run was needed.
