### PR TITLE
Fix open issues #176–#180: inbox reply loss, GURPS drops, flush --help, mobrpg write-back, stamper shape

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.3] — 2026-08-28
+
+### Fixed
+
+- **A change-request reply no longer self-destructs after ten minutes (#176).**
+  Finalized inbox entries were stored with a 300s/600s KV TTL, so an answer
+  written while the player had put the phone down was deleted before it was
+  read — and a missing key was reported as `handled`, indistinguishable from an
+  answered one, so the widget dropped the request in silence. Handled entries now
+  linger 24h and replies 7 days; a missing or unreadable entry reports
+  `status: gone`, which the widget surfaces to the player as "expired — please
+  send it again" instead of nothing. `inbox reply` (and `handled`/`flag`) now
+  report the outcome of their own write and exit 1 when nothing was written,
+  and inbox commands run outside the site directory fail naming the missing
+  `wrangler.toml` rather than tracing.
+- **GURPS sheet sections are no longer dropped silently (#177).** Section
+  headings match loosely (case, punctuation, `&`/`and`), and a combined
+  `## Melee & Ranged` (or `## Weapons`) section feeds both the melee and ranged
+  tables, each routed by its own header row — previously it matched nothing and
+  the combat tab rendered empty. The build now warns per page when a
+  weapons-titled section yields no rows, when a Skills/Techniques/Spells section
+  is present but empty, and when tables under a `###` subheading were excluded
+  from those sections (naming the subheading), so an unrendered table is a
+  five-second heading fix instead of a mid-combat mystery.
+- **`gm-publish flush --help` prints help instead of flushing (#178).** Every
+  subcommand now honours `--help`/`-h` with no side effects, `flush` and the
+  `setup-*` commands reject unknown arguments with usage and exit 1 rather than
+  falling through to execution, and `flush --dry-run` (`-n`) prints the same
+  per-PC `✓ Name — HP 10→13` lines without writing.
+- **`mobrpg suggest` no longer 400s a whole batch on an already-claimed create,
+  and `--write-back` stamps only what the server accepted (#179).** Before
+  building batches it checks the live world for net-new entities that already
+  exist upstream without a `mobrpg:` node, holds them, and points at
+  `mobrpg adopt`; a bare HTTP 400 now carries the same hint. With `--execute
+  --write-back`, pending nodes are written per batch after the POST succeeds and
+  never for externalRefs the server refused, so a failed batch no longer leaves
+  its entities marked `pending` and unsubmittable.
+- **`stamp_entities.py` preserves the vault's `asOfSession` shape (#180).**
+  `--session` is a free string written verbatim — a bare number stays bare, a
+  label such as `"Chapter 4, Session 9"` is quoted — and a file whose existing
+  value has the other shape is refused (with an `ERROR` line) unless
+  `--force-shape`, so a wrap-up stamp can no longer flatten a label vault to
+  bare integers and drop the chapter. session-wrapup Step 3c and
+  `vault-access.md` now say so.
+
+---
+
 ## [1.9.2] — 2026-08-23
 
 ### Fixed

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -211,7 +211,7 @@ happened; if the request no longer exists (it expired, or the id is wrong)
 it prints `<id>: reply NOT stored …` and exits 1 — tell the player to send
 it again. KV is eventually consistent, so re-reading right after a write can
 show stale state; never "verify" by polling and re-sending, which delivers the
-same answer twice. Finalized entries linger for days (a reply for 7), so a
+same answer twice. Finalized entries linger for 7 days, so a
 player who put the phone down still gets the answer; a request the server has
 lost reports `status: gone` to the widget, which tells the player to resend.
 

--- a/skills/publish-site/references/change-request-loop.md
+++ b/skills/publish-site/references/change-request-loop.md
@@ -205,6 +205,16 @@ reason), or `advice`. A deploy failure leaves the applied items `pending` to
 retry next tick, unreplied for now. `reply` is the single finalizer for every
 item — it supersedes the old `handled`/`flag` commands.
 
+**Trust `reply`'s exit code, not a follow-up read.** It prints
+`<id>: reply stored (<kind>) → status …` and exits 0 only when the write
+happened; if the request no longer exists (it expired, or the id is wrong)
+it prints `<id>: reply NOT stored …` and exits 1 — tell the player to send
+it again. KV is eventually consistent, so re-reading right after a write can
+show stale state; never "verify" by polling and re-sending, which delivers the
+same answer twice. Finalized entries linger for days (a reply for 7), so a
+player who put the phone down still gets the answer; a request the server has
+lost reports `status: gone` to the widget, which tells the player to resend.
+
 ## When the watcher reports failure
 
 Either mode can wake you with a failure signal instead of a batch — the

--- a/skills/publish-site/references/live-state-flush.md
+++ b/skills/publish-site/references/live-state-flush.md
@@ -26,10 +26,14 @@ Loadout (carried items) and hero points are not synced.
 From the **site directory** (the one holding `vault.config.json` and
 `wrangler.toml`):
 
-    npx gm-apprentice-publish flush
+    npx gm-apprentice-publish flush --dry-run   # preview: same lines, writes nothing
+    npx gm-apprentice-publish flush             # write the sheets
 
 (or `node <tool>/bin/gm-publish.js flush`). It prints a per-PC summary
 (`✓ Karl Brenner — HP 12→7, FP 11→9`). Report that summary to the GM.
+`flush` is the one command that edits the vault, so preview first when the
+GM is unsure; `--help` prints usage, and an unknown flag is rejected rather
+than run.
 
 ## When it does nothing
 

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -162,8 +162,14 @@ and any who were off-screen this session):
    ```bash
    python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/stamp_entities.py" \
      <vault> Characters/PCs/A.md Characters/PCs/B.md \
-     --session N --date YYYY-MM-DD --retag old-tag=new-tag
+     --session "<asOfSession value>" --date YYYY-MM-DD --retag old-tag=new-tag
    ```
+
+   `--session` is written verbatim, so match the vault's existing
+   `asOfSession` shape — `"Chapter 4, Session 9"` where the vault
+   uses labels, `9` where it uses bare numbers. The stamper refuses
+   a file whose shape would change (it prints an `ERROR` line);
+   re-run with the matching form rather than `--force-shape`.
 
    It touches only those frontmatter lines; body content and
    line endings are preserved. Steps 3–4 remain manual editing

--- a/skills/shared/scripts/stamp_entities.py
+++ b/skills/shared/scripts/stamp_entities.py
@@ -12,10 +12,18 @@ Dry-run by default — prints planned changes and exits. Pass --write
 to apply. Stdlib only.
 
 Usage:
-  stamp_entities.py VAULT --session N --date YYYY-MM-DD \
-      [--retag OLD=NEW] [--write] FILE [FILE...]
+  stamp_entities.py VAULT --session SESSION --date YYYY-MM-DD \
+      [--retag OLD=NEW] [--force-shape] [--write] FILE [FILE...]
 
 FILE paths are vault-relative.
+
+SESSION is written verbatim as `asOfSession`: a bare integer (`9`) stays a
+bare integer, anything else (`"Chapter 4, Session 9"`) is written as a
+quoted string. A vault that already uses one shape keeps it: a file whose
+existing `asOfSession` is a label is refused a bare number (and vice
+versa) unless --force-shape is given, because silently flattening
+"Chapter 4, Session 8" to `9` drops the chapter and diverges from what
+every other writer in the toolchain produces.
 """
 
 import argparse
@@ -47,6 +55,44 @@ def frontmatter_span(lines: list[str]) -> tuple[int, str | None]:
                                 f"YAML ({body_line.rstrip()!r}) — refusing")
             return i, None
     return -1, "unterminated frontmatter"
+
+
+def get_key(fm: list[str], key: str) -> str | None:
+    """Raw value text after `key:` (whitespace-stripped), or None."""
+    pattern = re.compile(rf"^{re.escape(key)}:([^\r\n]*)")
+    for line in fm:
+        m = pattern.match(line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def unquote(text: str) -> str:
+    """Strip one layer of matching surrounding quotes, if present."""
+    text = text.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        return text[1:-1]
+    return text
+
+
+def yaml_scalar(value: str, *, quoted_int: bool = False) -> str:
+    """An integer stays bare unless the file already quotes its integer
+    (`asOfSession: "9"` stays `"10"`); anything else is double-quoted."""
+    if re.fullmatch(r"\d+", value) and not quoted_int:
+        return value
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def session_shape(raw: str | None) -> str | None:
+    """'int' for an integer (bare or quoted), 'label' for any other
+    non-empty value, None for absent or empty (a fresh template's
+    `asOfSession: ""`)."""
+    if raw is None:
+        return None
+    text = unquote(raw)
+    if text == "":
+        return None
+    return "int" if re.fullmatch(r"\d+", text) else "label"
 
 
 def set_key(fm: list[str], key: str, value: str, eol: str) -> str:
@@ -93,13 +139,25 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("vault", type=Path)
     ap.add_argument("files", nargs="+", help="vault-relative paths")
-    ap.add_argument("--session", type=int, required=True)
+    ap.add_argument("--session", required=True,
+                    help="asOfSession value, written verbatim: a bare "
+                         "number (9) or a label (\"Chapter 4, Session 9\")")
     ap.add_argument("--date", required=True,
                     help="lastUpdated value, YYYY-MM-DD")
     ap.add_argument("--retag", help="OLD=NEW chapter tag swap")
+    ap.add_argument("--force-shape", action="store_true",
+                    help="allow asOfSession to change shape (label <-> "
+                         "bare number) in files that already use one")
     ap.add_argument("--write", action="store_true",
                     help="apply changes (default: dry run)")
     args = ap.parse_args()
+
+    # A shell-quoted '"10"' means the integer 10, not a label containing quotes.
+    session = unquote(args.session)
+    if not session:
+        print("error: --session must not be empty", file=sys.stderr)
+        return 2
+    new_shape = session_shape(session)
 
     if not re.match(r"^\d{4}-\d{2}-\d{2}$", args.date):
         print(f"error: --date must be YYYY-MM-DD, got {args.date}",
@@ -144,7 +202,21 @@ def main() -> int:
             continue
         eol = "\r\n" if lines[0].endswith("\r\n") else "\n"
         fm = lines[1:close]
-        actions = [set_key(fm, "asOfSession", str(args.session), eol),
+        old_raw = get_key(fm, "asOfSession")
+        old_shape = session_shape(old_raw)
+        if (old_shape and old_shape != new_shape
+                and not args.force_shape):
+            want = ("a label like the existing value" if old_shape == "label"
+                    else "a plain session number")
+            print(f"ERROR\t{rel}\tasOfSession is currently "
+                  f"{old_raw} ({old_shape}); --session "
+                  f"{session!r} would change its shape. Pass {want}, or "
+                  f"--force-shape to override — not stamped")
+            errors += 1
+            continue
+        quoted_int = (old_shape == "int" and old_raw.strip()[:1] in "\"'")
+        actions = [set_key(fm, "asOfSession",
+                           yaml_scalar(session, quoted_int=quoted_int), eol),
                    set_key(fm, "lastUpdated", f'"{args.date}"', eol)]
         if tag_old:
             act = retag(fm, tag_old, tag_new)

--- a/skills/shared/vault-access.md
+++ b/skills/shared/vault-access.md
@@ -91,12 +91,14 @@ present in more than one chapter) and when later session
 indexes were ignored as unplayed. Confirm it with the GM: a
 wrong bundle reads exactly as authoritative as a right one.
 
-`stamp_entities.py <vault> FILE... --session N --date
+`stamp_entities.py <vault> FILE... --session SESSION --date
 YYYY-MM-DD [--retag OLD=NEW]` batch-stamps `asOfSession`,
-`lastUpdated`, and a chapter-tag swap across files. Dry-run
-by default — review the plan, then re-run with `--write`. It
-touches only those frontmatter lines; everything else is
-preserved byte-for-byte.
+`lastUpdated`, and a chapter-tag swap across files. SESSION is
+written verbatim — a label (`"Chapter 4, Session 9"`) or a bare
+number — and a file already using the other shape is refused
+unless `--force-shape`. Dry-run by default — review the plan,
+then re-run with `--write`. It touches only those frontmatter
+lines; everything else is preserved byte-for-byte.
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_check.py" \

--- a/tests/test_vault_utilities.py
+++ b/tests/test_vault_utilities.py
@@ -418,6 +418,52 @@ try:
     check("stamp: empty retag NEW side rejected",
           ["chapter-2" in (work / "Characters/PCs/Hero.md").read_text()],
           [True])
+
+    # --- asOfSession shape (#180): a label vault must not be flattened ---
+    hero = work / "Characters/PCs/Hero.md"
+    hero.write_text(hero.read_text().replace(
+        "asOfSession: 3", 'asOfSession: "Chapter 4, Session 8"'))
+    refused = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",
+                            "--session", "9", "--date", "2026-08-27",
+                            "--write", vault=work, expect_rc=1))
+    check("stamp: bare number refused on a label-shaped vault",
+          ["would change its shape" in refused
+           and 'asOfSession: "Chapter 4, Session 8"' in hero.read_text()],
+          [True])
+    labelled = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",
+                             "--session", "Chapter 4, Session 9",
+                             "--date", "2026-08-27", "--write", vault=work))
+    check("stamp: label written verbatim, quoted",
+          ['asOfSession: "Chapter 4, Session 9"' in hero.read_text()
+           and "STAMPED" in labelled], [True])
+    forced = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",
+                           "--session", "10", "--date", "2026-08-28",
+                           "--force-shape", "--write", vault=work))
+    check("stamp: --force-shape allows the shape change",
+          ["asOfSession: 10" in hero.read_text() and "STAMPED" in forced],
+          [True])
+    hero.write_text(hero.read_text().replace(
+        "asOfSession: 10", 'asOfSession: ""'))
+    fresh = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",
+                          "--session", "Chapter 5, Session 1",
+                          "--date", "2026-08-29", "--write", vault=work))
+    check("stamp: an empty template value takes either shape",
+          ['asOfSession: "Chapter 5, Session 1"' in hero.read_text()
+           and "STAMPED" in fresh], [True])
+    hero.write_text(hero.read_text().replace(
+        'asOfSession: "Chapter 5, Session 1"', 'asOfSession: "9"'))
+    qint = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",
+                         "--session", "10", "--date", "2026-08-30",
+                         "--write", vault=work))
+    check("stamp: a quoted integer is an int and keeps its quotes",
+          ['asOfSession: "10"' in hero.read_text() and "STAMPED" in qint],
+          [True])
+    qq = "\n".join(run("stamp_entities.py", "Characters/PCs/Hero.md",
+                       "--session", '"11"', "--date", "2026-08-31",
+                       "--write", vault=work))
+    check("stamp: shell-quoted number never double-quotes",
+          ['asOfSession: "11"' in hero.read_text()
+           and '\\"' not in hero.read_text() and "STAMPED" in qq], [True])
 finally:
     shutil.rmtree(tmp)
 

--- a/tools/mobrpg/mobrpg/commands/suggest.py
+++ b/tools/mobrpg/mobrpg/commands/suggest.py
@@ -837,6 +837,47 @@ def _default_map_path(vault):
     return os.path.join(os.path.expanduser(vault), "_meta", "mobrpg-map.json")
 
 
+def upstream_unlinked(world, token, entities, mp) -> tuple[list[tuple[dict, dict]], list[tuple[dict, list]]]:
+    """Net-new candidates that already exist live upstream (matched by
+    normalized name/alias within their element kind, exactly as `adopt` does).
+
+    A vault can lose track of an element it pushed earlier — accepted upstream,
+    never pulled, no `element_id` on the note — and re-filing it looks harmless
+    (the server skips the CreateElement as already claimed). It is not: every
+    AddRelation in the batch whose ref is `suggestion:<that ref>` is then
+    unresolvable and the WHOLE batch 400s with no hint which item is at fault
+    (#179). Checking first costs one paginated GET per element kind present.
+    Returns `(matched, ambiguous)`: `matched` pairs an entity with its single
+    live element; `ambiguous` pairs it with the several that share its name."""
+    from mobrpg.commands import adopt   # local: adopt imports this module
+    by_kind: dict[str, list] = {}
+    for ent in entities:
+        try:
+            by_kind.setdefault(element_spec(ent, mp)[0], []).append(ent)
+        except (KeyError, TypeError):
+            continue
+    matched, ambiguous = [], []
+    for ek, ents in sorted(by_kind.items()):
+        idx = adopt.index_live(adopt.live_by_kind(world, token, ek))
+        for ent in ents:
+            hits = adopt._match(ent, idx)
+            if len(hits) == 1:
+                matched.append((ent, hits[0]))
+            elif hits:
+                ambiguous.append((ent, hits))
+    return matched, ambiguous
+
+
+def entities_in_chunk(chunk, ents_by_ref) -> list[dict]:
+    """The net-new entities whose CreateElement rides in `chunk`, keyed by the
+    externalRef the create carries (the same ref the server echoes back)."""
+    out = []
+    for it in chunk:
+        if it.get("operation") == "CreateElement" and it.get("externalRef") in ents_by_ref:
+            out.append(ents_by_ref[it["externalRef"]])
+    return out
+
+
 def run(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(
         prog="mobrpg suggest",
@@ -908,6 +949,26 @@ def run(argv: list[str]) -> int:
     net_new, linked_ents, submitted_ents = partition_entities(
         entities, ent_id_by_key, submitted_keys)
 
+    # Anything that already exists live but has no node must not be re-filed:
+    # its create is skipped as already claimed and the edges that hang off it
+    # fail the whole batch (#179). Hold it and point at `adopt`, which links it.
+    preexisting, ambiguous_live = [], []
+    if net_new:
+        try:
+            preexisting, ambiguous_live = upstream_unlinked(args.world, token, net_new, mp)
+        except client.ApiError as e:
+            print(f"ERROR checking live world for pre-existing elements: {e}", file=sys.stderr)
+            return 1
+        held_paths = {e["path"] for e, _ in preexisting} | {e["path"] for e, _ in ambiguous_live}
+        net_new = [e for e in net_new if e["path"] not in held_paths]
+        # The live id is known now — let edges from this run's creates resolve
+        # to it (the issue's preferred outcome) instead of being dropped as
+        # "not a world element".
+        for ent, live in preexisting:
+            ent_id_by_key.setdefault(_key(ent["name"]), live["id"])
+            for al in ent.get("aliases", []):
+                ent_id_by_key.setdefault(_key(al), live["id"])
+
     # Every NET-NEW entity's in-batch group ref, so a relationship whose target is
     # itself net-new in this push resolves to that target's `suggestion:<ref>`
     # instead of being skipped for want of an upstream id. (Linked targets resolve
@@ -973,6 +1034,20 @@ def run(argv: list[str]) -> int:
         print(f"  [held] {len(submitted_ents)} entit(y/ies) already ruled on upstream "
               f"(pending/dismissed suggestion, or deleted element) — not re-filed: "
               + ", ".join(sorted(e["name"] for e in submitted_ents)))
+    if preexisting or ambiguous_live:
+        parts = []
+        if preexisting:
+            parts.append(", ".join(sorted(e["name"] for e, _ in preexisting))
+                         + " (edges to them resolve to the live id)")
+        if ambiguous_live:
+            parts.append("ambiguous live name match: "
+                         + ", ".join(f"{e['name']} ({len(h)} matches)" for e, h in ambiguous_live))
+        print(f"  [held] {len(preexisting) + len(ambiguous_live)} entit(y/ies) already exist "
+              f"upstream but carry no mobrpg: node — not re-filed (the server would skip the "
+              f"create as already claimed and every edge referencing it would fail the whole "
+              f"batch with a bare HTTP 400): " + "; ".join(parts)
+              + f"\n         → run `mobrpg adopt {args.world} --vault {args.vault} --execute` "
+                f"to link them, then re-run suggest.")
     for r in all_reports:
         print(f"  [note] {r}")
     if deferred:
@@ -982,13 +1057,19 @@ def run(argv: list[str]) -> int:
         for src, tgt in deferred:
             print(f"    · {src} → {tgt}", file=sys.stderr)
 
-    if args.write_back:
-        # Only net-new entities get a fresh pending node here; already-linked
-        # entities keep their existing (accepted) nodes untouched.
-        w, s = write_back(net_new, mp, args.vault, namespace, execute=args.execute)
-        print(f"write-back: {w} node(s) written, {s} unchanged (skipped)"
-              + ("" if args.execute else "  [dry-run — no files changed]"))
+    if args.write_back and not args.execute:
+        # Dry-run: show the plan. Only net-new entities get a fresh pending node;
+        # already-linked entities keep their existing (accepted) nodes untouched.
+        w, s = write_back(net_new, mp, args.vault, namespace, execute=False)
+        print(f"write-back: {w} node(s) would be written, {s} unchanged (skipped)"
+              "  [dry-run — no files changed]")
 
+    # Executing: a node is stamped `pending` only for a create the server
+    # actually stored, per batch, after the POST result is known. Stamping up
+    # front left a failed batch's entities marked pending — which held-back
+    # detection then read as "already ruled on", so the failure made itself
+    # permanent until the frontmatter was hand-repaired (#179).
+    ents_by_ref = {external_ref(e["path"], args.vault, namespace): e for e in net_new}
     rc = 0
     for idx, chunk in enumerate(chunks, 1):
         req = {"batchLabel": f"{label} [{idx}/{len(chunks)}]", "suggestions": chunk}
@@ -996,11 +1077,26 @@ def run(argv: list[str]) -> int:
         with open(batch_path, "w", encoding="utf-8") as fh:
             json.dump(req, fh, indent=2, ensure_ascii=False)
         try:
-            submit_batch.submit(args.world, req, execute=args.execute, index=idx)
+            resp = submit_batch.submit(args.world, req, execute=args.execute, index=idx)
         except client.ApiError as e:
             print(f"ERROR on batch {idx}: {e}", file=sys.stderr)
+            if e.status == 400:
+                print(f"  hint: a bare 400 on a compound batch usually means an AddRelation "
+                      f"references `suggestion:<ref>` for a create the server skipped as "
+                      f"already claimed. Run `mobrpg adopt {args.world} --vault {args.vault}` "
+                      f"to link pre-existing elements, then re-run.", file=sys.stderr)
+            if args.write_back and args.execute:
+                print(f"  write-back: batch {idx} not stamped (nothing was accepted)",
+                      file=sys.stderr)
             rc = 1
             break
+        if args.write_back and args.execute:
+            refused = submit_batch.refused_refs(resp)
+            ents = [e for e in entities_in_chunk(chunk, ents_by_ref)
+                    if external_ref(e["path"], args.vault, namespace) not in refused]
+            w, s = write_back(ents, mp, args.vault, namespace, execute=True)
+            print(f"  write-back: batch {idx} — {w} node(s) written, {s} unchanged (skipped)"
+                  + (f", {len(refused)} refused by the server (not stamped)" if refused else ""))
     return rc
 
 

--- a/tools/mobrpg/skill/references/push.md
+++ b/tools/mobrpg/skill/references/push.md
@@ -21,9 +21,17 @@ So in practice:
 
 | Flags | What happens |
 |---|---|
-| `suggest --write-back --out <dir>` | Full dry-run. Writes `suggest-batch-N.json` into `<dir>`, computes the write-back and prints `write-back: N node(s) written, M unchanged (skipped)  [dry-run — no files changed]` — but touches nothing. |
-| `suggest --write-back --out <dir> --execute` | Submits the batches to the API **and** writes pending `mobrpg:` nodes into the vault (preserving any already-ratified `element_id` — see below). |
+| `suggest --write-back --out <dir>` | Full dry-run. Writes `suggest-batch-N.json` into `<dir>`, computes the write-back and prints `write-back: N node(s) would be written, M unchanged (skipped)  [dry-run — no files changed]` — but touches nothing. |
+| `suggest --write-back --out <dir> --execute` | Submits the batches to the API **and**, per batch, once the POST has succeeded, writes pending `mobrpg:` nodes for the creates the server stored (preserving any already-ratified `element_id` — see below). A batch that fails stamps nothing; an externalRef the server refused as already claimed is not stamped either. |
 | `suggest --out <dir> --execute` (no `--write-back`) | Submits the batches. No vault file is touched. |
+
+Before building batches, `suggest` checks the live world for net-new entities
+that already exist upstream without a `mobrpg:` node (matched by name within
+their element kind, as `adopt` does). Those are **held**, listed under
+`[held] … already exist upstream`, and not filed: the server would skip the
+create as already claimed and every edge referencing it would fail the whole
+batch with a bare HTTP 400. Run `mobrpg adopt <world> --vault <path> --execute`
+to link them, then re-run `suggest`.
 
 `--out` defaults to `./push_out` if omitted. `suggest-batch-N.json` files are
 written unconditionally on every run, dry-run or not — they're the batch

--- a/tools/mobrpg/tests/test_suggest.py
+++ b/tools/mobrpg/tests/test_suggest.py
@@ -85,6 +85,11 @@ def _map():
     }
 
 
+def _empty_live():
+    """A live-world page with nothing on it (for the #179 preflight GETs)."""
+    return {"content": [], "page": {"totalPages": 1}}
+
+
 def test_element_spec_routing():
     mp = _map()
     person = {"kind": "npc", "location_type": None}
@@ -512,8 +517,10 @@ def test_run_dry_run_end_to_end(tmp_path, monkeypatch, capsys):
     (d / "_meta/mobrpg-map.json").write_text(json.dumps(_map()), encoding="utf-8")
     monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
     monkeypatch.setattr(client, "get_access_token", lambda: "tok")
-    def boom(*a, **k):
-        raise AssertionError("no write in dry-run")
+    def boom(method, *a, **k):
+        if method != "GET":
+            raise AssertionError("no write in dry-run")
+        return _empty_live()   # the #179 preflight reads the live world
     monkeypatch.setattr(client, "_request", boom)
 
     rc = suggest.run(["w1", "--vault", str(d),
@@ -537,6 +544,7 @@ def test_run_namespace_and_label_not_hardcoded_canticle(tmp_path, monkeypatch, c
     (d / "_meta/mobrpg-map.json").write_text(json.dumps(mp), encoding="utf-8")
     monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
     monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+    monkeypatch.setattr(client, "_request", lambda *a, **k: _empty_live())
     rc = suggest.run(["w1", "--vault", str(d),
                       "--out", str(tmp_path / "out")])
     assert rc == 0
@@ -635,6 +643,7 @@ def test_run_skips_already_linked_creates(tmp_path, monkeypatch, capsys):
     (d / "_meta/mobrpg-map.json").write_text(json.dumps(_map()), encoding="utf-8")
     monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
     monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+    monkeypatch.setattr(client, "_request", lambda *a, **k: _empty_live())
 
     rc = suggest.run(["w1", "--vault", str(d),
                       "--out", str(tmp_path / "out")])
@@ -911,3 +920,144 @@ def test_create_description_config_replaces_the_default_list(tmp_path, capsys):
     assert "She is the traitor." in im["description"]
     err = capsys.readouterr().err
     assert "vaultOnlySections" in err and "GM Notes" in err and "PUSHED" in err
+
+
+# --- issue #179: pre-existing upstream elements and per-batch write-back ---
+
+def _two_npc_vault(tmp_path):
+    d = tmp_path / "space_game"
+    (d / "Characters/NPCs").mkdir(parents=True)
+    (d / "_meta").mkdir(parents=True)
+    for name in ("Kate_Broadbeck", "Gary_Johnson"):
+        (d / f"Characters/NPCs/{name}.md").write_text(
+            '---\ntype: npc\noccupation: "Escort"\ngender: Female\n---\nBody.\n', encoding="utf-8")
+    (d / "_meta/mobrpg-map.json").write_text(json.dumps(_map()), encoding="utf-8")
+    return d
+
+
+def test_edge_to_a_held_preexisting_entity_resolves_to_its_live_id(tmp_path, monkeypatch, capsys):
+    d = _two_npc_vault(tmp_path)
+    (d / "Characters/NPCs/Gary_Johnson.md").write_text(
+        '---\ntype: npc\noccupation: "Escort"\ngender: Female\nrelationships:\n'
+        '  - target: "[[Kate_Broadbeck]]"\n    type: knows\n---\nBody.\n', encoding="utf-8")
+    monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+    monkeypatch.setattr(client, "_request", lambda m, p, **k: (
+        {"content": [{"id": "kate-id", "name": "Kate Broadbeck"}], "page": {"totalPages": 1}}
+        if p.endswith("/person") else _empty_live()))
+    assert suggest.run(["w1", "--vault", str(d), "--out", str(tmp_path / "out")]) == 0
+    out = capsys.readouterr().out
+    assert "not a world element" not in out
+    batch = json.load(open(tmp_path / "out" / "suggest-batch-1.json"))
+    assert any("kate-id" in json.dumps(it) for it in batch["suggestions"])
+
+
+def test_run_holds_entities_that_already_exist_live_and_points_at_adopt(tmp_path, monkeypatch, capsys):
+    """Kate exists upstream (accepted from an earlier push) but her note has no
+    node. Re-filing her create is skipped server-side and every edge on it 400s
+    the batch. The preflight must hold her, name her, and suggest `adopt`."""
+    d = _two_npc_vault(tmp_path)
+    monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+
+    def live(method, path, **k):
+        assert method == "GET"
+        if path.endswith("/person"):
+            return {"content": [{"id": "kate-id", "name": "Kate Broadbeck"}],
+                    "page": {"totalPages": 1}}
+        return _empty_live()
+    monkeypatch.setattr(client, "_request", live)
+
+    rc = suggest.run(["w1", "--vault", str(d), "--out", str(tmp_path / "out")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[held] 1 entit(y/ies) already exist upstream" in out
+    assert "Kate Broadbeck" in out.split("[held]")[1].split("\n")[0]
+    assert "mobrpg adopt w1" in out
+    batch = json.load(open(tmp_path / "out" / "suggest-batch-1.json"))
+    created = [it["payload"]["name"] for it in batch["suggestions"]
+               if it.get("operation") == "CreateElement" and it.get("externalRef")]
+    assert created == ["Gary Johnson"]
+
+
+def test_run_ambiguous_live_match_is_held_not_guessed(tmp_path, monkeypatch, capsys):
+    d = _two_npc_vault(tmp_path)
+    monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+    monkeypatch.setattr(client, "_request", lambda m, p, **k: (
+        {"content": [{"id": "k1", "name": "Kate Broadbeck"}, {"id": "k2", "name": "Kate Broadbeck"}],
+         "page": {"totalPages": 1}} if p.endswith("/person") else _empty_live()))
+    rc = suggest.run(["w1", "--vault", str(d), "--out", str(tmp_path / "out")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ambiguous live name match: Kate Broadbeck (2 matches)" in out
+
+
+def _execute_with(monkeypatch, post):
+    """Route GETs to an empty live world and POSTs to `post(body)`."""
+    monkeypatch.setattr(suggest, "discover_race_id", lambda w, t: "race-h")
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+
+    def fake(method, path, *, token=None, query=None, body=None):
+        if method == "GET":
+            return _empty_live()
+        return post(body)
+    monkeypatch.setattr(client, "_request", fake)
+
+
+def test_write_back_stamps_only_after_the_post_succeeds(tmp_path, monkeypatch, capsys):
+    from mobrpg import node
+    d = _two_npc_vault(tmp_path)
+
+    def post(body):
+        raise client.ApiError(400, '{"status":400,"error":"Bad Request"}', "/world/w1/suggestion")
+    _execute_with(monkeypatch, post)
+
+    rc = suggest.run(["w1", "--vault", str(d), "--out", str(tmp_path / "out"),
+                      "--execute", "--write-back"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "ERROR on batch 1" in err
+    assert "mobrpg adopt w1" in err                     # the 400 hint
+    assert "batch 1 not stamped" in err
+    for name in ("Kate_Broadbeck", "Gary_Johnson"):
+        txt = (d / f"Characters/NPCs/{name}.md").read_text()
+        assert node.read_node(txt) is None, f"{name} must not carry a pending node"
+
+
+def test_write_back_stamps_accepted_batch_but_not_refused_refs(tmp_path, monkeypatch, capsys):
+    from mobrpg import node
+    d = _two_npc_vault(tmp_path)
+
+    def post(body):
+        rows = []
+        for it in body["suggestions"]:
+            if it.get("operation") != "CreateElement" or not it.get("externalRef"):
+                continue
+            ref = it["externalRef"]
+            rows.append({"id": ref, "externalRef": ref, "operation": "CreateElement",
+                         "payload": it["payload"],
+                         "reviewState": "Accepted" if ref.endswith("Kate_Broadbeck") else "Pending"})
+        return {"suggestions": rows, "updatedIds": []}
+    _execute_with(monkeypatch, post)
+
+    rc = suggest.run(["w1", "--vault", str(d), "--out", str(tmp_path / "out"),
+                      "--execute", "--write-back"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "write-back: batch 1 — 1 node(s) written" in out
+    assert "1 refused by the server (not stamped)" in out
+    gary = node.read_node((d / "Characters/NPCs/Gary_Johnson.md").read_text())
+    assert gary and gary["review_state"] == "pending"
+    kate = node.read_node((d / "Characters/NPCs/Kate_Broadbeck.md").read_text())
+    assert kate is None
+
+
+def test_dry_run_write_back_changes_no_files(tmp_path, monkeypatch, capsys):
+    from mobrpg import node
+    d = _two_npc_vault(tmp_path)
+    _execute_with(monkeypatch, lambda body: (_ for _ in ()).throw(AssertionError("no POST in dry-run")))
+    rc = suggest.run(["w1", "--vault", str(d), "--out", str(tmp_path / "out"), "--write-back"])
+    assert rc == 0
+    assert "would be written" in capsys.readouterr().out
+    assert node.read_node((d / "Characters/NPCs/Gary_Johnson.md").read_text()) is None

--- a/tools/publish/bin/gm-publish.js
+++ b/tools/publish/bin/gm-publish.js
@@ -23,7 +23,48 @@ Usage:
 
 Build options:
   --config <path>    Path to vault.config.json (default: ./vault.config.json)
+
+Flush options:
+  --config <path>    Path to vault.config.json (default: ./vault.config.json)
+  --dry-run, -n      Report what would change in each sheet without writing
+
+Every subcommand accepts --help / -h.
 `);
+}
+
+function printFlushHelp() {
+  console.log(`
+gm-apprentice-publish flush [--config <path>] [--dry-run]
+
+Writes each player's current KV live-state (HP, FP, conditions…) back into the
+matching vault character sheet so the build-time seed stays fresh. Edits vault
+source only — no rebuild, no deploy.
+
+  --config <path>    Path to vault.config.json (default: ./vault.config.json)
+  --dry-run, -n      Print the same per-PC "✓ Name — HP 10→13" lines, write nothing
+  --help, -h         Show this help
+`);
+}
+
+// Parse `--config <path>` plus an allowlist of flags, rejecting anything else.
+// A mutating command must never let an unrecognised argument fall through to
+// execution: `flush --help` used to perform the flush (#178). Returns
+// { configPath, flags } or { error }.
+function parseSubcommandArgs(rest, allowedFlags) {
+  let configPath = './vault.config.json';
+  const flags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--config') {
+      if (!rest[i + 1]) return { error: '--config needs a path' };
+      configPath = rest[i + 1]; i++;
+    } else if (Object.prototype.hasOwnProperty.call(allowedFlags, a)) {
+      flags[allowedFlags[a]] = true;
+    } else {
+      return { error: `Unknown argument: ${a}` };
+    }
+  }
+  return { configPath, flags };
 }
 
 function printVersion() {
@@ -106,6 +147,14 @@ if (command === '--version' || command === '-v') {
   process.exit(0);
 }
 
+// `--help` on any subcommand prints usage and exits 0 with no side effects (#178).
+const wantsHelp = args.slice(1).some((a) => a === '--help' || a === '-h');
+if (wantsHelp) {
+  if (command === 'flush') printFlushHelp(); else printHelp();
+  process.exit(0);
+}
+
+
 if (command === 'init') {
   const targetDir = args[1] || '.';
   const { init } = require('../lib/init');
@@ -176,12 +225,14 @@ if (command === 'inbox') {
 }
 
 if (command === 'flush') {
-  let configPath = './vault.config.json';
-  for (let i = 1; i < args.length; i++) {
-    if (args[i] === '--config' && args[i + 1]) { configPath = args[i + 1]; i++; }
+  const parsed = parseSubcommandArgs(args.slice(1), { '--dry-run': 'dryRun', '-n': 'dryRun' });
+  if (parsed.error) {
+    console.error(`Error: ${parsed.error}`);
+    printFlushHelp();
+    process.exit(1);
   }
   const { runFlush } = require('../lib/flush-cli.js');
-  runFlush({ configPath })
+  runFlush({ configPath: parsed.configPath, dryRun: !!parsed.flags.dryRun })
     .then((rc) => process.exit(rc))
     .catch((err) => { console.error(err.message); process.exit(1); });
   return;
@@ -196,10 +247,14 @@ if (command === 'doctor') {
 }
 
 if (command === 'setup-status-bar' || command === 'setup-inbox') {
-  let configPath = './vault.config.json';
-  for (let i = 1; i < args.length; i++) {
-    if (args[i] === '--config' && args[i + 1]) { configPath = args[i + 1]; i++; }
+  // Also mutating (KV namespace + deploy): reject unknown arguments (#178).
+  const parsed = parseSubcommandArgs(args.slice(1), {});
+  if (parsed.error) {
+    console.error(`Error: ${parsed.error}`);
+    printHelp();
+    process.exit(1);
   }
+  const configPath = parsed.configPath;
   const feature = command === 'setup-status-bar' ? 'status-bar' : 'inbox';
   const { runSetupBackend } = require('../lib/setup-backend.js');
   runSetupBackend(feature, { configPath })

--- a/tools/publish/bin/gm-publish.js
+++ b/tools/publish/bin/gm-publish.js
@@ -56,7 +56,7 @@ function parseSubcommandArgs(rest, allowedFlags) {
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
     if (a === '--config') {
-      if (!rest[i + 1]) return { error: '--config needs a path' };
+      if (!rest[i + 1] || rest[i + 1].startsWith('-')) return { error: '--config needs a path' };
       configPath = rest[i + 1]; i++;
     } else if (Object.prototype.hasOwnProperty.call(allowedFlags, a)) {
       flags[allowedFlags[a]] = true;

--- a/tools/publish/js/change-request.js
+++ b/tools/publish/js/change-request.js
@@ -32,6 +32,19 @@
     return out;
   }
 
+  // The server no longer has this request at all — it expired (or was never
+  // stored). Distinct from "handled": the player must be TOLD, not silently
+  // dropped, because any reply the GM wrote is lost with it (#176).
+  var GONE_TEXT = 'This request expired before a reply reached you — please send it again.';
+  function goneIds(results, pendingIds) {
+    var out = [];
+    (pendingIds || []).forEach(function (id) {
+      var r = (results || {})[id];
+      if (r && r.status === 'gone') out.push(id);
+    });
+    return out;
+  }
+
   function needsReload(resolvedList) {
     return (resolvedList || []).some(function (x) { return x.kind === 'applied'; });
   }
@@ -74,6 +87,8 @@
       shouldPromptForCode: shouldPromptForCode,
       resolvedResults: resolvedResults,
       staleIds: staleIds,
+      goneIds: goneIds,
+      GONE_TEXT: GONE_TEXT,
       needsReload: needsReload,
       appendLog: appendLog,
       setLogReply: setLogReply,
@@ -274,12 +289,19 @@
       }).then(function (results) {
         var done = resolvedResults(results, ids);
         var stale = staleIds(results, ids);
-        if (!done.length && !stale.length) return; // still waiting
-        // record replies into the log and drop resolved + gone/expired ids from pending
+        var gone = goneIds(results, ids);
+        if (!done.length && !stale.length && !gone.length) return; // still waiting
+        // record replies into the log and drop resolved + handled + gone ids from pending.
+        // A gone id gets an 'expired' reply so it surfaces exactly like an answer would.
         var log = getLog();
         var removeIds = {};
         done.forEach(function (d) { removeIds[d.id] = true; log = setLogReply(log, d.id, d.response, d.kind); });
         stale.forEach(function (id) { removeIds[id] = true; });
+        gone.forEach(function (id) {
+          removeIds[id] = true;
+          log = setLogReply(log, id, GONE_TEXT, 'expired');
+          done.push({ id: id, response: GONE_TEXT, kind: 'expired' });
+        });
         setLog(log);
         setPending(ids.filter(function (id) { return !removeIds[id]; }));
         renderLog();

--- a/tools/publish/lib/flush-cli.js
+++ b/tools/publish/lib/flush-cli.js
@@ -58,6 +58,9 @@ async function runFlush(deps) {
   const out = deps.out || console.log;
   const readFile = deps.readFile || function (p) { return fs.readFileSync(p, 'utf8'); };
   const writeFile = deps.writeFile || function (p, s) { fs.writeFileSync(p, s); };
+  // --dry-run: identical reconciliation and report, no write (#178). The GM
+  // reads the same "✓ Name — HP 10→13" lines they would get for real.
+  const dryRun = !!deps.dryRun;
 
   // Resolve config exactly as build.js does (so campaignId/pcSlug match).
   const configPath = path.resolve(deps.configPath || './vault.config.json');
@@ -80,6 +83,7 @@ async function runFlush(deps) {
   }
   const latest = latestStateByPcSlug(states);
 
+  if (dryRun) out('DRY RUN — nothing will be written.');
   if (!Object.keys(latest).length) {
     out('No live state to flush for campaign ' + campaignId + ' — no players have saved sheet state yet.');
     return 0;
@@ -113,8 +117,12 @@ async function runFlush(deps) {
       res = applyCoCFlush(raw, latest[slug]);
     }
     if (res.changes.length) {
-      writeFile(page.sourcePath, res.markdown);
-      out('✓ ' + name + ' — ' + summarize(res.changes));
+      if (dryRun) {
+        out('✓ ' + name + ' — ' + summarize(res.changes) + '  (would write)');
+      } else {
+        writeFile(page.sourcePath, res.markdown);
+        out('✓ ' + name + ' — ' + summarize(res.changes));
+      }
     } else {
       out('· ' + name + ' — no change');
     }

--- a/tools/publish/lib/inbox-cli.js
+++ b/tools/publish/lib/inbox-cli.js
@@ -19,7 +19,13 @@ function defaultRunWrangler(args, run = runCommand) {
 }
 
 function defaultAdapter(cwd) {
-  const tomlPath = path.join(cwd || process.cwd(), 'wrangler.toml');
+  const dir = cwd || process.cwd();
+  const tomlPath = path.join(dir, 'wrangler.toml');
+  // A write that cannot happen must not look like one that did (#176): name the
+  // directory so "run it from the site folder" is the obvious next step.
+  if (!fs.existsSync(tomlPath)) {
+    throw new Error(`No wrangler.toml in ${dir} — inbox commands must run from the site directory.`);
+  }
   const namespaceId = readNamespaceId(fs.readFileSync(tomlPath, 'utf8'));
   if (!namespaceId) throw new Error('No INBOX namespace id in wrangler.toml — run the inbox setup first.');
   return makeAdapter({ runWrangler: defaultRunWrangler, namespaceId });
@@ -54,13 +60,17 @@ async function runInbox(argv, deps = {}) {
       out(JSON.stringify(await inbox.readPending(kv)));
       return 0;
     }
-    case 'handled': {
-      for (const id of rest) await inbox.markHandled(kv, id);
-      return 0;
-    }
+    case 'handled':
     case 'flag': {
-      for (const id of rest) await inbox.markFlagged(kv, id);
-      return 0;
+      // Report the outcome of our OWN write. KV is eventually consistent, so a
+      // follow-up read is not a trustworthy check (#176); the return value is.
+      const mark = sub === 'handled' ? inbox.markHandled : inbox.markFlagged;
+      let rc = 0;
+      for (const id of rest) {
+        if (await mark(kv, id)) out(`${id}: marked ${sub === 'handled' ? 'handled' : 'flagged'}`);
+        else { out(`${id}: NOT ${sub === 'handled' ? 'marked handled' : 'flagged'} — no such request (expired, or never enqueued)`); rc = 1; }
+      }
+      return rc;
     }
     case 'reply': {
       const [id, kind, ...textParts] = rest;
@@ -69,7 +79,14 @@ async function runInbox(argv, deps = {}) {
         out('Usage: inbox reply <id> <applied|rejected|advice> "<text>"');
         return 1;
       }
-      await inbox.setResponse(kv, id, kind, text);
+      const entry = await inbox.setResponse(kv, id, kind, text);
+      if (!entry) {
+        // Nothing was written. Exit non-zero so the loop never reports a reply
+        // the player can never receive (#176).
+        out(`${id}: reply NOT stored — no such request (it may have expired, or the id is wrong). Nothing was written.`);
+        return 1;
+      }
+      out(`${id}: reply stored (${kind}) → status ${entry.status}`);
       return 0;
     }
     default:

--- a/tools/publish/lib/inbox-cli.js
+++ b/tools/publish/lib/inbox-cli.js
@@ -65,6 +65,7 @@ async function runInbox(argv, deps = {}) {
       // Report the outcome of our OWN write. KV is eventually consistent, so a
       // follow-up read is not a trustworthy check (#176); the return value is.
       const mark = sub === 'handled' ? inbox.markHandled : inbox.markFlagged;
+      if (!rest.length) { out(`Usage: inbox ${sub} <id> [<id>...]`); return 1; }
       let rc = 0;
       for (const id of rest) {
         if (await mark(kv, id)) out(`${id}: marked ${sub === 'handled' ? 'handled' : 'flagged'}`);

--- a/tools/publish/lib/templates/gurps/index.js
+++ b/tools/publish/lib/templates/gurps/index.js
@@ -10,6 +10,9 @@ function renderGURPSSheet(frontmatter, sections, meta) {
     sheetHtml: buildSheet(model),
     combatHtml: buildCombat(model, sections || []),
     equipmentHtml: buildEquipment(model),
+    // Structural warnings (sections found but unread, hidden sub-tables, an
+    // empty combat tab) — build.js prints them per page (#177).
+    warnings: model.warnings,
     liveData,
     // Panel rides the live-data island: only mount when the island exists AND
     // vitals resolved. Otherwise there is no gurps-live.js to drive it.

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -1,4 +1,4 @@
-const { parseTableRows, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings } = require('./tables');
+const { parseTableRows, parseTables, countTables, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings } = require('./tables');
 const { splitMarkers, stripCost } = require('./render');
 
 const PRIMARY = ['ST', 'DX', 'IQ', 'HT'];
@@ -22,6 +22,7 @@ function emptyModel() {
     equipment: { items: [], loadouts: [] },
     chains: { melee: [], ranged: [] },
     points: [],
+    warnings: [],
   };
 }
 
@@ -159,6 +160,7 @@ function parseSkills(model, sections, fm) {
   const sec = findSectionByTitle(sections, 'skills');
   if (!sec) return;
   const rows = parseTableRows(topLevelHtml(sec.html));
+  noteHiddenSubtables(model, sec, rows);
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = header.findIndex(h => h.includes('name')) >= 0
     ? header.findIndex(h => h.includes('name')) : 0;
@@ -388,6 +390,7 @@ function parseSpells(model, sections, fm) {
   const sec = findSectionByTitle(sections, 'spells');
   if (!sec) return;
   const rows = parseTableRows(topLevelHtml(sec.html));
+  noteHiddenSubtables(model, sec, rows);
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = Math.max(0, header.findIndex(h => h.includes('name')));
   const { iLevel } = resolveLevelColumns(header);
@@ -418,6 +421,100 @@ function parsePoints(model, sections, fm) {
   }
 }
 
+// Skills/Techniques/Spells read only the table(s) above the first `###` (#82:
+// helper tables under a subheading carry a foreign schema). That exclusion is
+// deliberate, but it must not be silent — a sheet that keeps six usable
+// techniques in a `### … at a glance` sub-table shipped none of them for five
+// sessions with no hint in the build output (#177). Say what was skipped.
+function noteHiddenSubtables(model, sec, rowsRead) {
+  const total = countTables(sec.html);
+  const read = countTables(topLevelHtml(sec.html));
+  if (total > read) {
+    const subs = [...String(sec.html).matchAll(/<h3[^>]*>([\s\S]*?)<\/h3>/gi)]
+      .map(m => m[1].replace(/<[^>]+>/g, '').trim()).filter(Boolean);
+    model.warnings.push(
+      `GURPS "## ${sec.title}": ${total - read} table(s) under ### subheading(s) (${subs.join(', ') || 'untitled'}) are not published — only the top-level table is read. Move rows that belong on the sheet into the main table.`);
+  }
+  if (rowsRead.length <= 1) {
+    model.warnings.push(total === 0
+      ? `GURPS "## ${sec.title}" is present but contains no table — its content will not publish. GURPS sheets keep these rows in a table with a Name column.`
+      : `GURPS "## ${sec.title}" is present but yielded no rows — check the table's header row (expected a Name column).`);
+  }
+}
+
+// Section titles that may hold weapon tables. A combined `## Melee & Ranged`
+// (or plain `## Weapons`) is a natural heading; each table inside is routed to
+// melee or ranged by its own header, so one section can feed both (#177).
+const MELEE_TITLES = ['melee weapons', 'melee', 'melee attacks'];
+const RANGED_TITLES = ['ranged weapons', 'ranged', 'ranged attacks'];
+const COMBINED_TITLES = ['melee and ranged', 'melee and ranged weapons', 'ranged and melee', 'ranged and melee weapons', 'weapons', 'attacks', 'combat weapons'];
+
+// What a weapon table is, from its header alone: ranged-only columns win, then
+// melee-only ones; a bare Weapon/Skill/Damage/Notes table is `null` and takes
+// its kind from the section it sits in.
+function weaponTableKind(header) {
+  const h = header.map(x => x.toLowerCase());
+  const has = (...names) => h.some(c => names.some(n => c === n || c.startsWith(n + ' ') || c.startsWith(n + '/')));
+  if (has('acc', 'range', 'rof', 'shots', 'rcl', 'bulk')) return 'ranged';
+  if (has('parry', 'reach')) return 'melee';
+  return null;
+}
+
+// Every weapon table in scope for `kind`, from a dedicated section (all of its
+// tables not positively of the other kind) and from a combined section (only
+// tables whose header says `kind`; an unclassifiable table in a combined
+// section counts as melee, the commoner case). Returns { tables, sections }.
+function weaponTables(sections, kind) {
+  const own = kind === 'melee' ? MELEE_TITLES : RANGED_TITLES;
+  const other = kind === 'melee' ? 'ranged' : 'melee';
+  const found = [];
+  const tables = [];
+  const ownSec = findSectionByTitle(sections, ...own);
+  if (ownSec) {
+    found.push(ownSec);
+    for (const t of parseTables(ownSec.html)) if (weaponTableKind(t[0]) !== other) tables.push(t);
+  }
+  const both = findSectionByTitle(sections, ...COMBINED_TITLES);
+  if (both) {
+    found.push(both);
+    for (const t of parseTables(both.html)) {
+      const split = splitMixedTable(t);
+      if (split) { if (split[kind].length > 1) tables.push(split[kind]); continue; }
+      if ((weaponTableKind(t[0]) || 'melee') === kind) tables.push(t);
+    }
+  }
+  return { tables, sections: found };
+}
+
+// A combined section written as ONE table carries both Parry/Reach and
+// Acc/Range columns; classifying it whole would file every knife under Ranged
+// with blank Acc/Range and no warning. Route row by row instead: a row with any
+// ranged-only cell filled is ranged, the rest are melee. Returns null when the
+// table is not mixed.
+const RANGED_ONLY = ['acc', 'range', 'rof', 'shots', 'rcl', 'bulk'];
+const MELEE_ONLY = ['parry', 'reach'];
+function splitMixedTable(rows) {
+  const header = (rows[0] || []).map(h => h.toLowerCase());
+  const cols = names => header.map((c, i) => names.some(n => c === n || c.startsWith(n + ' ') || c.startsWith(n + '/')) ? i : -1).filter(i => i >= 0);
+  const rCols = cols(RANGED_ONLY); const mCols = cols(MELEE_ONLY);
+  if (!rCols.length || !mCols.length) return null;
+  const filled = (row, i) => { const v = (row[i] || '').trim(); return v && v !== '—' && v !== '-' && v !== '–'; };
+  const out = { melee: [rows[0]], ranged: [rows[0]] };
+  for (const row of rows.slice(1)) out[rCols.some(i => filled(row, i)) ? 'ranged' : 'melee'].push(row);
+  return out;
+}
+
+// Silence is the defect (#177): a section that names weapons but produced no
+// rows for either kind reads at the table as lost data. Called once both
+// parsers have run.
+function noteEmptyWeapons(model, sections) {
+  if (model.melee.length || model.ranged.length) return;
+  const named = sections.filter(s => /weapon|melee|ranged|attack/i.test(String(s.title || '')));
+  if (!named.length) return;
+  model.warnings.push(
+    `GURPS combat tab is empty: section(s) ${named.map(s => `"## ${s.title}"`).join(', ')} exist but no melee or ranged rows were read. Headings recognised: ${[...MELEE_TITLES, ...RANGED_TITLES, ...COMBINED_TITLES].map(t => `"${t}"`).join(', ')}; a weapon table needs a header row with a Weapon column (plus Parry/Reach for melee or Acc/Range/RoF/Shots for ranged).`);
+}
+
 function parseMelee(model, sections, fm) {
   if (Array.isArray(fm.melee)) {
     model.melee = fm.melee.map(a => ({
@@ -426,22 +523,21 @@ function parseMelee(model, sections, fm) {
     }));
     return;
   }
-  const sec = findSectionByTitle(sections, 'melee weapons', 'melee');
-  if (!sec) return;
-  const rows = parseTableRows(sec.html);
-  const header = (rows[0] || []).map(h => h.toLowerCase());
-  const idx = n => header.findIndex(h => h.includes(n));
-  const iWep = Math.max(0, idx('weapon') >= 0 ? idx('weapon') : idx('mode') >= 0 ? idx('mode') : 0);
-  const iSkill = idx('skill'); const iParry = idx('parry'); const iDmg = idx('damage') >= 0 ? idx('damage') : idx('dmg');
-  const iReach = idx('reach'); const iSt = idx('st'); const iNotes = idx('notes');
-  for (const row of rows.slice(1)) {
-    if (!row[iWep]) continue;
-    model.melee.push({
-      weapon: row[iWep], skill: iSkill >= 0 ? row[iSkill] : '',
-      parry: iParry >= 0 ? row[iParry] : '', damage: iDmg >= 0 ? row[iDmg] : '',
-      reach: iReach >= 0 ? row[iReach] : '', st: iSt >= 0 ? row[iSt] : '',
-      notes: iNotes >= 0 ? row[iNotes] : '',
-    });
+  for (const rows of weaponTables(sections, 'melee').tables) {
+    const header = (rows[0] || []).map(h => h.toLowerCase());
+    const idx = n => header.findIndex(h => h.includes(n));
+    const iWep = Math.max(0, idx('weapon') >= 0 ? idx('weapon') : idx('mode') >= 0 ? idx('mode') : 0);
+    const iSkill = idx('skill'); const iParry = idx('parry'); const iDmg = idx('damage') >= 0 ? idx('damage') : idx('dmg');
+    const iReach = idx('reach'); const iSt = idx('st'); const iNotes = idx('notes');
+    for (const row of rows.slice(1)) {
+      if (!row[iWep]) continue;
+      model.melee.push({
+        weapon: row[iWep], skill: iSkill >= 0 ? row[iSkill] : '',
+        parry: iParry >= 0 ? row[iParry] : '', damage: iDmg >= 0 ? row[iDmg] : '',
+        reach: iReach >= 0 ? row[iReach] : '', st: iSt >= 0 ? row[iSt] : '',
+        notes: iNotes >= 0 ? row[iNotes] : '',
+      });
+    }
   }
 }
 
@@ -455,26 +551,25 @@ function parseRanged(model, sections, fm) {
     }));
     return;
   }
-  const sec = findSectionByTitle(sections, 'ranged weapons', 'ranged');
-  if (!sec) return;
-  const rows = parseTableRows(sec.html);
-  const header = (rows[0] || []).map(h => h.toLowerCase());
-  const idx = n => header.findIndex(h => h.includes(n));
-  const iWep = Math.max(0, idx('weapon'));
-  const iSkill = idx('skill'); const iDmg = idx('damage') >= 0 ? idx('damage') : idx('dmg');
-  const iAcc = idx('acc'); const iRange = idx('range'); const iRof = idx('rof');
-  const iShots = idx('shots'); const iSt = idx('st'); const iBulk = idx('bulk');
-  const iRcl = idx('rcl'); const iNotes = idx('notes');
-  for (const row of rows.slice(1)) {
-    if (!row[iWep]) continue;
-    model.ranged.push({
-      weapon: row[iWep], skill: iSkill >= 0 ? row[iSkill] : '',
-      damage: iDmg >= 0 ? row[iDmg] : '', acc: iAcc >= 0 ? row[iAcc] : '',
-      range: iRange >= 0 ? row[iRange] : '', rof: iRof >= 0 ? row[iRof] : '',
-      shots: iShots >= 0 ? row[iShots] : '', st: iSt >= 0 ? row[iSt] : '',
-      bulk: iBulk >= 0 ? row[iBulk] : '', rcl: iRcl >= 0 ? row[iRcl] : '',
-      notes: iNotes >= 0 ? row[iNotes] : '',
-    });
+  for (const rows of weaponTables(sections, 'ranged').tables) {
+    const header = (rows[0] || []).map(h => h.toLowerCase());
+    const idx = n => header.findIndex(h => h.includes(n));
+    const iWep = Math.max(0, idx('weapon'));
+    const iSkill = idx('skill'); const iDmg = idx('damage') >= 0 ? idx('damage') : idx('dmg');
+    const iAcc = idx('acc'); const iRange = idx('range'); const iRof = idx('rof');
+    const iShots = idx('shots'); const iSt = idx('st'); const iBulk = idx('bulk');
+    const iRcl = idx('rcl'); const iNotes = idx('notes');
+    for (const row of rows.slice(1)) {
+      if (!row[iWep]) continue;
+      model.ranged.push({
+        weapon: row[iWep], skill: iSkill >= 0 ? row[iSkill] : '',
+        damage: iDmg >= 0 ? row[iDmg] : '', acc: iAcc >= 0 ? row[iAcc] : '',
+        range: iRange >= 0 ? row[iRange] : '', rof: iRof >= 0 ? row[iRof] : '',
+        shots: iShots >= 0 ? row[iShots] : '', st: iSt >= 0 ? row[iSt] : '',
+        bulk: iBulk >= 0 ? row[iBulk] : '', rcl: iRcl >= 0 ? row[iRcl] : '',
+        notes: iNotes >= 0 ? row[iNotes] : '',
+      });
+    }
   }
 }
 
@@ -568,6 +663,7 @@ function parseTechniques(model, sections, fm) {
   const sec = findSectionByTitle(sections, 'techniques');
   if (!sec) return;
   const rows = parseTableRows(topLevelHtml(sec.html));
+  noteHiddenSubtables(model, sec, rows);
   const header = (rows[0] || []).map(h => h.toLowerCase());
   const iName = header.findIndex(h => h.includes('name')) >= 0
     ? header.findIndex(h => h.includes('name')) : 0;
@@ -817,6 +913,7 @@ function parseGurps(frontmatter, sections) {
   parsePoints(model, secs, fm);
   parseMelee(model, secs, fm);
   parseRanged(model, secs, fm);
+  noteEmptyWeapons(model, secs);
   parseGrimoire(model, secs, fm);
   parseStatus(model, secs, fm);
   resolveCurrentEncumbrance(model);
@@ -826,4 +923,4 @@ function parseGurps(frontmatter, sections) {
   return model;
 }
 
-module.exports = { parseGurps, emptyModel, cell };
+module.exports = { parseGurps, emptyModel, cell, weaponTableKind };

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -508,11 +508,26 @@ function splitMixedTable(rows) {
 // rows for either kind reads at the table as lost data. Called once both
 // parsers have run.
 function noteEmptyWeapons(model, sections) {
+  const shape = 'a weapon table needs a header row with a Weapon column (plus Parry/Reach for melee or Acc/Range/RoF/Shots for ranged)';
+  // Each recognised section is judged on its own: a good Ranged table must not
+  // hide an unreadable Melee one.
+  const own = [[findSectionByTitle(sections, ...MELEE_TITLES), 'melee'], [findSectionByTitle(sections, ...RANGED_TITLES), 'ranged']];
+  const recognised = new Set();
+  for (const [sec, kind] of own) {
+    if (!sec) continue;
+    recognised.add(sec);
+    if (!model[kind].length) model.warnings.push(`GURPS "## ${sec.title}" is present but no ${kind} rows were read — ${shape}.`);
+  }
+  const both = findSectionByTitle(sections, ...COMBINED_TITLES);
+  if (both) {
+    recognised.add(both);
+    if (!model.melee.length && !model.ranged.length) model.warnings.push(`GURPS combat tab is empty: "## ${both.title}" is present but no melee or ranged rows were read — ${shape}.`);
+  }
   if (model.melee.length || model.ranged.length) return;
-  const named = sections.filter(s => /weapon|melee|ranged|attack/i.test(String(s.title || '')));
+  const named = sections.filter(s => !recognised.has(s) && /weapon|melee|ranged|attack/i.test(String(s.title || '')));
   if (!named.length) return;
   model.warnings.push(
-    `GURPS combat tab is empty: section(s) ${named.map(s => `"## ${s.title}"`).join(', ')} exist but no melee or ranged rows were read. Headings recognised: ${[...MELEE_TITLES, ...RANGED_TITLES, ...COMBINED_TITLES].map(t => `"${t}"`).join(', ')}; a weapon table needs a header row with a Weapon column (plus Parry/Reach for melee or Acc/Range/RoF/Shots for ranged).`);
+    `GURPS combat tab is empty: section(s) ${named.map(s => `"## ${s.title}"`).join(', ')} exist but were not recognised as weapon sections. Headings recognised: ${[...MELEE_TITLES, ...RANGED_TITLES, ...COMBINED_TITLES].map(t => `"${t}"`).join(', ')}; ${shape}.`);
 }
 
 function parseMelee(model, sections, fm) {

--- a/tools/publish/lib/templates/gurps/tables.js
+++ b/tools/publish/lib/templates/gurps/tables.js
@@ -31,9 +31,41 @@ function topLevelHtml(sectionHtml) {
   return /<table[ >]/i.test(top) ? top : sectionHtml;
 }
 
+// Each table in a fragment as its own row list, in document order. parseTableRows
+// flattens every table into one list, which is right for a single-schema section
+// and wrong for a combined one (`## Melee & Ranged` holds two tables with two
+// header rows, #177).
+function parseTables(html) {
+  const out = [];
+  const tableRegex = /<table[^>]*>([\s\S]*?)<\/table>/gi;
+  let m;
+  while ((m = tableRegex.exec(String(html || ''))) !== null) {
+    const rows = parseTableRows(m[1]);
+    if (rows.length) out.push(rows);
+  }
+  return out;
+}
+
+function countTables(html) {
+  return (String(html || '').match(/<table[ >]/gi) || []).length;
+}
+
+// Loose heading key: case-folded, `&`/`&amp;`/`+` read as "and", punctuation
+// and runs of whitespace collapsed to one space. A sheet author writes
+// `## Melee & Ranged` or `## Advantages/Perks` and expects it to match; exact
+// string equality silently dropped whole sections (#177).
+function normalizeTitle(title) {
+  return String(title || '')
+    .toLowerCase()
+    .replace(/&amp;/g, '&')
+    .replace(/[&+]/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
 function findSectionByTitle(sections, ...titles) {
-  const lower = titles.map(t => t.toLowerCase());
-  return sections.find(s => lower.includes(s.title.toLowerCase()));
+  const keys = titles.map(normalizeTitle);
+  return sections.find(s => keys.includes(normalizeTitle(s.title)));
 }
 
 function escapeRegex(s) {
@@ -50,4 +82,4 @@ function extractSubsectionHtml(sectionHtml, subsectionTitle) {
   return match ? match[1] : '';
 }
 
-module.exports = { parseTableRows, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings };
+module.exports = { parseTableRows, parseTables, countTables, normalizeTitle, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings };

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.25",
+  "version": "1.11.26",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -8,8 +8,14 @@ export const PREFIX = 'req:';
 export const CODE_KEY = 'config:code';
 export const INDEX_KEY = 'config:req-index'; // JSON array of request ids; lets readPending skip kv.list()
 export const RL_PREFIX = 'rl:';
-export const HANDLED_TTL = 300; // seconds a handled entry lingers for the widget
-export const RESPONSE_TTL = 600; // seconds a responded (handled) entry lingers for the widget
+// How long a finalized entry lingers so the widget can collect it. These must
+// outlive the session they were written in (#176): at the old 300s/600s an answer
+// expired before a player who had put the phone down could read it, and a missing
+// key read back as "handled", so the reply was destroyed and every observer was
+// told the request had been dealt with. KV storage for a few text entries is
+// free and the index prune already keeps readPending cheap, so days, not minutes.
+export const HANDLED_TTL = 86400;   // 24h — handled with no reply text
+export const RESPONSE_TTL = 604800; // 7d  — handled with a reply the player must still see
 
 // The request index removes kv.list() from the change-request loop's hot path.
 // The GM's inbox loop polls readPending repeatedly during a session; on the free
@@ -172,15 +178,21 @@ export async function setResponse(kv, id, kind, text) {
   return entry;
 }
 
+// A missing (expired or never-written) entry reports `gone`, never `handled`:
+// the two must stay distinguishable so the widget can tell the player a reply
+// was lost rather than silently dropping the request as dealt with (#176). An
+// unparseable entry is reported the same way — its contents are unrecoverable.
+export const GONE = Object.freeze({ status: 'gone', response: null, kind: null });
+
 export async function getResults(kv, ids) {
   const pairs = await Promise.all(ids.map(async (id) => {
     const raw = await kv.get(PREFIX + id);
-    let val = { status: 'handled', response: null, kind: null };
+    let val = GONE;
     if (raw) {
       try {
         const e = JSON.parse(raw);
         val = { status: e.status, response: e.response ?? null, kind: e.kind ?? null };
-      } catch { /* corrupt → treat as handled/no-response */ }
+      } catch { /* corrupt → gone */ }
     }
     return [id, val];
   }));

--- a/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
+++ b/tools/publish/templates-scaffold/functions/api/inbox-core.mjs
@@ -191,7 +191,11 @@ export async function getResults(kv, ids) {
     if (raw) {
       try {
         const e = JSON.parse(raw);
-        val = { status: e.status, response: e.response ?? null, kind: e.kind ?? null };
+        // Only a record-shaped entry counts; an array, scalar, or object with no
+        // string status is as unusable as unparseable JSON.
+        if (e && typeof e === 'object' && !Array.isArray(e) && typeof e.status === 'string') {
+          val = { status: e.status, response: e.response ?? null, kind: e.kind ?? null };
+        }
       } catch { /* corrupt → gone */ }
     }
     return [id, val];

--- a/tools/publish/test/change-request-logic.test.js
+++ b/tools/publish/test/change-request-logic.test.js
@@ -83,3 +83,16 @@ test('classifySubmitError maps HTTP status', () => {
   assert.equal(cr.classifySubmitError(400), 'bad');
   assert.equal(cr.classifySubmitError(500), 'bad');
 });
+
+test('goneIds returns ids the server no longer holds, and nothing else (#176)', () => {
+  const results = {
+    a: { status: 'gone', response: null, kind: null },
+    b: { status: 'pending', response: null, kind: null },
+    c: { status: 'handled', response: null, kind: null },
+    d: { status: 'handled', response: '✓', kind: 'applied' },
+  };
+  assert.deepEqual(cr.goneIds(results, ['a', 'b', 'c', 'd']), ['a']);
+  // gone is NOT stale: stale drops silently, gone must be surfaced to the player
+  assert.deepEqual(cr.staleIds(results, ['a', 'b', 'c', 'd']), ['c']);
+  assert.match(cr.GONE_TEXT, /expired/);
+});

--- a/tools/publish/test/cli/flush-cli-smoke.test.js
+++ b/tools/publish/test/cli/flush-cli-smoke.test.js
@@ -42,6 +42,12 @@ describe('CLI: gm-publish flush argument handling (issue #178)', () => {
     }
   });
 
+  it('--config refuses an option token as its value', async () => {
+    const r = await runIn(['flush', '--config', '--dry-run']);
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /--config needs a path/);
+  });
+
   it('an unknown flag on setup-inbox is rejected too', async () => {
     const r = await runIn(['setup-inbox', '--dry-run']);
     assert.strictEqual(r.code, 1);

--- a/tools/publish/test/cli/flush-cli-smoke.test.js
+++ b/tools/publish/test/cli/flush-cli-smoke.test.js
@@ -1,0 +1,58 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+const execFileAsync = promisify(execFile);
+const CLI = path.join(__dirname, '..', '..', 'bin', 'gm-publish.js');
+
+// Run the bin in an empty temp dir: no vault.config.json, no wrangler.toml. If an
+// argument ever falls through to execution, the run fails on the missing config
+// instead of the usage path, so the assertions below cannot pass by accident.
+function runIn(args) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-flush-smoke-'));
+  return execFileAsync(process.execPath, [CLI, ...args], { cwd })
+    .then((r) => ({ code: 0, ...r }))
+    .catch((err) => ({ code: err.code, stdout: err.stdout || '', stderr: err.stderr || '' }));
+}
+
+describe('CLI: gm-publish flush argument handling (issue #178)', () => {
+  it('flush --help prints usage and exits 0 without running the flush', async () => {
+    const r = await runIn(['flush', '--help']);
+    assert.strictEqual(r.code, 0);
+    assert.match(r.stdout, /--dry-run/);
+    assert.doesNotMatch(r.stderr, /Could not read live state|wrangler|ENOENT/);
+  });
+
+  it('flush -h behaves the same', async () => {
+    const r = await runIn(['flush', '-h']);
+    assert.strictEqual(r.code, 0);
+    assert.match(r.stdout, /flush \[--config/);
+  });
+
+  it('an unknown flag on flush is rejected with usage, not executed', async () => {
+    for (const bad of ['--nope', '--pcs', 'Six']) {
+      const r = await runIn(['flush', bad]);
+      assert.strictEqual(r.code, 1, `${bad} must exit 1`);
+      assert.match(r.stderr, new RegExp(`Unknown argument: ${bad.replace(/[-]/g, '\\-')}`));
+      assert.doesNotMatch(r.stderr, /Could not read live state/);
+    }
+  });
+
+  it('an unknown flag on setup-inbox is rejected too', async () => {
+    const r = await runIn(['setup-inbox', '--dry-run']);
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /Unknown argument: --dry-run/);
+  });
+
+  it('--help on any subcommand is safe', async () => {
+    for (const cmd of ['build', 'inbox', 'setup-inbox', 'doctor', 'init']) {
+      const r = await runIn([cmd, '--help']);
+      assert.strictEqual(r.code, 0, `${cmd} --help exits 0`);
+      assert.match(r.stdout, /Usage:/);
+    }
+  });
+});

--- a/tools/publish/test/flush-cli.test.js
+++ b/tools/publish/test/flush-cli.test.js
@@ -200,3 +200,12 @@ test('the flush wrapper passes the process error through', () => {
     () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }));
   assert.equal(res.error, 'ETIMEDOUT');
 });
+
+test('flush --dry-run reports the same changes and writes nothing (#178)', async () => {
+  const r = run({ dryRun: true });
+  const code = await r.promise;
+  assert.equal(code, 0);
+  assert.deepEqual(Object.keys(r.writes), [], 'no file written');
+  assert.ok(r.lines.some((l) => /DRY RUN/.test(l)));
+  assert.ok(r.lines.some((l) => /Jane Ashford/.test(l) && /HP 11→7/.test(l) && /would write/.test(l)));
+});

--- a/tools/publish/test/inbox-cli.test.js
+++ b/tools/publish/test/inbox-cli.test.js
@@ -109,3 +109,35 @@ test('a timed-out wrangler call reports failure instead of hanging', () => {
     () => ({ code: 1, stdout: '', stderr: '', error: 'ETIMEDOUT' }));
   assert.equal(res.code, 1);
 });
+
+test('reply exits non-zero and says so when the request no longer exists (#176)', async () => {
+  const kv = fakeKV(); const c = capture();
+  const rc = await runInbox(['reply', 'nope', 'advice', 'hello'], { adapter: kv, out: c.out });
+  assert.equal(rc, 1);
+  assert.match(c.lines.join('\n'), /NOT stored/);
+  assert.equal(await kv.get('req:nope'), null, 'nothing was written');
+});
+
+test('reply reports its own write outcome on success (#176)', async () => {
+  const kv = fakeKV(); const c = capture();
+  await inbox.enqueue(kv, { id: 'a', character: 'ana', text: 'x', timestamp: '2026-07-11T14:01:00.000Z' });
+  const rc = await runInbox(['reply', 'a', 'advice', 'try', 'this'], { adapter: kv, out: c.out });
+  assert.equal(rc, 0);
+  assert.match(c.lines.join('\n'), /a: reply stored \(advice\) → status handled/);
+  assert.equal(JSON.parse(await kv.get('req:a')).response, 'try this');
+});
+
+test('handled/flag exit non-zero for an id that does not exist (#176)', async () => {
+  const kv = fakeKV(); const c = capture();
+  await inbox.enqueue(kv, { id: 'a', character: 'ana', text: 'x', timestamp: '2026-07-11T14:01:00.000Z' });
+  assert.equal(await runInbox(['handled', 'a', 'ghost'], { adapter: kv, out: c.out }), 1);
+  assert.match(c.lines.join('\n'), /a: marked handled/);
+  assert.match(c.lines.join('\n'), /ghost: NOT marked handled/);
+  assert.equal(await runInbox(['flag', 'ghost'], { adapter: kv, out: c.out }), 1);
+});
+
+test('inbox commands fail clearly outside a site directory (no wrangler.toml) (#176)', async () => {
+  const os = require('os'); const fs = require('fs'); const path = require('path');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-inbox-nosite-'));
+  await assert.rejects(runInbox(['pull'], { cwd: dir }), /No wrangler\.toml in .*site directory/);
+});

--- a/tools/publish/test/inbox-cli.test.js
+++ b/tools/publish/test/inbox-cli.test.js
@@ -141,3 +141,9 @@ test('inbox commands fail clearly outside a site directory (no wrangler.toml) (#
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gm-inbox-nosite-'));
   await assert.rejects(runInbox(['pull'], { cwd: dir }), /No wrangler\.toml in .*site directory/);
 });
+
+test('handled/flag with no ids print usage and exit 1', async () => {
+  const kv = fakeKV(); const c = capture();
+  assert.equal(await runInbox(['handled'], { adapter: kv, out: c.out }), 1);
+  assert.match(c.lines.join('\n'), /Usage: inbox handled <id>/);
+});

--- a/tools/publish/test/inbox-core.test.js
+++ b/tools/publish/test/inbox-core.test.js
@@ -281,13 +281,33 @@ test('setResponse: missing id returns null', async () => {
   assert.equal(await inbox.setResponse(kv, 'nope', 'advice', 'x'), null);
 });
 
-test('getResults returns {status,response,kind}; missing → nulls', async () => {
+test('getResults returns {status,response,kind}; missing → gone, never handled (#176)', async () => {
   const kv = fakeKV();
   await inbox.enqueue(kv, { id: 'c', character: 'a', text: 't', timestamp: '2026-07-12T00:00:02Z' });
   await inbox.setResponse(kv, 'c', 'advice', '• do this');
   const r = await inbox.getResults(kv, ['c', 'gone']);
   assert.deepEqual(r.c, { status: 'handled', response: '• do this', kind: 'advice' });
-  assert.deepEqual(r.gone, { status: 'handled', response: null, kind: null });
+  // An expired/never-written key must be distinguishable from an answered one.
+  assert.deepEqual(r.gone, { status: 'gone', response: null, kind: null });
+});
+
+test('getResults reports a corrupt entry as gone (#176)', async () => {
+  const kv = fakeKV();
+  await kv.put('req:bad', '{not json');
+  const r = await inbox.getResults(kv, ['bad']);
+  assert.deepEqual(r.bad, { status: 'gone', response: null, kind: null });
+});
+
+test('finalized entries carry session-safe TTLs — days, not minutes (#176)', async () => {
+  assert.ok(inbox.HANDLED_TTL >= 24 * 3600, 'handled lingers at least a day');
+  assert.ok(inbox.RESPONSE_TTL >= 7 * 24 * 3600, 'a reply lingers at least a week');
+  const kv = fakeKV();
+  const puts = [];
+  const spy = { ...kv, async put(k, v, opts) { puts.push([k, opts]); return kv.put(k, v, opts); } };
+  await inbox.enqueue(spy, { id: 'r', character: 'a', text: 't', timestamp: '2026-07-12T00:00:02Z' });
+  await inbox.setResponse(spy, 'r', 'advice', 'hi');
+  const [, opts] = puts.find(([k, o]) => k === 'req:r' && o);
+  assert.equal(opts.expirationTtl, inbox.RESPONSE_TTL);
 });
 
 test('rateLimited allows up to limit then blocks', async () => {

--- a/tools/publish/test/inbox-core.test.js
+++ b/tools/publish/test/inbox-core.test.js
@@ -291,11 +291,17 @@ test('getResults returns {status,response,kind}; missing → gone, never handled
   assert.deepEqual(r.gone, { status: 'gone', response: null, kind: null });
 });
 
-test('getResults reports a corrupt entry as gone (#176)', async () => {
+test('getResults reports a corrupt or mis-shaped entry as gone (#176)', async () => {
   const kv = fakeKV();
   await kv.put('req:bad', '{not json');
-  const r = await inbox.getResults(kv, ['bad']);
-  assert.deepEqual(r.bad, { status: 'gone', response: null, kind: null });
+  await kv.put('req:arr', '[]');
+  await kv.put('req:str', '"text"');
+  await kv.put('req:obj', '{}');
+  await kv.put('req:nul', 'null');
+  const r = await inbox.getResults(kv, ['bad', 'arr', 'str', 'obj', 'nul']);
+  for (const id of ['bad', 'arr', 'str', 'obj', 'nul']) {
+    assert.deepEqual(r[id], { status: 'gone', response: null, kind: null }, id);
+  }
 });
 
 test('finalized entries carry session-safe TTLs — days, not minutes (#176)', async () => {

--- a/tools/publish/test/inbox-function.test.js
+++ b/tools/publish/test/inbox-function.test.js
@@ -69,7 +69,7 @@ test('GET returns per-id {status,response,kind}', async () => {
   assert.equal(res.status, 200);
   assert.deepEqual(await res.json(), {
     k: { status: 'handled', response: '• hi', kind: 'advice' },
-    gone: { status: 'handled', response: null, kind: null },
+    gone: { status: 'gone', response: null, kind: null },
   });
 });
 

--- a/tools/publish/test/unit/gurps/parse.test.js
+++ b/tools/publish/test/unit/gurps/parse.test.js
@@ -581,6 +581,16 @@ describe('parseGurps — silent section drops (issue #177)', () => {
     assert.match(c.warnings[0], /"## Weapons"/);
   });
 
+  it('warns per section: an empty Melee Weapons is reported even when Ranged Weapons parsed', () => {
+    const c = parseGurps({}, [
+      { title: 'Melee Weapons', id: 'm', html: '<p>none carried</p>' },
+      { title: 'Ranged Weapons', id: 'r', html: '<table><tr><th>Weapon</th><th>Skill</th><th>Acc</th></tr><tr><td>Bow</td><td>13</td><td>2</td></tr></table>' },
+    ]);
+    assert.deepStrictEqual(c.ranged.map(w => w.weapon), ['Bow']);
+    assert.strictEqual(c.warnings.length, 1);
+    assert.match(c.warnings[0], /"## Melee Weapons" is present but no melee rows/);
+  });
+
   it('stays silent for a sheet with no weapon sections (a weaponless PC is not a defect)', () => {
     const c = parseGurps({}, [statSheet]);
     assert.deepStrictEqual(c.warnings, []);

--- a/tools/publish/test/unit/gurps/parse.test.js
+++ b/tools/publish/test/unit/gurps/parse.test.js
@@ -518,3 +518,95 @@ describe('parseGurps — helper tables under a ### subheading (issue #82)', () =
     assert.deepStrictEqual(c.spells.map(s => s.name), ['Lend Energy']);
   });
 });
+
+describe('parseGurps — silent section drops (issue #177)', () => {
+  const combined = {
+    title: 'Melee & Ranged', id: 'melee-ranged',
+    html: '<table><tr><th>Weapon</th><th>Skill</th><th>Parry</th><th>Damage</th><th>Reach</th></tr>' +
+          '<tr><td>Knife</td><td>12</td><td>9</td><td>1d-2 cut</td><td>C,1</td></tr></table>' +
+          '<h3>Ranged</h3>' +
+          '<table><tr><th>Weapon</th><th>Skill</th><th>Damage</th><th>Acc</th><th>Range</th><th>RoF</th><th>Shots</th></tr>' +
+          '<tr><td>Pistol</td><td>14</td><td>2d pi</td><td>2</td><td>150/1850</td><td>3</td><td>15+1</td></tr></table>',
+  };
+
+  it('reads both tables from a combined "Melee & Ranged" section', () => {
+    const c = parseGurps({}, [combined]);
+    assert.deepStrictEqual(c.melee.map(w => w.weapon), ['Knife']);
+    assert.deepStrictEqual(c.ranged.map(w => w.weapon), ['Pistol']);
+    assert.strictEqual(c.ranged[0].range, '150/1850');
+    assert.deepStrictEqual(c.warnings, []);
+  });
+
+  it('matches headings loosely: "and", "&amp;", punctuation, case', () => {
+    for (const title of ['Melee and Ranged', 'Melee &amp; Ranged', 'MELEE & RANGED WEAPONS', 'Weapons']) {
+      const c = parseGurps({}, [{ ...combined, title }]);
+      assert.strictEqual(c.melee.length + c.ranged.length, 2, `title "${title}" should parse both tables`);
+    }
+  });
+
+  it('keeps dedicated Melee Weapons / Ranged Weapons sections working', () => {
+    const c = parseGurps({}, [
+      { title: 'Melee Weapons', id: 'm', html: '<table><tr><th>Weapon</th><th>Skill</th><th>Parry</th></tr><tr><td>Club</td><td>11</td><td>8</td></tr></table>' },
+      { title: 'Ranged Weapons', id: 'r', html: '<table><tr><th>Weapon</th><th>Skill</th><th>Acc</th></tr><tr><td>Bow</td><td>13</td><td>2</td></tr></table>' },
+    ]);
+    assert.deepStrictEqual(c.melee.map(w => w.weapon), ['Club']);
+    assert.deepStrictEqual(c.ranged.map(w => w.weapon), ['Bow']);
+  });
+
+  it('a dedicated section with a bare Weapon/Skill/Damage table still takes the section kind', () => {
+    const c = parseGurps({}, [
+      { title: 'Ranged Weapons', id: 'r', html: '<table><tr><th>Weapon</th><th>Skill</th><th>Damage</th></tr><tr><td>Sling</td><td>10</td><td>1d</td></tr></table>' },
+    ]);
+    assert.deepStrictEqual(c.ranged.map(w => w.weapon), ['Sling']);
+    assert.deepStrictEqual(c.melee, []);
+  });
+
+  it('routes a single mixed table row by row (melee rows have no ranged cells)', () => {
+    const c = parseGurps({}, [{
+      title: 'Melee & Ranged', id: 'mr',
+      html: '<table><tr><th>Weapon</th><th>Skill</th><th>Parry</th><th>Damage</th><th>Reach</th><th>Acc</th><th>Range</th><th>RoF</th><th>Shots</th></tr>' +
+            '<tr><td>Knife</td><td>12</td><td>9</td><td>1d-2 cut</td><td>C,1</td><td>—</td><td></td><td></td><td></td></tr>' +
+            '<tr><td>Pistol</td><td>14</td><td>—</td><td>2d pi</td><td></td><td>2</td><td>150/1850</td><td>3</td><td>15+1</td></tr></table>',
+    }]);
+    assert.deepStrictEqual(c.melee.map(w => w.weapon), ['Knife']);
+    assert.deepStrictEqual(c.ranged.map(w => w.weapon), ['Pistol']);
+    assert.strictEqual(c.ranged[0].acc, '2');
+    assert.strictEqual(c.melee[0].reach, 'C,1');
+  });
+
+  it('warns when a weapons-titled section yields no rows at all', () => {
+    const c = parseGurps({}, [{ title: 'Weapons', id: 'w', html: '<p>Carries nothing but a grudge.</p>' }]);
+    assert.strictEqual(c.warnings.length, 1);
+    assert.match(c.warnings[0], /combat tab is empty/);
+    assert.match(c.warnings[0], /"## Weapons"/);
+  });
+
+  it('stays silent for a sheet with no weapon sections (a weaponless PC is not a defect)', () => {
+    const c = parseGurps({}, [statSheet]);
+    assert.deepStrictEqual(c.warnings, []);
+  });
+
+  it('warns when ### sub-tables under Techniques are excluded, naming the subheading', () => {
+    const c = parseGurps({}, [{
+      title: 'Techniques', id: 't',
+      html: '<table><tr><th>Name</th><th>Default</th><th>Points</th><th>Level</th></tr>' +
+            '<tr><td>Choke Hold</td><td>Judo-2</td><td>[3]</td><td>14</td></tr></table>' +
+            '<h3>Freefighting — techniques at a glance</h3>' +
+            '<table><tr><th>Technique</th><th>Use</th></tr><tr><td>Arm Lock</td><td>lock</td></tr></table>',
+    }]);
+    assert.deepStrictEqual(c.techniques.map(t => t.name), ['Choke Hold']);
+    assert.strictEqual(c.warnings.length, 1);
+    assert.match(c.warnings[0], /"## Techniques": 1 table\(s\) under ### subheading/);
+    assert.match(c.warnings[0], /Freefighting — techniques at a glance/);
+  });
+
+  it('warns when a Skills section is present but its table produced no rows', () => {
+    const c = parseGurps({}, [{ title: 'Skills', id: 's', html: '<table><tr><th>Name</th><th>Level</th></tr></table>' }]);
+    assert.ok(c.warnings.some(w => /"## Skills" is present but yielded no rows/.test(w)));
+  });
+
+  it('renderGURPSSheet surfaces the warnings for build.js', () => {
+    const out = renderGURPSSheet({}, [{ title: 'Weapons', id: 'w', html: '<p>none</p>' }]);
+    assert.ok(Array.isArray(out.warnings) && out.warnings.length === 1);
+  });
+});


### PR DESCRIPTION
Closes #176, closes #177, closes #178, closes #179, closes #180.

## #176 — change-request replies destroyed after 10 minutes
- `HANDLED_TTL` 300s → 24h, `RESPONSE_TTL` 600s → 7d. A reply must outlive the session it was written in.
- `getResults` reports a missing or unreadable entry as `status: gone`, never `handled`; the widget surfaces it to the player as "expired — please send it again" instead of silently dropping the request.
- `inbox reply` / `handled` / `flag` print the outcome of their own write and exit 1 when nothing was written. Running outside the site directory fails naming the missing `wrangler.toml`.

## #177 — GURPS sheet sections silently dropped
- Section headings match loosely (case, punctuation, `&`/`and`), so `## Melee & Ranged` / `## Weapons` now parse; each table is routed to melee or ranged by its header, and a single mixed table is routed row by row.
- Build warnings per page when a weapons-titled section yields no rows, when Skills/Techniques/Spells is present but empty, and when `###` sub-tables were excluded (naming the subheading).

## #178 — `gm-publish flush --help` performed the flush
- `--help`/`-h` prints usage and exits 0 on every subcommand.
- `flush` and `setup-*` reject unknown arguments with usage and exit 1.
- `flush --dry-run` / `-n` prints the same per-PC change lines without writing.

## #179 — mobrpg suggest 400s the batch; `--write-back` before the POST result
- Preflight checks the live world for net-new entities that already exist upstream without a node; they are held, edges to them resolve to the live id, and the output points at `mobrpg adopt`. A bare HTTP 400 carries the same hint.
- With `--execute --write-back`, pending nodes are written per batch after the POST succeeds and never for externalRefs the server refused.

## #180 — `stamp_entities.py` forces `asOfSession` to an integer
- `--session` is written verbatim (bare number stays bare, labels quoted, a quoted integer keeps its quotes). A file whose existing shape differs is refused unless `--force-shape`. session-wrapup Step 3c and `vault-access.md` updated.

## Verification
- `tools/publish`: 1520/1520 · `tools/mobrpg`: 500 pass (1 pre-existing local-credentials failure) · `tests/test_vault_utilities.py` all ok · `validate_schema.py` · markdownlint · skill-creator validation on session-wrapup, publish-site, mobrpg skill.
- Version 1.9.3 (publish 1.11.26).