### PR TITLE
Surface advice and rejected change-request replies to the player

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.2] — 2026-08-23
+
+### Fixed
+
+- **An `advice` or `rejected` change-request reply is no longer invisible to the
+  player (#174).** Only an `applied` reply reloaded the page, so a player whose
+  widget had collapsed never learned an answer had arrived — one re-submitted the
+  same question 90 seconds later, then found the reply only by refreshing and
+  opening the History modal by hand. A reply now surfaces three ways, any one of
+  which survives a player who submitted and looked away: an unread badge on the
+  💬 History button (with `aria-live` and an `aria-label` count), the widget
+  re-expanded with the reply inline (truncated past 240 characters, pointing at
+  History for the rest), and an unread marker in the document title. Opening the
+  log is what marks replies read; log entries written before this change carry no
+  `read` flag and deliberately count as unread.
+
+---
+
 ## [1.9.1] — 2026-08-23
 
 ### Fixed

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -47,6 +47,19 @@
     });
   }
 
+  // A reply the player has not yet opened the History modal on. Entries predating
+  // this feature have no `read` flag, so they read as unread — deliberately, since
+  // the bug this fixes is replies the player never saw.
+  function unreadCount(log) {
+    return (log || []).filter(function (e) { return e.reply != null && !e.read; }).length;
+  }
+
+  function markAllRead(log) {
+    return (log || []).map(function (e) {
+      return e.reply != null && !e.read ? Object.assign({}, e, { read: true }) : e;
+    });
+  }
+
   function classifySubmitError(httpStatus) {
     if (httpStatus === 403) return 'code';
     if (httpStatus === 429) return 'rate';
@@ -64,6 +77,8 @@
       needsReload: needsReload,
       appendLog: appendLog,
       setLogReply: setLogReply,
+      unreadCount: unreadCount,
+      markAllRead: markAllRead,
       classifySubmitError: classifySubmitError,
     };
   }
@@ -145,11 +160,35 @@
       });
     }
     renderLog();
+
+    // Unread badge on the History button. An `advice`/`rejected` reply does not
+    // reload the page the way `applied` does, so without a passive signal a player
+    // with a collapsed widget never learns an answer arrived.
+    var badge = document.createElement('span');
+    badge.className = 'cr-unread';
+    badge.setAttribute('aria-live', 'polite');
+    badge.style.cssText = 'display:none;margin-left:.4em;min-width:1.35em;padding:0 .35em;' +
+      'border-radius:1em;background:#c0392b;color:#fff;font-size:.8em;font-weight:700;' +
+      'line-height:1.35em;text-align:center;';
+    logBtn.appendChild(badge);
+
+    var baseTitle = document.title;
+    function renderBadge() {
+      var n = unreadCount(getLog());
+      badge.textContent = n ? String(n) : '';
+      badge.style.display = n ? 'inline-block' : 'none';
+      logBtn.setAttribute('aria-label', n ? 'Open chat history, ' + n + ' unread' : 'Open chat history');
+      document.title = n ? '(' + n + ') ' + baseTitle : baseTitle;
+    }
+    renderBadge();
+
     function openModal() {
       backdrop.hidden = false;
       document.body.style.overflow = 'hidden';
       logBtn.setAttribute('aria-expanded', 'true');
+      setLog(markAllRead(getLog()));  // opening the log is what marks replies seen
       renderLog();
+      renderBadge();
       closeBtn.focus();               // move focus into the dialog for keyboard/SR users
     }
     function closeModal() {
@@ -253,9 +292,17 @@
           u.searchParams.set('_cr', String(Date.now()));
           location.replace(u.href);
         } else {
-          // advice / rejected only — show the newest reply inline, keep the log open-able
-          // (stale-only ticks have no response to show; the log entry is left as-is)
-          if (done.length) msg.textContent = done[done.length - 1].response;
+          // advice / rejected only — no reload, so surface it three ways: badge on the
+          // History button, the widget expanded with the reply inline, and a title marker.
+          // Any one of them survives a player who submitted and looked away.
+          renderBadge();
+          if (done.length) {
+            var newest = done[done.length - 1].response || '';
+            msg.textContent = newest.length > 240 ? newest.slice(0, 237) + '… (full reply in 💬 History)' : newest;
+            panel.hidden = false;
+            toggle.setAttribute('aria-expanded', 'true');
+            codeInput.hidden = !shouldPromptForCode(readJSON(K_CODE), Date.now());
+          }
           if (!getPending().length) { clearInterval(timer); timer = null; }
         }
       }).catch(function () { /* transient; try again next tick */ });

--- a/tools/publish/test/change-request-logic.test.js
+++ b/tools/publish/test/change-request-logic.test.js
@@ -47,6 +47,36 @@ test('setLogReply fills the matching entry', () => {
   assert.equal(out[0].reply, undefined); // others untouched
 });
 
+test('unreadCount counts replies the player has not opened the log on', () => {
+  const log = [
+    { id: 'a', ts: 1, message: 'q', reply: 'answered', kind: 'advice' },   // unread
+    { id: 'b', ts: 2, message: 'r', reply: 'seen', kind: 'advice', read: true },
+    { id: 'c', ts: 3, message: 's' },                                      // no reply yet
+  ];
+  assert.equal(cr.unreadCount(log), 1);
+  assert.equal(cr.unreadCount([]), 0);
+  assert.equal(cr.unreadCount(undefined), 0);
+});
+
+// Entries written before this feature carry no `read` flag. They must read as UNREAD:
+// the bug being fixed is a reply the player never saw, so defaulting them to read
+// would hide exactly the case the badge exists for.
+test('unreadCount treats a pre-feature reply with no read flag as unread', () => {
+  assert.equal(cr.unreadCount([{ id: 'a', ts: 1, message: 'q', reply: 'old answer' }]), 1);
+});
+
+test('markAllRead flags replies only, leaves unanswered entries alone', () => {
+  const log = [
+    { id: 'a', ts: 1, message: 'q', reply: 'answered' },
+    { id: 'b', ts: 2, message: 's' },
+  ];
+  const out = cr.markAllRead(log);
+  assert.equal(out[0].read, true);
+  assert.equal(out[1].read, undefined);   // nothing to have read
+  assert.equal(cr.unreadCount(out), 0);
+  assert.equal(log[0].read, undefined);   // input not mutated
+});
+
 test('classifySubmitError maps HTTP status', () => {
   assert.equal(cr.classifySubmitError(403), 'code');
   assert.equal(cr.classifySubmitError(429), 'rate');


### PR DESCRIPTION
Closes #174.

The fix was written in another session and left uncommitted in the working tree on an unrelated (since-merged) branch. This lifts it onto its own branch off `main`, adds the missing test coverage, and versions it.

## Problem

`poll()` in `tools/publish/js/change-request.js` only forced a reload for an `applied` result:

```js
if (needsReload(done)) { ... location.replace(u.href); }   // applied → player cannot miss it
else { if (done.length) msg.textContent = done[done.length - 1].response; }
```

That `else` writes the reply into a panel the player has usually collapsed. Observed live in Dead End Session 06: a player asked a question, the GM answered with `inbox reply <id> advice`, the player saw nothing and re-submitted the same question ~90 seconds later. He found the answer only after manually refreshing and opening the 💬 History modal.

## Fix

Three independent signals, so any one of them catches a player who submitted and looked away:

- **Unread badge** on the History button — `aria-live="polite"` and an `aria-label` carrying the count, so it is announced rather than purely visual.
- **Widget re-expanded** with the reply inline, truncated past 240 characters with a pointer to History for the rest.
- **Document title marker** — `(2) Character Name`, visible on a backgrounded tab.

Opening the log is what marks replies read. Two pure helpers, `unreadCount` and `markAllRead`, join the existing exported logic block.

Log entries written before this change carry no `read` flag and **deliberately** count as unread — defaulting them to read would hide exactly the case the badge exists for.

## Tests

Three added to `test/change-request-logic.test.js`, covering the counting rule, the pre-feature-entry default, and that `markAllRead` touches only answered entries and does not mutate its input.

Full publish suite: **1497 passed, 0 failed** (288 suites). `validate_schema.py` clean (41 files); markdownlint clean on `CHANGELOG.md`.

## Not included

The other session also wrote up the ledger race on #143 (already closed) for whoever folds the watcher upstream — that is commentary, not code, and there is no working-tree change for it.
