### PR TITLE
Fix open issues #182–#184, #186–#188: GURPS identity band, double-escaping, banner clicks, push embeds, routing learn-back, write guard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,7 @@ tests/benchmark-results/
 # ...but never the npm-generated cruft: .bin holds machine-local (absolute-target)
 # symlinks that would ship as dangling links, and .package-lock.json is regenerable.
 tools/publish/node_modules/.bin/
+tools/publish/node_modules/.cache/
+tools/publish/node_modules/.vite/
 tools/publish/node_modules/.package-lock.json
 tools/publish/node_modules/**/.package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sheet, PCs and NPCs. Every recognised identity sub-table merges into the band
   (not just the first found), a plain `appearance:` string joins it instead of
   silently shadowing an `identity:` map, table columns beyond the second are
-  kept, and a header-less senses table no longer loses its first row.
+  kept, a header-less senses table no longer loses its first row, a
+  `Sense | Check` header is not stored as a sense, and numeric `0` /
+  `false` identity values render instead of being dropped as blank.
 - **GURPS table cells are no longer double-escaped (#188).** Cell text was
   pulled out of already-rendered HTML with its entities intact, then correctly
   escaped again at render — so a height of `6'2"` shipped as `6’2&quot;`, and
@@ -32,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   escaping happens once, at render; every interpolation in the GURPS blocks was
   audited to confirm that single-escape invariant (the local review round also
   caught — and reverted — a double-escape the audit itself had introduced on
-  the load-out heading).
+  the load-out heading). The decoder rejects lone-surrogate code points and
+  resolves only its own named entities, so `&constructor;` and friends stay
+  literal.
 - **Banner clicks reach the banner image (#183).** `.hero-banner-overlay`
   stacked above `.hero-banner-img` with no `pointer-events` rule, swallowing
   every click over the title area — the lightbox never opened exactly where a
@@ -65,7 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   site's location index instead of only in the graph. Every empty YAML spelling
   is filled, the Optional key is inserted when absent, an authored value is
   never touched — and an authored value that disagrees with the new edge is
-  surfaced in the report instead of silently shipping split.
+  surfaced in the report instead of silently shipping split. Only the opening
+  frontmatter block is read or written, so a body line starting with
+  `parent_location:` is never mistaken for the scalar.
 
 ### Changed
 
@@ -75,7 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `## GM Notes` included, while the docs grouped it with the reassuring
   "only ever write local vault files" set. Existing notes are now skipped and
   counted, `--overwrite` restores the old behaviour explicitly, entities of
-  kinds `write` cannot map are counted instead of dropped without a trace, and
+  kinds `write` cannot map are counted instead of dropped without a trace,
+  filename collisions (distinct names slugging to one file) are reported
+  instead of silently losing a record, and
   the README and `llms.txt` spell out the danger, note that `images` is
   pull-only (#185), and document exactly which fields `link-orphans` populates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now parses into its own identity model and renders as a full-width band above
   the two-column flow, recognised keys first, sheet-specific extras (Race,
   Nationality, …) following in source order; `parseSenses` is narrowed to
-  `Senses` / `Senses & Checks`. Applies to every GURPS sheet, PCs and NPCs.
+  `Senses` / `Senses & Checks` / `Senses and Checks`. Applies to every GURPS
+  sheet, PCs and NPCs. Every recognised identity sub-table merges into the band
+  (not just the first found), a plain `appearance:` string joins it instead of
+  silently shadowing an `identity:` map, table columns beyond the second are
+  kept, and a header-less senses table no longer loses its first row.
 - **GURPS table cells are no longer double-escaped (#188).** Cell text was
   pulled out of already-rendered HTML with its entities intact, then correctly
   escaped again at render — so a height of `6'2"` shipped as `6’2&quot;`, and
   any cell with `" & ' < >` (weapon notes, equipment names, skill specialties)
   showed literal entity text. Entities are decoded at the parse boundary so
-  escaping happens once, at render; the same audit found and escaped the one
-  raw interpolation (the equipment load-out heading).
+  escaping happens once, at render; every interpolation in the GURPS blocks was
+  audited to confirm that single-escape invariant (the local review round also
+  caught — and reverted — a double-escape the audit itself had introduced on
+  the load-out heading).
 - **Banner clicks reach the banner image (#183).** `.hero-banner-overlay`
   stacked above `.hero-banner-img` with no `pointer-events` rule, swallowing
   every click over the title area — the lightbox never opened exactly where a
@@ -50,11 +56,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   location kind before reporting "no live match": an exact-named element of the
   other kind is reported as its own `kind mismatch` outcome naming the
   `locationRouting` entry to fix, instead of being buried among vault-only
-  notes.
+  notes. A failed live listing degrades learning to the agreement gate with a
+  warning instead of silently discarding every ratified binding, `map sync`
+  notes any canon binding it replaces, and `adopt` treats a failed sibling
+  listing as the error it is rather than reporting a false "no live match".
 - **`link-orphans` fills the empty `parent_location:` scalar when it writes a
   `part_of` edge (#186)**, so an import groups correctly on the published
-  site's location index instead of only in the graph. An authored value is
-  never touched.
+  site's location index instead of only in the graph. Every empty YAML spelling
+  is filled, the Optional key is inserted when absent, an authored value is
+  never touched — and an authored value that disagrees with the new edge is
+  surfaced in the report instead of silently shipping split.
 
 ### Changed
 
@@ -63,9 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matched an entity in the extract was replaced wholesale, hand-authored prose
   and `## GM Notes` included, while the docs grouped it with the reassuring
   "only ever write local vault files" set. Existing notes are now skipped and
-  counted, `--overwrite` restores the old behaviour explicitly, and the README
-  and `llms.txt` spell out the danger, note that `images` is pull-only (#185),
-  and document exactly which fields `link-orphans` populates.
+  counted, `--overwrite` restores the old behaviour explicitly, entities of
+  kinds `write` cannot map are counted instead of dropped without a trace, and
+  the README and `llms.txt` spell out the danger, note that `images` is
+  pull-only (#185), and document exactly which fields `link-orphans` populates.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.4] — 2026-08-30
+
+### Fixed
+
+- **GURPS physical description leads the sheet instead of hiding mid-column
+  (#187).** `parseSenses` read the `### Appearance & Social` sub-table in
+  preference to `### Senses`, so height, weight, build, hair, eyes, skin and
+  handedness shipped under the heading "Senses & Checks", buried in one of the
+  two masonry columns — and any real Senses table was shadowed. The sub-table
+  now parses into its own identity model and renders as a full-width band above
+  the two-column flow, recognised keys first, sheet-specific extras (Race,
+  Nationality, …) following in source order; `parseSenses` is narrowed to
+  `Senses` / `Senses & Checks`. Applies to every GURPS sheet, PCs and NPCs.
+- **GURPS table cells are no longer double-escaped (#188).** Cell text was
+  pulled out of already-rendered HTML with its entities intact, then correctly
+  escaped again at render — so a height of `6'2"` shipped as `6’2&quot;`, and
+  any cell with `" & ' < >` (weapon notes, equipment names, skill specialties)
+  showed literal entity text. Entities are decoded at the parse boundary so
+  escaping happens once, at render; the same audit found and escaped the one
+  raw interpolation (the equipment load-out heading).
+- **Banner clicks reach the banner image (#183).** `.hero-banner-overlay`
+  stacked above `.hero-banner-img` with no `pointer-events` rule, swallowing
+  every click over the title area — the lightbox never opened exactly where a
+  reader clicks, and on a short `cover`-cropped banner the lightbox is the only
+  way to see a wide map at all. The overlay is now out of hit-testing, with
+  interactive children (links, buttons, inputs) restored.
+- **`mobrpg sync` no longer pushes mangled image embeds (#184).** The push
+  rewrite had no notion of the `!` embed prefix, so `![[map.png]]` became the
+  literal `!map.png` and `![[map.svg|697]]` became `!697` (an embed's pipe is a
+  display width, not an alias) — junk text filed into the world owner's review
+  queue under the collaborator's name. Embeds are dropped at the push boundary
+  (they reference vault attachments with no upstream counterpart), and a new
+  `sync --show-body` flag prints each push's exact outgoing markdown so the dry
+  run can be inspected without reconstructing the payload by hand.
+- **A guessed location routing is no longer learned back as canon (#182).**
+  `map init`/`map sync` learned location bindings from `determined` blocks that
+  the tool itself had written from its own routing guess, making a wrong route
+  self-confirming forever. Learning now requires the block to agree with the
+  node's `element_kind`, and — when live listings are available — with the
+  linked element's actual upstream kind. `adopt` also checks the sibling
+  location kind before reporting "no live match": an exact-named element of the
+  other kind is reported as its own `kind mismatch` outcome naming the
+  `locationRouting` entry to fix, instead of being buried among vault-only
+  notes.
+- **`link-orphans` fills the empty `parent_location:` scalar when it writes a
+  `part_of` edge (#186)**, so an import groups correctly on the published
+  site's location index instead of only in the graph. An authored value is
+  never touched.
+
+### Changed
+
+- **`mobrpg write` refuses to overwrite existing vault notes (#186).** It had
+  no existence check, no `--execute` gate, and no dry-run — any note whose path
+  matched an entity in the extract was replaced wholesale, hand-authored prose
+  and `## GM Notes` included, while the docs grouped it with the reassuring
+  "only ever write local vault files" set. Existing notes are now skipped and
+  counted, `--overwrite` restores the old behaviour explicitly, and the README
+  and `llms.txt` spell out the danger, note that `images` is pull-only (#185),
+  and document exactly which fields `link-orphans` populates.
+
+---
+
 ## [1.9.3] — 2026-08-28
 
 ### Fixed

--- a/tools/mobrpg/README.md
+++ b/tools/mobrpg/README.md
@@ -82,8 +82,13 @@ Exit codes: `0` ok, `1` API error, `2` bad args / no auth configured.
 
 ## Read-only vs mutating
 
-Read-only verbs are safe to run anywhere: `whoami`, `worlds`, `pull`,
-`whats-new`, `suggestions`, `catalog`, `map`.
+Truly read-only verbs — they write nothing at all: `whoami`, `worlds`,
+`whats-new`, `catalog`, `suggestions` (without `--out`), and `map check`.
+
+`pull` (writes the extract named by `--out`), `suggestions --out` (writes a
+report), and `map init` / `map sync` (write `_meta/mobrpg-map.json`) read from
+mobRPG but create or update local files as soon as they run, with no
+`--execute` gate.
 
 Mutating verbs are **dry-run by default** — add `--execute` to actually write.
 `suggest`, `sync`, and `submit-batch` only ever file *suggestions* — a

--- a/tools/mobrpg/README.md
+++ b/tools/mobrpg/README.md
@@ -90,10 +90,18 @@ Mutating verbs are **dry-run by default** — add `--execute` to actually write.
 collaborator can run them with just Read access, and the world owner accepts or
 dismisses each one, so none of them overwrites a live element directly. The
 owner-side verbs `update` and `review` (and listing others' suggestions) need
-write access on the world. The rest (`write`, `images`, `link-orphans`,
-`pull-canon`, `adopt`, `relink`) only ever write local vault files;
-`pull-canon`, `adopt`, and `images` read from mobRPG but write locally, and
-`relink` makes no API calls at all.
+write access on the world. The rest (`images`, `link-orphans`, `pull-canon`,
+`adopt`, `relink`) only ever write local vault files; `pull-canon`, `adopt`,
+and `images` read from mobRPG but write locally, and `relink` makes no API
+calls at all.
+
+`write` is the exception, twice over: it runs as soon as it is invoked (no
+`--execute`, no dry-run), and with `--overwrite` it replaces existing notes
+**wholesale** — hand-authored prose, `## GM Notes`, play bookkeeping, all of
+it. Without `--overwrite` it skips notes that already exist and reports the
+count, so the default is safe against a populated vault; to bring new entities
+into one, filter the extract to just the new ids, or `write` into a scratch
+directory and diff before copying in.
 
 Entity and event IDs live in each note's `mobrpg:` frontmatter node — the single
 source of truth. There is no sidecar crosswalk. A vault whose entities already
@@ -115,10 +123,16 @@ Run `mobrpg <command> --help` for a command's own options.
 - `pull <world>` — import a world into a structured JSON extract
   (default `extract.json`); the entry point of the import pipeline.
 - `write <extract.json> --out <out_dir>` — materialize an extract into vault
-  markdown, one file per entity.
+  markdown, one file per entity. **Skips notes that already exist** (and says
+  so); `--overwrite` replaces them wholesale, hand-authored prose and
+  `## GM Notes` included — intended for a fresh or scratch directory.
 - `link-orphans <extract.json> --vault <path> --out <outdir>` — auto-link obvious
-  orphan relationships after an import.
+  orphan relationships after an import. Writes the derived `part_of`/`created`
+  edge into `relationships:` and fills an empty `parent_location:` scalar to
+  match; no other frontmatter fields are populated.
 - `images <world> --vault <path>` — pull entity images into the vault.
+  **Pull-only**: there is no upload path, so a vault-side image reaches mobRPG
+  only through the web UI.
 
 ### Reconcile (keep a vault current)
 

--- a/tools/mobrpg/llms.txt
+++ b/tools/mobrpg/llms.txt
@@ -39,7 +39,10 @@ map init and map sync (write _meta/mobrpg-map.json), images (--execute writes
 into _attachments/ and can set portrait:), write, link-orphans, pull-canon,
 adopt, relink. These read from mobRPG but only ever write to disk; relink makes
 no API calls at all. `map` and `images` as a whole are NOT read-only — only
-`map check` is.
+`map check` is. `images` is PULL-ONLY: nothing uploads a vault image to
+mobRPG; attachments go up through the web UI or not at all. `write` skips
+notes that already exist unless given --overwrite, which replaces them
+wholesale — hand-authored prose and GM Notes included.
 
 Writes to mobRPG (need write access; dry-run by default, add --execute):
 suggest, submit-batch, update, review, sync. sync only submits a suggestion on
@@ -150,10 +153,13 @@ vault whose entities already exist upstream but carry no node is linked with
                                   accept is irreversible; dismiss keeps the
                                   externalRef claimed (see resubmit note below).
     mobrpg write <extract.json> --out <vault-dir> [--campaign NAME]
-                 [--source-doc TEXT] [--name-style plain|space]
+                 [--source-doc TEXT] [--name-style plain|space] [--overwrite]
                                   Materialize a mobRPG extract (from `pull`)
                                   into vault markdown — one file per entity,
                                   mapped to the correct folder/template/type.
+                                  Existing notes are SKIPPED unless --overwrite
+                                  is given; with it they are replaced wholesale,
+                                  hand-authored prose and GM Notes included.
     mobrpg link-orphans <extract.json> --vault <path> --out <dir>
                         [--systems NAMES] [--execute]
                                   Auto-link obvious orphan entities after an
@@ -164,9 +170,12 @@ vault whose entities already exist upstream but carry no node is linked with
                                   Only links to targets that already exist in
                                   the vault. Writes a report; vault edits
                                   (relationships: frontmatter) gated by
-                                  --execute (dry-run default).
+                                  --execute (dry-run default). Writes the edge
+                                  and fills an empty parent_location: scalar to
+                                  match; no other frontmatter fields are
+                                  populated.
     mobrpg sync <world> --vault <path> [--only S] [--skew SECONDS]
-                [--batch-label L] [--execute]
+                [--batch-label L] [--show-body] [--execute]
                                   Timestamp last-writer-wins sync of every
                                   linked note's description prose against
                                   mtime / node last_synced / server
@@ -187,7 +196,9 @@ vault whose entities already exist upstream but carry no node is linked with
                                   externalRef) and marks the node
                                   review_state: pending until `review`
                                   adjudicates it. Notes already pending are
-                                  skipped. Dry-run by default.
+                                  skipped. Dry-run by default; --show-body
+                                  prints each push's exact outgoing description
+                                  markdown (what the suggestion will carry).
     mobrpg suggest <world> --vault <path> [--chapter CH] [--kind K] [--only S]
                   [--limit N] [--out DIR] [--write-back] [--include-pcs]
                   [--execute]
@@ -209,6 +220,8 @@ vault whose entities already exist upstream but carry no node is linked with
     mobrpg images <world> --vault <path> [--execute]
                                   Pull entity images into the vault (id->file map
                                   comes from the vault's own mobrpg: nodes).
+                                  PULL-ONLY: there is no image upload path;
+                                  push images via the mobRPG web UI.
 
 Dry-run-by-default applies to the verbs that carry an --execute flag — the
 mobRPG-mutating ones (suggest, submit-batch, update, review, sync) plus the
@@ -217,7 +230,9 @@ gated local writers (images, link-orphans, pull-canon, adopt, relink). Add
 
 It does NOT apply to `pull` and `write`, which have no --execute flag and write
 their output as soon as they are run: `pull` creates the file named by --out,
-and `write` materializes vault notes. Neither is a preview. Run
+and `write` materializes vault notes. Neither is a preview. `write` will not
+replace a note that already exists unless given --overwrite; with it, the
+replacement is wholesale (hand-authored prose and GM Notes included). Run
 `mobrpg <command> --help` for a command's own options.
 
 ## Typical workflows

--- a/tools/mobrpg/llms.txt
+++ b/tools/mobrpg/llms.txt
@@ -126,7 +126,11 @@ vault whose entities already exist upstream but carry no node is linked with
                                   same kind by normalized name (aliases too) and
                                   write an `accepted` node with the real
                                   element_id. Ambiguous (several live matches) or
-                                  unmatched notes are reported, never guessed.
+                                  unmatched notes are reported, never guessed. A
+                                  location whose exact name exists upstream under
+                                  the SIBLING location kind reports as its own
+                                  "kind mismatch" outcome (fix locationRouting in
+                                  _meta/mobrpg-map.json, then re-run).
                                   The node-establishment path for imported / pushed
                                   vaults and the dup-safe alternative to any
                                   crosswalk. GET-only against mobRPG; dry-run

--- a/tools/mobrpg/mobrpg/commands/adopt.py
+++ b/tools/mobrpg/mobrpg/commands/adopt.py
@@ -104,7 +104,7 @@ def run(argv: list[str]) -> int:
 
     # Only entities that DON'T already carry a node with a real element_id are
     # candidates; a linked note is left exactly as-is.
-    candidates, linked = [], 0
+    candidates, linked, unroutable = [], 0, 0
     for ent in entities:
         nd = _existing_node(ent["path"])
         if nd and nd.get("element_id"):
@@ -113,7 +113,8 @@ def run(argv: list[str]) -> int:
         try:
             ent["_ek"] = suggest.element_spec(ent, mp)[0]
         except (KeyError, TypeError):
-            continue          # kind the map can't route to an element kind (e.g. an unmapped PC)
+            unroutable += 1   # kind the map can't route to an element kind (e.g. an unmapped PC)
+            continue
         candidates.append(ent)
 
     if not candidates:
@@ -132,7 +133,7 @@ def run(argv: list[str]) -> int:
     for ek in needed_kinds:
         try:
             live_idx[ek] = index_live(live_by_kind(args.world, token, ek))
-        except client.ApiError as e:
+        except (client.ApiError, ValueError) as e:
             print(f"ERROR listing live {ek}: {e}", file=sys.stderr)
             return 1
 
@@ -164,10 +165,13 @@ def run(argv: list[str]) -> int:
                     try:
                         live_idx[sib] = index_live(
                             live_by_kind(args.world, token, sib))
-                    except client.ApiError as e:
-                        print(f"WARNING: could not list live {sib} for the "
-                              f"kind-mismatch check: {e}", file=sys.stderr)
-                        live_idx[sib] = {}
+                    except (client.ApiError, ValueError) as e:
+                        # Same call, same contract as the primary listings
+                        # (fatal at run start): degrading here would let the
+                        # summary claim "no live match" for an element the
+                        # tool never actually looked for.
+                        print(f"ERROR listing live {sib}: {e}", file=sys.stderr)
+                        return 1
                 sib_matches = _match(ent, live_idx.get(sib, {}))
             if sib_matches:
                 kind_mismatch.append((ent, sib, sib_matches))
@@ -179,6 +183,9 @@ def run(argv: list[str]) -> int:
     print(f"{verb} {len(stamped)} node(s); {len(ambiguous)} ambiguous, "
           f"{mism}{len(unmatched)} unmatched, {linked} already linked"
           + ("" if args.execute else "  [dry-run — no files changed]"))
+    if unroutable:
+        print(f"  ({unroutable} entit(y/ies) had no element-kind mapping and "
+              f"were not considered)")
     for name, live_name, eid in stamped:
         note = "" if suggest._key(name) == suggest._key(live_name) else f" (live: {live_name!r})"
         print(f"  ✓ {name} → {eid}{note}")

--- a/tools/mobrpg/mobrpg/commands/adopt.py
+++ b/tools/mobrpg/mobrpg/commands/adopt.py
@@ -136,7 +136,7 @@ def run(argv: list[str]) -> int:
             print(f"ERROR listing live {ek}: {e}", file=sys.stderr)
             return 1
 
-    stamped, ambiguous, unmatched = [], [], []
+    stamped, ambiguous, unmatched, kind_mismatch = [], [], [], []
     for ent in candidates:
         matches = _match(ent, live_idx.get(ent["_ek"], {}))
         if len(matches) == 1:
@@ -150,17 +150,46 @@ def run(argv: list[str]) -> int:
         elif len(matches) > 1:
             ambiguous.append((ent["name"], [m["name"] for m in matches]))
         else:
-            unmatched.append(ent["name"])
+            # (#182) a location the map routes to one kind can exist upstream
+            # under the SIBLING location kind when locationRouting guessed
+            # wrong. An exact-named element there is a map bug to surface as
+            # its own outcome — not a vault-only note to bury in "no live
+            # match". Reported, never stamped: names can legitimately collide
+            # across kinds, and the durable fix is correcting the route.
+            sib = {"political": "landfeature",
+                   "landfeature": "political"}.get(ent["_ek"])
+            sib_matches = []
+            if sib:
+                if sib not in live_idx:
+                    try:
+                        live_idx[sib] = index_live(
+                            live_by_kind(args.world, token, sib))
+                    except client.ApiError as e:
+                        print(f"WARNING: could not list live {sib} for the "
+                              f"kind-mismatch check: {e}", file=sys.stderr)
+                        live_idx[sib] = {}
+                sib_matches = _match(ent, live_idx.get(sib, {}))
+            if sib_matches:
+                kind_mismatch.append((ent, sib, sib_matches))
+            else:
+                unmatched.append(ent["name"])
 
     verb = "stamped" if args.execute else "would stamp"
+    mism = f"{len(kind_mismatch)} kind mismatch, " if kind_mismatch else ""
     print(f"{verb} {len(stamped)} node(s); {len(ambiguous)} ambiguous, "
-          f"{len(unmatched)} unmatched, {linked} already linked"
+          f"{mism}{len(unmatched)} unmatched, {linked} already linked"
           + ("" if args.execute else "  [dry-run — no files changed]"))
     for name, live_name, eid in stamped:
         note = "" if suggest._key(name) == suggest._key(live_name) else f" (live: {live_name!r})"
         print(f"  ✓ {name} → {eid}{note}")
     for name, names in ambiguous:
         print(f"  ⚠ ambiguous, skipped: {name} — {len(names)} live matches: {', '.join(names)}")
+    for ent, sib, ms in kind_mismatch:
+        ids = ", ".join(m["id"] for m in ms)
+        print(f"  ⚠ kind mismatch, skipped: {ent['name']} — exists upstream as "
+              f"{sib} ({ids}), but locationRouting sends location_type "
+              f"{(ent.get('location_type') or '')!r} to {ent['_ek']}. Fix the "
+              f"route in _meta/mobrpg-map.json and re-run adopt.")
     for name in unmatched:
         print(f"  · no live match: {name}")
     return 0

--- a/tools/mobrpg/mobrpg/commands/link_orphans.py
+++ b/tools/mobrpg/mobrpg/commands/link_orphans.py
@@ -146,20 +146,28 @@ def fill_parent_location(text: str, target: str) -> tuple[str, str]:
     spelling: "", '\'\'', bare, null, ~), 'inserted' (the Optional key was
     absent and has been added after location_type:/type:), 'agrees' (already
     the target), or 'disagrees' (an authored value names something else — left
-    untouched, but surfaced in the report rather than silently shipped)."""
+    untouched, but surfaced in the report rather than silently shipped).
+
+    Only the opening YAML frontmatter block is read or written: a body line
+    that happens to start with `parent_location:` (docs, examples) is data,
+    not the scalar."""
+    fm_m = re.match(r"^---\r?\n.*?\r?\n---(?:\r?\n|$)", text, flags=re.S)
+    if fm_m is None:
+        return text, "disagrees"          # no frontmatter — nowhere safe to write
+    fm, body = text[:fm_m.end()], text[fm_m.end():]
     link = f'parent_location: "[[{target}]]"'
-    m = re.search(r"^parent_location:(.*)$", text, flags=re.M)
+    m = re.search(r"^parent_location:(.*)$", fm, flags=re.M)
     if m is None:
         for key in ("location_type", "type"):
-            new_text, n = re.subn(rf"^({key}:[^\n]*\n)",
-                                  lambda mm: mm.group(1) + link + "\n",
-                                  text, count=1, flags=re.M)
+            new_fm, n = re.subn(rf"^({key}:[^\n]*\n)",
+                                lambda mm: mm.group(1) + link + "\n",
+                                fm, count=1, flags=re.M)
             if n:
-                return new_text, "inserted"
+                return new_fm + body, "inserted"
         return text, "disagrees"          # no slot to write — surface it
     val = m.group(1).strip()
     if val in ("", '""', "''", "null", "~"):
-        return text.replace(m.group(0), link, 1), "filled"
+        return fm.replace(m.group(0), link, 1) + body, "filled"
     if val.strip('"\'') == f"[[{target}]]":
         return text, "agrees"
     return text, "disagrees"

--- a/tools/mobrpg/mobrpg/commands/link_orphans.py
+++ b/tools/mobrpg/mobrpg/commands/link_orphans.py
@@ -136,15 +136,33 @@ def add_relationship(text: str, target: str, rtype: str, desc: str) -> str | Non
     return new_text if n else None
 
 
-def fill_parent_location(text: str, target: str) -> str:
-    """Fill an EMPTY `parent_location:` scalar to agree with a freshly written
-    `part_of` edge. Both are documented vault conventions and the publish
-    renderer groups its location index on the scalar, so writing only the edge
-    left an import looking right in the graph and wrong on the site (#186). An
-    authored (non-empty) value is never touched."""
-    return re.sub(r'^parent_location:\s*""\s*$',
-                  lambda _m: f'parent_location: "[[{target}]]"',
-                  text, count=1, flags=re.M)
+def fill_parent_location(text: str, target: str) -> tuple[str, str]:
+    """Make the `parent_location:` scalar agree with a freshly written `part_of`
+    edge. Both are documented vault conventions and the publish renderer groups
+    its location index on the scalar, so writing only the edge left an import
+    looking right in the graph and wrong on the site (#186).
+
+    Returns (new_text, status): 'filled' (empty scalar set — any empty YAML
+    spelling: "", '\'\'', bare, null, ~), 'inserted' (the Optional key was
+    absent and has been added after location_type:/type:), 'agrees' (already
+    the target), or 'disagrees' (an authored value names something else — left
+    untouched, but surfaced in the report rather than silently shipped)."""
+    link = f'parent_location: "[[{target}]]"'
+    m = re.search(r"^parent_location:(.*)$", text, flags=re.M)
+    if m is None:
+        for key in ("location_type", "type"):
+            new_text, n = re.subn(rf"^({key}:[^\n]*\n)",
+                                  lambda mm: mm.group(1) + link + "\n",
+                                  text, count=1, flags=re.M)
+            if n:
+                return new_text, "inserted"
+        return text, "disagrees"          # no slot to write — surface it
+    val = m.group(1).strip()
+    if val in ("", '""', "''", "null", "~"):
+        return text.replace(m.group(0), link, 1), "filled"
+    if val.strip('"\'') == f"[[{target}]]":
+        return text, "agrees"
+    return text, "disagrees"
 
 
 def run(argv: list[str]) -> int:
@@ -208,8 +226,9 @@ def run(argv: list[str]) -> int:
         with open(path, encoding="utf-8") as fh:
             txt = fh.read()
         edited = add_relationship(txt, target, rtype, "auto-linked: " + why)
+        scalar_status = None
         if edited is not None and rtype == "part_of":
-            edited = fill_parent_location(edited, target)
+            edited, scalar_status = fill_parent_location(edited, target)
         if edited is None:
             # No relationships key to write into. Report it rather than
             # rewriting the file unchanged and claiming the link was made.
@@ -218,8 +237,11 @@ def run(argv: list[str]) -> int:
         if args.execute:
             with open(path, "w", encoding="utf-8") as fh:
                 fh.write(edited)
-        linked.append({"entity": name, "kind": kind, "type": rtype, "target": target,
-                       "subj_id": id_of.get(name), "obj_id": id_of.get(target)})
+        entry = {"entity": name, "kind": kind, "type": rtype, "target": target,
+                 "subj_id": id_of.get(name), "obj_id": id_of.get(target)}
+        if scalar_status is not None:
+            entry["parent_scalar"] = scalar_status
+        linked.append(entry)
 
     outdir = args.out
     os.makedirs(outdir, exist_ok=True)
@@ -239,6 +261,16 @@ def run(argv: list[str]) -> int:
         rep.append("| entity | type | → target |\n|---|---|---|")
         for kind, name, target, rtype in sorted(unwritable):
             rep.append(f"| {name} | {rtype} | {target} |")
+    misaligned = [l for l in linked if l.get("parent_scalar") == "disagrees"]
+    if misaligned:
+        rep.append("\n## parent_location scalar not aligned\n")
+        rep.append("The part_of edge was written, but the note's "
+                   "parent_location: scalar names something else (or offered "
+                   "no slot) and was left untouched. The published site groups "
+                   "locations on the scalar, so these need a manual look.\n")
+        rep.append("| entity | edge target |\n|---|---|")
+        for l in misaligned:
+            rep.append(f"| {l['entity']} | {l['target']} |")
     rep.append("\n## Still orphan (need manual judgement)\n")
     for k, n in sorted(still):
         rep.append(f"- [{k}] {n}")
@@ -254,6 +286,10 @@ def run(argv: list[str]) -> int:
     if not args.execute and linked:
         print("dry-run — pass --execute to write the vault edits above")
     print(f"linked {len(linked)}, still orphan {len(still)}")
+    if misaligned:
+        print(f"WARNING: {len(misaligned)} note(s) keep a parent_location: that "
+              f"does not match the new part_of edge — see the report",
+              file=sys.stderr)
     if unwritable:
         print(f"WARNING: {len(unwritable)} note(s) have no `relationships:` key — "
               f"nothing was written for them; see the report", file=sys.stderr)

--- a/tools/mobrpg/mobrpg/commands/link_orphans.py
+++ b/tools/mobrpg/mobrpg/commands/link_orphans.py
@@ -136,6 +136,17 @@ def add_relationship(text: str, target: str, rtype: str, desc: str) -> str | Non
     return new_text if n else None
 
 
+def fill_parent_location(text: str, target: str) -> str:
+    """Fill an EMPTY `parent_location:` scalar to agree with a freshly written
+    `part_of` edge. Both are documented vault conventions and the publish
+    renderer groups its location index on the scalar, so writing only the edge
+    left an import looking right in the graph and wrong on the site (#186). An
+    authored (non-empty) value is never touched."""
+    return re.sub(r'^parent_location:\s*""\s*$',
+                  lambda _m: f'parent_location: "[[{target}]]"',
+                  text, count=1, flags=re.M)
+
+
 def run(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(
         prog="mobrpg link-orphans",
@@ -197,6 +208,8 @@ def run(argv: list[str]) -> int:
         with open(path, encoding="utf-8") as fh:
             txt = fh.read()
         edited = add_relationship(txt, target, rtype, "auto-linked: " + why)
+        if edited is not None and rtype == "part_of":
+            edited = fill_parent_location(edited, target)
         if edited is None:
             # No relationships key to write into. Report it rather than
             # rewriting the file unchanged and claiming the link was made.

--- a/tools/mobrpg/mobrpg/commands/map_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/map_cmd.py
@@ -766,6 +766,9 @@ def _entry(old_entry: dict | None, fresh: dict, label: str, notes: list[str]) ->
         notes.append(f"{label}: canon now resolves to a different type "
                      f"({old_id} -> {new_id})")
         return fresh
+    if old_entry.get("status") == "canon" and fresh.get("status") != "canon":
+        notes.append(f"{label}: canon-learned binding no longer verified — "
+                     f"replaced by '{fresh.get('status')}' proposal")
     if old_entry.get("status") in ("new", "review") and fresh.get("status") == "bound":
         notes.append(f"{label}: now bound to existing type")
     return fresh
@@ -911,16 +914,33 @@ def run(argv: list[str]) -> int:
 
     # Live location-element kinds let the canon-learning pass consult what a
     # linked element actually IS upstream instead of trusting a `determined`
-    # block that may hold our own routing guess (#182). Unavailable -> None,
-    # and learning falls back to the element_kind-agreement gate alone.
+    # block that may hold our own routing guess (#182). The listing must be
+    # COMPLETE to be authoritative — a partial or empty-on-error map would
+    # silently discard every ratified binding — so the pagination runs strict
+    # here (_fetch_all degrades to a partial list on error, which is exactly
+    # wrong for this use). Any failure downgrades learning to the
+    # element_kind-agreement gate alone, and says so.
     live_loc: dict | None = {}
-    for ek in ("political", "landfeature"):
-        try:
-            for e in _fetch_all(f"/world/{args.world}/{ek}", token):
-                live_loc[e["id"]] = ek
-        except client.ApiError:
-            live_loc = None
-            break
+    try:
+        for ek in ("political", "landfeature"):
+            page = 0
+            while True:
+                r = client._request("GET", f"/world/{args.world}/{ek}",
+                                    token=token, query={"page": page, "size": 200})
+                if not isinstance(r, dict):
+                    break
+                for e in r.get("content", []):
+                    if isinstance(e, dict) and e.get("id"):
+                        live_loc[e["id"]] = ek
+                total = (r.get("page") or {}).get("totalPages", 1)
+                if page >= total - 1:
+                    break
+                page += 1
+    except (client.ApiError, ValueError) as e:
+        print(f"WARNING: could not list live location elements ({e}); "
+              f"canon-learning falls back to the element_kind gate alone",
+              file=sys.stderr)
+        live_loc = None
 
     vocab = scan_vault(args.vault)
     fresh = build_map(args.world, world_meta, args.vault, disc, vocab, now,

--- a/tools/mobrpg/mobrpg/commands/map_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/map_cmd.py
@@ -928,7 +928,9 @@ def run(argv: list[str]) -> int:
                 r = client._request("GET", f"/world/{args.world}/{ek}",
                                     token=token, query={"page": page, "size": 200})
                 if not isinstance(r, dict):
-                    break
+                    # a bare list / None is not the paged shape — treat it as a
+                    # failed listing, never as an authoritative empty one
+                    raise ValueError(f"unexpected {ek} listing shape: {type(r).__name__}")
                 for e in r.get("content", []):
                     if isinstance(e, dict) and e.get("id"):
                         live_loc[e["id"]] = ek

--- a/tools/mobrpg/mobrpg/commands/map_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/map_cmd.py
@@ -550,9 +550,9 @@ def _ontology_built(value: str) -> bool:
     return any(k in built for k in _axis_keys(value))
 
 
-def canon_location_bindings(vault: str) -> dict:
-    """{normalized location_type: (target, classifier_name, element_kind)} learned
-    from linked notes' ratified `determined` blocks.
+def canon_location_bindings(vault: str, live_kind_by_id: dict | None = None) -> dict:
+    """{normalized location_type: (target, classifier_name)} learned from linked
+    notes' ratified `determined` blocks.
 
     The vault's `location_type` is the GM's own free-text vocabulary and is not
     required to match mobRPG's; a vault says "hyperspace gate" where the world
@@ -565,6 +565,14 @@ def canon_location_bindings(vault: str) -> dict:
 
     A term whose linked notes disagree is left out, so the ordinary heuristics
     (and the near-duplicate review) decide rather than an arbitrary winner.
+
+    A `determined` block can also hold the tool's OWN routing guess (written by
+    suggest/adopt and never ratified), and learning that back would make a wrong
+    routing self-confirming (#182). Two gates break the loop: the block's key
+    must agree with the node's `element_kind`, and — when the caller supplies
+    `live_kind_by_id` ({element_id: "political"|"landfeature"}, from live
+    listings) — with what the linked element actually IS upstream. A note
+    failing either gate simply casts no vote.
     """
     seen: dict = {}
     for path in glob.glob(os.path.join(os.path.expanduser(vault), "**", "*.md"),
@@ -583,11 +591,19 @@ def canon_location_bindings(vault: str) -> dict:
             continue
         det = nd.get("determined") or {}
         pol, land = det.get("political_type"), det.get("land_feature_type")
-        if pol:
+        kind = nd.get("element_kind")
+        if pol and kind == "Political":
             hit = ("political", pol)
-        elif land:
+        elif land and kind == "LandFeature":
             hit = ("landfeature", land)
         else:
+            # determined disagrees with (or lacks) the node's own element kind —
+            # a self-contradictory block written from a routing guess (#182)
+            continue
+        if live_kind_by_id is not None and \
+                live_kind_by_id.get(nd.get("element_id")) != hit[0]:
+            # the live element is another kind (or gone): the block holds our
+            # own proposal, not canon — never learn it back (#182)
             continue
         seen.setdefault(_norm(lt), set()).add(hit)
     return {k: next(iter(v)) for k, v in seen.items() if len(v) == 1}
@@ -642,7 +658,8 @@ def _route_location(value: str, disc: dict, canon: dict | None = None) -> dict:
     return {"target": "political", "politicalType": tok.title(), "mobrpgId": None, "status": "new"}
 
 
-def build_map(world: str, world_meta: dict, vault: str, disc: dict, vocab: dict, now: str) -> dict:
+def build_map(world: str, world_meta: dict, vault: str, disc: dict, vocab: dict,
+              now: str, live_loc_kinds: dict | None = None) -> dict:
     classifiers = {
         "profession": {v: _bind(v, disc["person/profession"], "person/profession")
                        for v in vocab["occupation"]},
@@ -654,7 +671,7 @@ def build_map(world: str, world_meta: dict, vault: str, disc: dict, vocab: dict,
                     "status": "new"}
                 for v in vocab["gender"]},
     }
-    canon_loc = canon_location_bindings(vault)
+    canon_loc = canon_location_bindings(vault, live_kind_by_id=live_loc_kinds)
     location_routing = {v: _route_location(v, disc, canon_loc)
                         for v in vocab["location_type"]}
     # Report every off-vocabulary predicate at once rather than dying on the
@@ -892,8 +909,22 @@ def run(argv: list[str]) -> int:
         print(f"ERROR: {e}", file=sys.stderr)
         return 1
 
+    # Live location-element kinds let the canon-learning pass consult what a
+    # linked element actually IS upstream instead of trusting a `determined`
+    # block that may hold our own routing guess (#182). Unavailable -> None,
+    # and learning falls back to the element_kind-agreement gate alone.
+    live_loc: dict | None = {}
+    for ek in ("political", "landfeature"):
+        try:
+            for e in _fetch_all(f"/world/{args.world}/{ek}", token):
+                live_loc[e["id"]] = ek
+        except client.ApiError:
+            live_loc = None
+            break
+
     vocab = scan_vault(args.vault)
-    fresh = build_map(args.world, world_meta, args.vault, disc, vocab, now)
+    fresh = build_map(args.world, world_meta, args.vault, disc, vocab, now,
+                      live_loc_kinds=live_loc)
 
     if args.action == "check":
         old = _read_map(map_path) if os.path.exists(map_path) else fresh

--- a/tools/mobrpg/mobrpg/commands/sync_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/sync_cmd.py
@@ -324,6 +324,10 @@ def run(argv: list[str]) -> int:
     ap.add_argument("--execute", action="store_true",
                     help="write vault changes and submit suggestions (default: dry-run)")
     ap.add_argument("--batch-label", default="sync", help="suggestion batch label")
+    ap.add_argument("--show-body", action="store_true",
+                    help="print each push decision's outgoing description "
+                         "markdown — the exact payload its suggestion will "
+                         "carry into the world owner's review queue")
     args = ap.parse_args(argv)
 
     try:
@@ -367,6 +371,16 @@ def run(argv: list[str]) -> int:
     for a in actions:
         counts[a.decision] = counts.get(a.decision, 0) + 1
         print(f"  {a.decision:8} {a.ref}{a.delta}")
+
+    # A push lands prose in someone ELSE's review queue, under this user's
+    # name; --show-body prints exactly what will be sent, so the dry run can
+    # be inspected without reconstructing the payload by hand (#184).
+    if args.show_body:
+        for a in actions:
+            if a.suggestion is not None:
+                print(f"  --- push body: {a.ref} ---")
+                print((a.suggestion.get("payload") or {}).get("description", ""))
+                print("  --- end push body ---")
 
     # Local-only writes first: pull / in-sync / baseline record what canon
     # already says and depend on nothing upstream.

--- a/tools/mobrpg/mobrpg/commands/write_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/write_cmd.py
@@ -257,12 +257,24 @@ def run(argv: list[str]) -> int:
 
     written: dict[str, int] = {}
     skipped = unsupported = 0
+    # Preflight: slug() can map distinct names ("A/B", "AB") onto one file, and
+    # case-insensitive filesystems collapse case variants too. Without this the
+    # later record silently vanished (or replaced the earlier under
+    # --overwrite). First name claims the path; the rest are reported.
+    claimed: dict[str, str] = {}
+    collisions: list[tuple[str, str, str]] = []
     for rec in data["entities"]:
         r = build(rec, args.campaign, args.source_doc, args.name_style)
         if not r:
             unsupported += 1
             continue
         rel_path, md = r
+        key = rel_path.lower()
+        holder = claimed.get(key)
+        if holder is not None and holder != rec["name"]:
+            collisions.append((rec["name"], holder, rel_path))
+            continue
+        claimed[key] = rec["name"]
         full = os.path.join(args.out, rel_path)
         # An existing note is someone's work — hand-authored prose, GM Notes,
         # play bookkeeping. Replacing it wholesale is the most destructive thing
@@ -281,4 +293,9 @@ def run(argv: list[str]) -> int:
     if unsupported:
         print(f"ignored {unsupported} entit(y/ies) of unsupported kind(s) — "
               f"no vault template maps them")
+    for name, holder, rel_path in collisions:
+        print(f"WARNING: filename collision — {name!r} maps to {rel_path}, "
+              f"already claimed by {holder!r}; not written")
+    if collisions:
+        print(f"{len(collisions)} filename collision(s) — rename to disambiguate")
     return 0

--- a/tools/mobrpg/mobrpg/commands/write_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/write_cmd.py
@@ -256,10 +256,11 @@ def run(argv: list[str]) -> int:
         data = json.load(f)
 
     written: dict[str, int] = {}
-    skipped = 0
+    skipped = unsupported = 0
     for rec in data["entities"]:
         r = build(rec, args.campaign, args.source_doc, args.name_style)
         if not r:
+            unsupported += 1
             continue
         rel_path, md = r
         full = os.path.join(args.out, rel_path)
@@ -277,4 +278,7 @@ def run(argv: list[str]) -> int:
     print(f"wrote to {args.out}/:", written, "| total", sum(written.values()))
     if skipped:
         print(f"skipped {skipped} existing note(s) — pass --overwrite to replace them")
+    if unsupported:
+        print(f"ignored {unsupported} entit(y/ies) of unsupported kind(s) — "
+              f"no vault template maps them")
     return 0

--- a/tools/mobrpg/mobrpg/commands/write_cmd.py
+++ b/tools/mobrpg/mobrpg/commands/write_cmd.py
@@ -247,22 +247,34 @@ def run(argv: list[str]) -> int:
                     help="source reference string for '## Source References'")
     ap.add_argument("--name-style", choices=["plain", "space"], default="plain",
                     help="filename/wiki-link naming convention (default: plain)")
+    ap.add_argument("--overwrite", action="store_true",
+                    help="replace notes that already exist under --out "
+                         "(default: skip them, keeping hand-authored content)")
     args = ap.parse_args(argv)
 
     with open(args.extract, encoding="utf-8") as f:
         data = json.load(f)
 
     written: dict[str, int] = {}
+    skipped = 0
     for rec in data["entities"]:
         r = build(rec, args.campaign, args.source_doc, args.name_style)
         if not r:
             continue
         rel_path, md = r
         full = os.path.join(args.out, rel_path)
+        # An existing note is someone's work — hand-authored prose, GM Notes,
+        # play bookkeeping. Replacing it wholesale is the most destructive thing
+        # this tool can do, so it only happens on an explicit --overwrite (#186).
+        if os.path.exists(full) and not args.overwrite:
+            skipped += 1
+            continue
         os.makedirs(os.path.dirname(full), exist_ok=True)
         with open(full, "w", encoding="utf-8") as f:
             f.write(md)
         written.setdefault(rec["kind"], 0)
         written[rec["kind"]] += 1
     print(f"wrote to {args.out}/:", written, "| total", sum(written.values()))
+    if skipped:
+        print(f"skipped {skipped} existing note(s) — pass --overwrite to replace them")
     return 0

--- a/tools/mobrpg/mobrpg/links.py
+++ b/tools/mobrpg/mobrpg/links.py
@@ -34,12 +34,17 @@ from mobrpg.commands import suggest
 # would need a type the node need not know).
 URL_FMT = "https://www.mobrpg.com/world/{world}/link/{eid}"
 
-# `![[...]]` is an image EMBED, not a link: it points at a vault attachment
-# that has no upstream counterpart (there is no attachment-push path), so a
-# push drops it entirely. Left to the wikilink pass, the `!` was stranded while
-# the target collapsed — `![[map.png]]` -> `!map.png`, and `![[map.svg|697]]`
-# -> `!697` (an embed's pipe is a display width, not an alias). See #184.
-_EMBED = re.compile(r"!\[\[[^\]]+\]\]\s*\n?")
+# `![[...]]` is an EMBED (image attachment or note transclusion), not a link:
+# it has no upstream counterpart (there is no attachment-push path), so a push
+# drops it entirely. Left to the wikilink pass, the `!` was stranded while the
+# target collapsed — `![[map.png]]` -> `!map.png`, and `![[map.svg|697]]` ->
+# `!697` (an embed's pipe is a display width, not an alias). See #184.
+# An embed alone on its line vanishes with the line; an inline embed vanishes
+# with the spaces immediately before it, so surrounding words never weld
+# together. (Like the wikilink pass this is a regex, not a parser: an embed
+# inside a code span is dropped too — the same documented trade-off.)
+_EMBED_LINE = re.compile(r"^[ \t]*!\[\[[^\]]+\]\][ \t]*\n?", re.M)
+_EMBED_INLINE = re.compile(r"[ \t]*!\[\[[^\]]+\]\]")
 # `[[Name]]` or `[[Name|Alias]]` — group 1 is the resolution Name, group 2 the
 # optional display Alias.
 _WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
@@ -75,7 +80,8 @@ def rewrite_md_for_push(md_text: str, ent_id_by_key: dict,
             return f"[{display}]({url_fmt.format(world=world_id, eid=eid)})"
         return display
 
-    text = _WIKILINK.sub(_wl, _EMBED.sub("", md_text or ""))
+    text = _EMBED_LINE.sub("", md_text or "")
+    text = _WIKILINK.sub(_wl, _EMBED_INLINE.sub("", text))
 
     def _ml(m: re.Match) -> str:
         label, href = m.group(1), m.group(2)

--- a/tools/mobrpg/mobrpg/links.py
+++ b/tools/mobrpg/mobrpg/links.py
@@ -43,8 +43,14 @@ URL_FMT = "https://www.mobrpg.com/world/{world}/link/{eid}"
 # with the spaces immediately before it, so surrounding words never weld
 # together. (Like the wikilink pass this is a regex, not a parser: an embed
 # inside a code span is dropped too — the same documented trade-off.)
-_EMBED_LINE = re.compile(r"^[ \t]*!\[\[[^\]]+\]\][ \t]*\n?", re.M)
-_EMBED_INLINE = re.compile(r"[ \t]*!\[\[[^\]]+\]\]")
+_EMBED_LINE = re.compile(r"^[ \t]*!\[\[[^\]\r\n]+\]\][ \t]*\r?\n?", re.M)
+_EMBED_INLINE = re.compile(r"(?P<lead>[ \t]*)!\[\[[^\]\r\n]+\]\](?P<trail>[ \t]*)")
+
+
+def _drop_inline_embed(m: re.Match) -> str:
+    """Leave at most one separating space where whitespace flanked the embed,
+    so `before ![[m.png]]after` reads `before after`, never `beforeafter`."""
+    return " " if (m.group("lead") or m.group("trail")) else ""
 # `[[Name]]` or `[[Name|Alias]]` — group 1 is the resolution Name, group 2 the
 # optional display Alias.
 _WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
@@ -81,7 +87,7 @@ def rewrite_md_for_push(md_text: str, ent_id_by_key: dict,
         return display
 
     text = _EMBED_LINE.sub("", md_text or "")
-    text = _WIKILINK.sub(_wl, _EMBED_INLINE.sub("", text))
+    text = _WIKILINK.sub(_wl, _EMBED_INLINE.sub(_drop_inline_embed, text))
 
     def _ml(m: re.Match) -> str:
         label, href = m.group(1), m.group(2)

--- a/tools/mobrpg/mobrpg/links.py
+++ b/tools/mobrpg/mobrpg/links.py
@@ -5,7 +5,9 @@ The vault authors cross-references as Obsidian wikilinks (`[[Name]]` /
 id-only redirect route. This module bridges the two, always operating on the
 `main` (canon-prose) slice — never the GM Notes tail:
 
-  push  — `[[Name]]` / `[[Name|Alias]]` -> `[display](element-url)` when the name
+  push  — `![[embeds]]` are dropped first (an image embed references a vault
+          attachment with no upstream counterpart); then `[[Name]]` /
+          `[[Name|Alias]]` -> `[display](element-url)` when the name
           resolves in the node index; unresolvable wikilinks and `.md` relative
           links collapse to bare display text; `http(s)` links are left alone.
           Runs BEFORE `md.md_to_html`.
@@ -32,6 +34,12 @@ from mobrpg.commands import suggest
 # would need a type the node need not know).
 URL_FMT = "https://www.mobrpg.com/world/{world}/link/{eid}"
 
+# `![[...]]` is an image EMBED, not a link: it points at a vault attachment
+# that has no upstream counterpart (there is no attachment-push path), so a
+# push drops it entirely. Left to the wikilink pass, the `!` was stranded while
+# the target collapsed — `![[map.png]]` -> `!map.png`, and `![[map.svg|697]]`
+# -> `!697` (an embed's pipe is a display width, not an alias). See #184.
+_EMBED = re.compile(r"!\[\[[^\]]+\]\]\s*\n?")
 # `[[Name]]` or `[[Name|Alias]]` — group 1 is the resolution Name, group 2 the
 # optional display Alias.
 _WIKILINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
@@ -67,7 +75,7 @@ def rewrite_md_for_push(md_text: str, ent_id_by_key: dict,
             return f"[{display}]({url_fmt.format(world=world_id, eid=eid)})"
         return display
 
-    text = _WIKILINK.sub(_wl, md_text or "")
+    text = _WIKILINK.sub(_wl, _EMBED.sub("", md_text or ""))
 
     def _ml(m: re.Match) -> str:
         label, href = m.group(1), m.group(2)

--- a/tools/mobrpg/tests/test_adopt.py
+++ b/tools/mobrpg/tests/test_adopt.py
@@ -181,3 +181,24 @@ def test_true_no_live_match_still_reported_for_locations(tmp_path, monkeypatch, 
     out = capsys.readouterr().out
     assert "no live match: Vault Only Place" in out
     assert "kind mismatch" not in out
+
+
+def test_sibling_listing_failure_is_fatal_not_a_false_no_match(tmp_path, monkeypatch, capsys):
+    # The primary listing treats an ApiError as fatal; the sibling check must
+    # too — degrading it silently would let the run claim "no live match" for
+    # an element the tool never actually looked for.
+    v = _loc_vault(tmp_path)
+    _note(v, "Locations/Eris-Peric Route.md",
+          fm="type: location\nlocation_type: trade route")
+    _auth(monkeypatch)
+
+    def stub(method, path, *, token=None, query=None, body=None):
+        if path.rsplit("/", 1)[-1] == "landfeature":
+            raise client.ApiError(502, "boom", "u")
+        return {"content": [], "page": {"totalPages": 1}}
+    monkeypatch.setattr(client, "_request", stub)
+
+    assert adopt.run(["w1", "--vault", str(v)]) == 1
+    captured = capsys.readouterr()
+    assert "no live match: Eris-Peric Route" not in captured.out
+    assert "ERROR" in captured.err

--- a/tools/mobrpg/tests/test_adopt.py
+++ b/tools/mobrpg/tests/test_adopt.py
@@ -130,3 +130,54 @@ def test_kind_filter_scopes_the_pull(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(client, "_request", stub)
     assert adopt.run(["w1", "--vault", str(v), "--kind", "npc", "--execute"]) == 0
     assert seen_kinds == ["person"]                     # only the npc→person endpoint pulled
+
+
+# ---- #182: an exact-named element of the sibling location kind is a routing
+# bug to surface, not a "no live match" to bury ----
+
+def _loc_map():
+    mp = _map()
+    mp["kinds"]["location"] = "political"
+    mp["locationRouting"] = {"trade route": {"target": "political",
+                                             "politicalType": "Trade Route",
+                                             "status": "new"}}
+    return mp
+
+
+def _loc_vault(tmp_path):
+    (tmp_path / "_meta").mkdir(parents=True)
+    (tmp_path / "_meta/mobrpg-map.json").write_text(json.dumps(_loc_map()),
+                                                    encoding="utf-8")
+    return tmp_path
+
+
+def test_kind_mismatch_is_its_own_outcome_not_unmatched(tmp_path, monkeypatch, capsys):
+    v = _loc_vault(tmp_path)
+    _note(v, "Locations/Eris-Peric Route.md",
+          fm="type: location\nlocation_type: trade route")
+    _auth(monkeypatch)
+    monkeypatch.setattr(client, "_request", _fake_live({
+        "political": [],
+        "landfeature": [{"id": "lf-1", "name": "Eris-Peric Route"}],
+    }))
+    assert adopt.run(["w1", "--vault", str(v), "--execute"]) == 0
+    out = capsys.readouterr().out
+    assert "kind mismatch" in out
+    assert "landfeature" in out
+    assert "no live match: Eris-Peric Route" not in out
+    # reported, never stamped — the fix is the map's locationRouting
+    nd = node.read_node((v / "Locations/Eris-Peric Route.md").read_text())
+    assert nd is None or not nd.get("element_id")
+
+
+def test_true_no_live_match_still_reported_for_locations(tmp_path, monkeypatch, capsys):
+    v = _loc_vault(tmp_path)
+    _note(v, "Locations/Vault Only Place.md",
+          fm="type: location\nlocation_type: trade route")
+    _auth(monkeypatch)
+    monkeypatch.setattr(client, "_request",
+                        _fake_live({"political": [], "landfeature": []}))
+    assert adopt.run(["w1", "--vault", str(v)]) == 0
+    out = capsys.readouterr().out
+    assert "no live match: Vault Only Place" in out
+    assert "kind mismatch" not in out

--- a/tools/mobrpg/tests/test_client.py
+++ b/tools/mobrpg/tests/test_client.py
@@ -99,6 +99,10 @@ def test_resolve_environment_field_override(monkeypatch):
 def test_get_access_token_requires_auth(monkeypatch, unblock_client_network):
     for k in ("MOBRPG_TOKEN", "MOBRPG_EMAIL", "MOBRPG_PASSWORD"):
         monkeypatch.delenv(k, raising=False)
+    # Isolate from the developer's real managed credentials: on a machine with
+    # ~/.config/mobrpg/credentials.json this test would otherwise find them and
+    # never exit.
+    monkeypatch.setattr("mobrpg.config.read", lambda: {})
     with pytest.raises(SystemExit) as exc:
         client.get_access_token()
     assert exc.value.code == 2

--- a/tools/mobrpg/tests/test_link_orphans.py
+++ b/tools/mobrpg/tests/test_link_orphans.py
@@ -312,3 +312,26 @@ def test_disagreeing_parent_location_is_surfaced_in_report(tmp_path):
     assert 'parent_location: "[[Somewhere Else]]"' in txt   # never clobbered
     report = (out / "orphan-linking-report.md").read_text(encoding="utf-8")
     assert "parent_location" in report                      # ...but surfaced
+
+
+def test_body_text_is_never_touched_by_parent_location_fill(tmp_path):
+    # The scalar lives in frontmatter; a body line that happens to start with
+    # `parent_location:` (docs, examples) must not be rewritten in its place.
+    vault = tmp_path / "vault"
+    locs = vault / "Locations"
+    locs.mkdir(parents=True)
+    (locs / "Corwin System.md").write_text(
+        LOC_NOTE.format(name="Corwin System", parent=""), encoding="utf-8")
+    (locs / "Corwin I.md").write_text(
+        "---\ntype: location\nname: Corwin I\n"
+        "relationships: []\n---\n# Corwin I\n\n"
+        "parent_location:\n", encoding="utf-8")
+    extract = _extract(tmp_path)
+    out = tmp_path / "out"
+
+    link_orphans.run([str(extract), "--vault", str(vault),
+                      "--out", str(out), "--systems", "Corwin", "--execute"])
+
+    txt = (locs / "Corwin I.md").read_text(encoding="utf-8")
+    assert 'parent_location: "[[Corwin System]]"' in txt.split("---")[1]  # fm inserted
+    assert txt.rstrip().endswith("parent_location:")                      # body decoy intact

--- a/tools/mobrpg/tests/test_link_orphans.py
+++ b/tools/mobrpg/tests/test_link_orphans.py
@@ -202,3 +202,54 @@ def test_system_name_with_regex_metacharacters(tmp_path):
         "Alpha (Prime) II", exists, ["Alpha (Prime)"]) == "Alpha (Prime) System"
     # the dot must be literal, not "any character"
     assert link_orphans.derive_parent("StXJohn II", {"St.John System"}, ["St.John"]) is None
+
+
+LOC_NOTE = """---
+type: location
+name: {name}
+parent_location: "{parent}"
+relationships: []
+---
+# {name}
+"""
+
+
+def test_execute_fills_empty_parent_location_scalar(tmp_path):
+    # (#186) the publish renderer groups its location index on parent_location,
+    # so writing only the part_of edge left imports right in the graph and
+    # wrong on the site — the scalar and the edge must agree.
+    vault = tmp_path / "vault"
+    locs = vault / "Locations"
+    locs.mkdir(parents=True)
+    (locs / "Corwin System.md").write_text(
+        LOC_NOTE.format(name="Corwin System", parent=""), encoding="utf-8")
+    (locs / "Corwin I.md").write_text(
+        LOC_NOTE.format(name="Corwin I", parent=""), encoding="utf-8")
+    extract = _extract(tmp_path)
+    out = tmp_path / "out"
+
+    rc = link_orphans.run([str(extract), "--vault", str(vault),
+                           "--out", str(out), "--systems", "Corwin", "--execute"])
+
+    assert rc == 0
+    txt = (locs / "Corwin I.md").read_text(encoding="utf-8")
+    assert 'parent_location: "[[Corwin System]]"' in txt
+    assert '- target: "[[Corwin System]]"' in txt
+
+
+def test_authored_parent_location_is_never_clobbered(tmp_path):
+    vault = tmp_path / "vault"
+    locs = vault / "Locations"
+    locs.mkdir(parents=True)
+    (locs / "Corwin System.md").write_text(
+        LOC_NOTE.format(name="Corwin System", parent=""), encoding="utf-8")
+    (locs / "Corwin I.md").write_text(
+        LOC_NOTE.format(name="Corwin I", parent="[[Somewhere Else]]"), encoding="utf-8")
+    extract = _extract(tmp_path)
+    out = tmp_path / "out"
+
+    link_orphans.run([str(extract), "--vault", str(vault),
+                      "--out", str(out), "--systems", "Corwin", "--execute"])
+
+    txt = (locs / "Corwin I.md").read_text(encoding="utf-8")
+    assert 'parent_location: "[[Somewhere Else]]"' in txt

--- a/tools/mobrpg/tests/test_link_orphans.py
+++ b/tools/mobrpg/tests/test_link_orphans.py
@@ -253,3 +253,62 @@ def test_authored_parent_location_is_never_clobbered(tmp_path):
 
     txt = (locs / "Corwin I.md").read_text(encoding="utf-8")
     assert 'parent_location: "[[Somewhere Else]]"' in txt
+
+
+def test_fills_bare_and_single_quoted_parent_location(tmp_path):
+    # Hand-authored notes write the empty scalar every way YAML allows; the
+    # double-quoted form is only what `mobrpg write` emits.
+    vault = tmp_path / "vault"
+    locs = vault / "Locations"
+    locs.mkdir(parents=True)
+    (locs / "Corwin System.md").write_text(
+        LOC_NOTE.format(name="Corwin System", parent=""), encoding="utf-8")
+    (locs / "Corwin I.md").write_text(
+        "---\ntype: location\nname: Corwin I\nparent_location:\n"
+        "relationships: []\n---\n# Corwin I\n", encoding="utf-8")
+    extract = _extract(tmp_path)
+    out = tmp_path / "out"
+
+    rc = link_orphans.run([str(extract), "--vault", str(vault),
+                           "--out", str(out), "--systems", "Corwin", "--execute"])
+
+    assert rc == 0
+    txt = (locs / "Corwin I.md").read_text(encoding="utf-8")
+    assert 'parent_location: "[[Corwin System]]"' in txt
+
+
+def test_inserts_parent_location_when_key_is_missing(tmp_path):
+    # parent_location is Optional in the schema, so a hand-authored note may
+    # omit it entirely; writing only the edge would leave the exact
+    # graph-vs-site split #186 reported.
+    vault = _vault(tmp_path)          # NOTE template has no parent_location key
+    extract = _extract(tmp_path)
+    out = tmp_path / "out"
+
+    rc = link_orphans.run([str(extract), "--vault", str(vault),
+                           "--out", str(out), "--systems", "Corwin", "--execute"])
+
+    assert rc == 0
+    txt = (vault / "Locations" / "Corwin I.md").read_text(encoding="utf-8")
+    assert 'parent_location: "[[Corwin System]]"' in txt
+
+
+def test_disagreeing_parent_location_is_surfaced_in_report(tmp_path):
+    vault = tmp_path / "vault"
+    locs = vault / "Locations"
+    locs.mkdir(parents=True)
+    (locs / "Corwin System.md").write_text(
+        LOC_NOTE.format(name="Corwin System", parent=""), encoding="utf-8")
+    (locs / "Corwin I.md").write_text(
+        LOC_NOTE.format(name="Corwin I", parent="[[Somewhere Else]]"),
+        encoding="utf-8")
+    extract = _extract(tmp_path)
+    out = tmp_path / "out"
+
+    link_orphans.run([str(extract), "--vault", str(vault),
+                      "--out", str(out), "--systems", "Corwin", "--execute"])
+
+    txt = (locs / "Corwin I.md").read_text(encoding="utf-8")
+    assert 'parent_location: "[[Somewhere Else]]"' in txt   # never clobbered
+    report = (out / "orphan-linking-report.md").read_text(encoding="utf-8")
+    assert "parent_location" in report                      # ...but surfaced

--- a/tools/mobrpg/tests/test_links.py
+++ b/tools/mobrpg/tests/test_links.py
@@ -74,3 +74,15 @@ def test_push_embed_lines_do_not_merge_paragraphs():
     out = links.rewrite_md_for_push("Para one.\n\n![[map.png]]\n\nPara two.",
                                     IDX, "w1", FMT)
     assert _re.search(r"Para one\.\n\n+Para two\.", out)
+
+
+def test_push_embed_with_no_trailing_space_keeps_a_separator():
+    out = links.rewrite_md_for_push("before ![[m.png]]after", IDX, "w1", FMT)
+    assert "beforeafter" not in out
+    assert "before after" in out
+
+
+def test_push_malformed_multiline_embed_does_not_eat_prose():
+    # `[^\]]+` spanning newlines could delete unrelated prose up to the next ]]
+    out = links.rewrite_md_for_push("keep ![[foo\nbar]] this line too", IDX, "w1", FMT)
+    assert "keep" in out and "this line too" in out

--- a/tools/mobrpg/tests/test_links.py
+++ b/tools/mobrpg/tests/test_links.py
@@ -59,3 +59,18 @@ def test_push_inline_embed_leaves_surrounding_text():
     out = links.rewrite_md_for_push("before ![[m.png]] after", IDX, "w1", FMT)
     assert "m.png" not in out
     assert "before" in out and "after" in out
+
+
+def test_push_embed_between_words_preserves_spacing():
+    # `\s*` greediness must not weld the surrounding words together.
+    out = links.rewrite_md_for_push("The gate opened![[Corwin]] stood there.",
+                                    IDX, "w1", FMT)
+    assert "openedstood" not in out
+    assert "opened" in out and "stood there." in out
+
+
+def test_push_embed_lines_do_not_merge_paragraphs():
+    import re as _re
+    out = links.rewrite_md_for_push("Para one.\n\n![[map.png]]\n\nPara two.",
+                                    IDX, "w1", FMT)
+    assert _re.search(r"Para one\.\n\n+Para two\.", out)

--- a/tools/mobrpg/tests/test_links.py
+++ b/tools/mobrpg/tests/test_links.py
@@ -32,3 +32,30 @@ def test_pull_leaves_unknown_element_urls_untouched():
     md_in = f"See [Ghost]({url})."
     out = links.rewrite_md_for_pull(md_in, {"e-77": "Marsh Hag"})
     assert url in out and "[[" not in out
+
+
+# ---- image embeds (#184) — an embed points at a vault attachment with no
+# upstream counterpart, so a push must drop it, not flatten it to junk text ----
+
+def test_push_drops_image_embed_line():
+    md_in = "Intro.\n\n![[Eris System.jpg]]\n\nSee [[Marsh Hag]].\n"
+    out = links.rewrite_md_for_push(md_in, IDX, "w1", FMT)
+    assert "Eris System.jpg" not in out
+    assert "!" not in out
+    assert FMT.format(world="w1", eid="e-77") in out
+
+
+def test_push_drops_sized_embed_width_is_not_an_alias():
+    # In an Obsidian embed the pipe is a display width, not an alias:
+    # ![[map.svg|697]] must vanish, never become the literal "!697".
+    out = links.rewrite_md_for_push("![[Meridian-system-map.svg|697]]\nProse.",
+                                    IDX, "w1", FMT)
+    assert "697" not in out
+    assert "!" not in out
+    assert "Prose." in out
+
+
+def test_push_inline_embed_leaves_surrounding_text():
+    out = links.rewrite_md_for_push("before ![[m.png]] after", IDX, "w1", FMT)
+    assert "m.png" not in out
+    assert "before" in out and "after" in out

--- a/tools/mobrpg/tests/test_map.py
+++ b/tools/mobrpg/tests/test_map.py
@@ -569,3 +569,59 @@ def test_canon_bindings_live_kind_confirms_real_canon(tmp_path):
     live = {"id-Betelgeuse": "landfeature"}
     got = m.canon_location_bindings(str(tmp_path), live_kind_by_id=live)
     assert got == {"sun": ("landfeature", "Star")}
+
+
+def test_run_learning_survives_listing_failure(tmp_path, monkeypatch, capsys):
+    # A 502 on the live location listings must degrade the canon-learning gate
+    # (element_kind agreement only) with a warning — NOT silently discard every
+    # ratified binding by treating {} as "verified: nothing exists".
+    _canon_note(tmp_path, "Betelgeuse", "sun", "LandFeature",
+                {"land_feature_type": "Star"})
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+
+    def stub(method, path, **k):
+        raise client.ApiError(502, "boom", "u")
+    monkeypatch.setattr(client, "_request", stub)
+
+    mp = str(tmp_path / "map.json")
+    assert m.run(["init", "w1", "--vault", str(tmp_path), "--map", mp,
+                  "--now", "T0"]) == 0
+    data = json.load(open(mp, encoding="utf-8"))
+    assert data["locationRouting"]["sun"]["status"] == "canon"
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_run_learning_consults_live_kinds(tmp_path, monkeypatch):
+    # Internally consistent but wrong: the block carries the tool's own guess
+    # (Political) while the live element is a landfeature. run() must build the
+    # live id->kind map and refuse to learn the guess back as canon.
+    _canon_note(tmp_path, "Corwin-Thides Route", "trade route", "Political",
+                {"political_type": "Trade Route"})
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+
+    def stub(method, path, *, token=None, query=None, body=None):
+        if path == "/world":
+            return []
+        if path.endswith("/landfeature"):
+            return {"content": [{"id": "id-Corwin-Thides Route",
+                                 "name": "Corwin-Thides Route"}],
+                    "page": {"totalPages": 1}}
+        return {"content": [], "page": {"totalPages": 1}}
+    monkeypatch.setattr(client, "_request", stub)
+
+    mp = str(tmp_path / "map.json")
+    assert m.run(["init", "w1", "--vault", str(tmp_path), "--map", mp,
+                  "--now", "T0"]) == 0
+    data = json.load(open(mp, encoding="utf-8"))
+    assert data["locationRouting"]["trade route"]["status"] != "canon"
+
+
+def test_entry_notes_a_canon_downgrade():
+    notes = []
+    old = {"target": "landfeature", "landFeatureType": "Gate",
+           "mobrpgId": None, "status": "canon"}
+    fresh = {"target": "political", "politicalType": "Hyperspace",
+             "mobrpgId": None, "status": "new"}
+    out = m._entry(old, fresh, "locationRouting[hyperspace gate]", notes)
+    assert out == fresh
+    assert any("canon" in n for n in notes)

--- a/tools/mobrpg/tests/test_map.py
+++ b/tools/mobrpg/tests/test_map.py
@@ -519,3 +519,53 @@ def test_merge_lets_a_rediscovered_value_win_over_the_old_one():
     old = {"world": "Old Name", "classifiers": {}, "locationRouting": {}}
     new = {"world": "New Name", "classifiers": {}, "locationRouting": {}}
     assert m._merge(old, new)[0]["world"] == "New Name"
+
+
+# ---- #182: a guessed routing must not be learned back as canon ----
+
+def _canon_note(tmp_path, name, location_type, element_kind, det):
+    from mobrpg import node as _node
+    nd = {"world_id": "w1", "external_ref": f"ns:Locations/{name}",
+          "element_id": f"id-{name}", "element_kind": element_kind,
+          "review_state": "accepted", "determined": det,
+          "relationships": [], "languages": []}
+    p = tmp_path / "Locations" / f"{name}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"---\ntype: location\nlocation_type: {location_type}\n"
+                 + _node.emit_node(nd) + "---\nBody.\n", encoding="utf-8")
+    return p
+
+
+def test_canon_bindings_skip_kind_disagreeing_determined(tmp_path):
+    # determined says Political while the node's own element_kind says
+    # LandFeature — a self-contradictory block written from the tool's guess.
+    _canon_note(tmp_path, "Trade Route A", "trade route", "LandFeature",
+                {"political_type": "Trade Route"})
+    assert m.canon_location_bindings(str(tmp_path)) == {}
+
+
+def test_canon_bindings_learn_agreeing_node(tmp_path):
+    _canon_note(tmp_path, "Betelgeuse", "sun", "LandFeature",
+                {"land_feature_type": "Star"})
+    got = m.canon_location_bindings(str(tmp_path))
+    assert got == {"sun": ("landfeature", "Star")}
+
+
+def test_canon_bindings_live_kind_overrules_self_written_block(tmp_path):
+    # Internally consistent but wrong: element_kind AND determined both carry
+    # the tool's own proposal, while the live element is another kind. With a
+    # live id->kind map the learning path must consult the element, not the
+    # block the routing guess wrote.
+    _canon_note(tmp_path, "Corwin-Thides Route", "trade route", "Political",
+                {"political_type": "Trade Route"})
+    live = {"id-Corwin-Thides Route": "landfeature"}
+    assert m.canon_location_bindings(str(tmp_path),
+                                           live_kind_by_id=live) == {}
+
+
+def test_canon_bindings_live_kind_confirms_real_canon(tmp_path):
+    _canon_note(tmp_path, "Betelgeuse", "sun", "LandFeature",
+                {"land_feature_type": "Star"})
+    live = {"id-Betelgeuse": "landfeature"}
+    got = m.canon_location_bindings(str(tmp_path), live_kind_by_id=live)
+    assert got == {"sun": ("landfeature", "Star")}

--- a/tools/mobrpg/tests/test_map.py
+++ b/tools/mobrpg/tests/test_map.py
@@ -625,3 +625,26 @@ def test_entry_notes_a_canon_downgrade():
     out = m._entry(old, fresh, "locationRouting[hyperspace gate]", notes)
     assert out == fresh
     assert any("canon" in n for n in notes)
+
+
+def test_run_learning_treats_non_dict_listing_as_failure(tmp_path, monkeypatch, capsys):
+    # A bare-list (or None) response is not a verified listing; leaving live_loc
+    # authoritative would silently discard every ratified binding.
+    _canon_note(tmp_path, "Betelgeuse", "sun", "LandFeature",
+                {"land_feature_type": "Star"})
+    monkeypatch.setattr(client, "get_access_token", lambda: "tok")
+
+    def stub(method, path, *, token=None, query=None, body=None):
+        if path == "/world":
+            return []
+        if path.endswith("/political") or path.endswith("/landfeature"):
+            return []                       # bare list — not the paged dict shape
+        return {"content": [], "page": {"totalPages": 1}}
+    monkeypatch.setattr(client, "_request", stub)
+
+    mp = str(tmp_path / "map.json")
+    assert m.run(["init", "w1", "--vault", str(tmp_path), "--map", mp,
+                  "--now", "T0"]) == 0
+    data = json.load(open(mp, encoding="utf-8"))
+    assert data["locationRouting"]["sun"]["status"] == "canon"
+    assert "WARNING" in capsys.readouterr().err

--- a/tools/mobrpg/tests/test_sync.py
+++ b/tools/mobrpg/tests/test_sync.py
@@ -660,3 +660,31 @@ def test_stored_ref_still_marks_the_note_pending(tmp_path, monkeypatch):
     assert sync_cmd.run(["w1", "--vault", str(v), "--execute"]) == 0
     nd = _node.read_node(p.read_text(encoding="utf-8"))
     assert nd["review_state"] == "pending"
+
+
+def test_show_body_prints_the_push_payload(tmp_path, monkeypatch, capsys):
+    # (#184) nothing in the dry-run showed the description body being pushed
+    # into someone else's review queue; --show-body prints exactly what would
+    # be sent, vault-only tail already stripped.
+    v = _vault(tmp_path)
+    p = v / "Creatures" / "marsh-hag.md"
+    os.utime(p, None)  # vault freshly edited -> push decision
+    detail = {"description": "<p>Stale server text.</p>",
+              "lastModified": "2026-07-21T00:00:00Z"}
+    _wire(monkeypatch, detail, [])
+    rc = sync_cmd.run(["w1", "--vault", str(v), "--show-body"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Old vault prose." in out
+    assert "Secret plans." not in out       # GM Notes never shown as push body
+
+
+def test_without_show_body_the_payload_stays_out_of_the_table(tmp_path, monkeypatch, capsys):
+    v = _vault(tmp_path)
+    p = v / "Creatures" / "marsh-hag.md"
+    os.utime(p, None)
+    detail = {"description": "<p>Stale server text.</p>",
+              "lastModified": "2026-07-21T00:00:00Z"}
+    _wire(monkeypatch, detail, [])
+    sync_cmd.run(["w1", "--vault", str(v)])
+    assert "Old vault prose." not in capsys.readouterr().out

--- a/tools/mobrpg/tests/test_write.py
+++ b/tools/mobrpg/tests/test_write.py
@@ -83,3 +83,22 @@ def test_write_overwrite_flag_replaces_existing_note(tmp_path):
 
     assert rc == 0
     assert "A smuggler." in existing.read_text(encoding="utf-8")
+
+
+def test_write_reports_unsupported_kinds(tmp_path, capsys):
+    # An extract entity of a kind write can't map was dropped without a trace,
+    # making the written+skipped summary look like a complete accounting.
+    extract = {"entities": [
+        {"kind": "person", "name": "Vela Kesh", "body_md": "", "relationships": [],
+         "altNames": [], "notes_public": [], "notes_gm": [], "classifiers": []},
+        {"kind": "creature", "name": "Void Maw", "body_md": "", "relationships": [],
+         "altNames": [], "notes_public": [], "notes_gm": [], "classifiers": []},
+    ]}
+    src = tmp_path / "extract.json"
+    src.write_text(json.dumps(extract), encoding="utf-8")
+
+    rc = write_cmd.run([str(src), "--out", str(tmp_path / "vault")])
+
+    assert rc == 0
+    printed = capsys.readouterr().out
+    assert "unsupported kind" in printed

--- a/tools/mobrpg/tests/test_write.py
+++ b/tools/mobrpg/tests/test_write.py
@@ -82,7 +82,9 @@ def test_write_overwrite_flag_replaces_existing_note(tmp_path):
     rc = write_cmd.run([str(src), "--out", str(out), "--overwrite"])
 
     assert rc == 0
-    assert "A smuggler." in existing.read_text(encoding="utf-8")
+    txt = existing.read_text(encoding="utf-8")
+    assert "A smuggler." in txt
+    assert "old" not in txt          # wholesale replacement, not an append
 
 
 def test_write_reports_unsupported_kinds(tmp_path, capsys):
@@ -102,3 +104,23 @@ def test_write_reports_unsupported_kinds(tmp_path, capsys):
     assert rc == 0
     printed = capsys.readouterr().out
     assert "unsupported kind" in printed
+
+
+def test_write_reports_slug_collisions(tmp_path, capsys):
+    # slug() maps "A/B" and "AB" to the same file; the second must not silently
+    # vanish (default) or silently replace the first (--overwrite).
+    extract = {"entities": [
+        {"kind": "person", "name": "A/B", "body_md": "first", "relationships": [],
+         "altNames": [], "notes_public": [], "notes_gm": [], "classifiers": []},
+        {"kind": "person", "name": "AB", "body_md": "second", "relationships": [],
+         "altNames": [], "notes_public": [], "notes_gm": [], "classifiers": []},
+    ]}
+    src = tmp_path / "extract.json"
+    src.write_text(json.dumps(extract), encoding="utf-8")
+
+    rc = write_cmd.run([str(src), "--out", str(tmp_path / "vault")])
+
+    assert rc == 0
+    printed = capsys.readouterr().out
+    assert "collision" in printed
+    assert "A/B" in printed and "AB" in printed

--- a/tools/mobrpg/tests/test_write.py
+++ b/tools/mobrpg/tests/test_write.py
@@ -40,3 +40,46 @@ def test_faction_part_of_scalar_is_derived_from_the_edge(tmp_path):
     assert part_of == 'part_of: "[[The_Ashen_Hand]]"', part_of   # slug style, as parent_location
     # and the edge is still present — scalar and edge agree, not one or the other
     assert "type: part_of" in txt
+
+
+def test_write_skips_existing_note_without_overwrite(tmp_path, capsys):
+    # (#186) `write` had no existence check: any note whose path matched an
+    # entity in the extract was replaced wholesale, hand-authored prose and all.
+    extract = {"entities": [{
+        "kind": "person", "name": "Vela Kesh", "body_md": "A smuggler.",
+        "relationships": [], "altNames": [],
+        "notes_public": [], "notes_gm": [], "classifiers": [],
+    }]}
+    src = tmp_path / "extract.json"
+    src.write_text(json.dumps(extract), encoding="utf-8")
+    out = tmp_path / "vault"
+    existing = out / "Characters/NPCs/Vela_Kesh.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("HAND-AUTHORED — do not clobber\n", encoding="utf-8")
+
+    rc = write_cmd.run([str(src), "--out", str(out)])
+
+    assert rc == 0
+    assert existing.read_text(encoding="utf-8") == "HAND-AUTHORED — do not clobber\n"
+    printed = capsys.readouterr().out
+    assert "--overwrite" in printed          # tells the user how to replace
+    assert "skipped" in printed
+
+
+def test_write_overwrite_flag_replaces_existing_note(tmp_path):
+    extract = {"entities": [{
+        "kind": "person", "name": "Vela Kesh", "body_md": "A smuggler.",
+        "relationships": [], "altNames": [],
+        "notes_public": [], "notes_gm": [], "classifiers": [],
+    }]}
+    src = tmp_path / "extract.json"
+    src.write_text(json.dumps(extract), encoding="utf-8")
+    out = tmp_path / "vault"
+    existing = out / "Characters/NPCs/Vela_Kesh.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("old\n", encoding="utf-8")
+
+    rc = write_cmd.run([str(src), "--out", str(out), "--overwrite"])
+
+    assert rc == 0
+    assert "A smuggler." in existing.read_text(encoding="utf-8")

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -380,6 +380,16 @@ h3 {
   padding: 3rem 1.5rem 1.5rem;
   background: linear-gradient(transparent 0%, rgba(0,0,0,0.7) 50%, rgba(0,0,0,0.85) 100%);
   color: #fff;
+  /* The overlay stacks above .hero-banner-img and would otherwise swallow
+     every click over the lower banner, so the lightbox never opened where a
+     reader actually clicks (#183). Interactive children get hit-testing back. */
+  pointer-events: none;
+}
+.hero-banner-overlay a,
+.hero-banner-overlay button,
+.hero-banner-overlay input,
+.hero-banner-overlay select {
+  pointer-events: auto;
 }
 .hero-banner h1 {
   font-size: 1.75rem;

--- a/tools/publish/css/style.css
+++ b/tools/publish/css/style.css
@@ -3066,6 +3066,39 @@ tr:nth-child(even) {
 .flow { column-count: 2; column-gap: 16px; }
 @media (max-width: 760px) { .flow { column-count: 1; } }
 
+/* === Identity band ===
+   Physical description (height/weight/hair/eyes/...). Spans the full sheet width
+   above the two-column flow, so it stays wide and thin instead of becoming a tall
+   tile inside one column. */
+.identity-band { margin: 0 0 16px; }
+.identity-band .id-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: 1px;
+  background: var(--border);
+}
+.identity-band .id-cell {
+  background: var(--bg-card);
+  padding: 6px 11px 7px;
+  min-width: 0;
+}
+.identity-band .id-l {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+.identity-band .id-v {
+  font-size: 13px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 480px) {
+  .identity-band .id-grid { grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr)); }
+}
+
 /* === Block tiles === */
 .blk {
   break-inside: avoid;

--- a/tools/publish/lib/templates/coc/layout.js
+++ b/tools/publish/lib/templates/coc/layout.js
@@ -26,7 +26,9 @@ function nameHtml(name) {
 function pad2(v) {
   if (v == null) return '';
   const n = Number(v);
-  return Number.isFinite(n) && n >= 0 && n < 10 ? `0${n}` : String(v);
+  // Non-numeric values are interpolated into skill rows; decodeEntities at the
+  // parse boundary means they can now hold real markup characters — escape them.
+  return Number.isFinite(n) && n >= 0 && n < 10 ? `0${n}` : escapeHtml(String(v));
 }
 
 function pct(part, whole) {
@@ -302,4 +304,4 @@ function buildEquipment(model, sections) {
     `<h2 class="section">Wealth <span class="rule"></span></h2>${wealth}`;
 }
 
-module.exports = { buildStatusBar, buildSheet, buildRecord, buildEquipment };
+module.exports = { buildStatusBar, buildSheet, buildRecord, buildEquipment, pad2 };

--- a/tools/publish/lib/templates/gurps/blocks/equipment.js
+++ b/tools/publish/lib/templates/gurps/blocks/equipment.js
@@ -31,7 +31,7 @@ function loadoutTable(loadout) {
     ? `<tr class="totals-row"><td class="eq-toggle-cell"></td><td></td><td><strong>Totals</strong></td><td class="num"><strong>${escapeHtml(String(loadout.totalCost ?? ''))}</strong></td><td class="num"><strong>${escapeHtml(String(loadout.totalWeight ?? ''))}</strong></td></tr>`
     : '';
   const inner = `<table class="equip-table loadout-table"><thead><tr><th class="eq-toggle-cell"></th><th class="num">Qty</th><th>Item</th><th class="num">Cost</th><th class="num">Weight</th></tr></thead><tbody>${rows}${totals}</tbody></table>`;
-  return wide('table', `Load-Out: ${loadout.name}`, inner);
+  return wide('table', `Load-Out: ${escapeHtml(String(loadout.name || ''))}`, inner);
 }
 
 function renderEquipment(model) {

--- a/tools/publish/lib/templates/gurps/blocks/equipment.js
+++ b/tools/publish/lib/templates/gurps/blocks/equipment.js
@@ -31,7 +31,8 @@ function loadoutTable(loadout) {
     ? `<tr class="totals-row"><td class="eq-toggle-cell"></td><td></td><td><strong>Totals</strong></td><td class="num"><strong>${escapeHtml(String(loadout.totalCost ?? ''))}</strong></td><td class="num"><strong>${escapeHtml(String(loadout.totalWeight ?? ''))}</strong></td></tr>`
     : '';
   const inner = `<table class="equip-table loadout-table"><thead><tr><th class="eq-toggle-cell"></th><th class="num">Qty</th><th>Item</th><th class="num">Cost</th><th class="num">Weight</th></tr></thead><tbody>${rows}${totals}</tbody></table>`;
-  return wide('table', `Load-Out: ${escapeHtml(String(loadout.name || ''))}`, inner);
+  // wide() escapes its title — escaping here too double-escaped the name (review find).
+    return wide('table', `Load-Out: ${loadout.name || ''}`, inner);
 }
 
 function renderEquipment(model) {

--- a/tools/publish/lib/templates/gurps/blocks/identity.js
+++ b/tools/publish/lib/templates/gurps/blocks/identity.js
@@ -18,7 +18,7 @@ function orderedEntries(identity) {
 // who the character physically is before any of the numbers.
 function renderIdentity(model) {
   const identity = model.identity || {};
-  const entries = orderedEntries(identity).filter(([, v]) => String(v || '').trim());
+  const entries = orderedEntries(identity).filter(([, v]) => v != null && String(v).trim());
   if (entries.length === 0) return null;
   const cells = entries.map(([k, v]) =>
     `<div class="id-cell"><div class="id-l">${escapeHtml(k)}</div><div class="id-v">${escapeHtml(String(v))}</div></div>`

--- a/tools/publish/lib/templates/gurps/blocks/identity.js
+++ b/tools/publish/lib/templates/gurps/blocks/identity.js
@@ -1,0 +1,29 @@
+const { escapeHtml } = require('../../../processor');
+
+// Physical description reads best in a fixed order regardless of how the sheet's
+// own table happens to be sorted; anything unrecognised follows in source order.
+const PREFERRED_ORDER = [
+  'Age', 'Gender', 'Height', 'Weight', 'Build', 'Hair', 'Eyes', 'Skin',
+  'Handedness', 'Appearance', 'Birthday', 'Religion', 'Status', 'Reputation', 'TL',
+];
+
+function orderedEntries(identity) {
+  const keys = Object.keys(identity);
+  const known = PREFERRED_ORDER.filter(k => keys.includes(k));
+  const rest = keys.filter(k => !PREFERRED_ORDER.includes(k));
+  return [...known, ...rest].map(k => [k, identity[k]]);
+}
+
+// A full-width band that sits above the two-column flow, so the sheet opens on
+// who the character physically is before any of the numbers.
+function renderIdentity(model) {
+  const identity = model.identity || {};
+  const entries = orderedEntries(identity).filter(([, v]) => String(v || '').trim());
+  if (entries.length === 0) return null;
+  const cells = entries.map(([k, v]) =>
+    `<div class="id-cell"><div class="id-l">${escapeHtml(k)}</div><div class="id-v">${escapeHtml(String(v))}</div></div>`
+  ).join('');
+  return `<section class="blk cat-attr identity-band"><h2>Appearance</h2><div class="id-grid">${cells}</div></section>`;
+}
+
+module.exports = { renderIdentity };

--- a/tools/publish/lib/templates/gurps/layout.js
+++ b/tools/publish/lib/templates/gurps/layout.js
@@ -1,5 +1,6 @@
 const { escapeHtml } = require('../../processor');
 const { renderAttributes } = require('./blocks/attributes');
+const { renderIdentity } = require('./blocks/identity');
 const { renderLiftingFeats, renderSlamTable } = require('./blocks/lifting');
 const { renderSenses } = require('./blocks/senses');
 const { renderDefenses } = require('./blocks/defenses');
@@ -34,8 +35,11 @@ function buildSheet(model) {
     renderSkills(model), renderTechniques(model), renderSpells(model), renderPoints(model),
   ].filter(Boolean);
   const wideBlocks = [renderMelee(model), renderRanged(model), renderGrimoire(model)].filter(Boolean);
-  if (flow.length === 0 && wideBlocks.length === 0) return null;
-  return `<div class="gurps-sheet"><div class="flow">${flow.join('\n')}</div>${wideBlocks.join('\n')}</div>`;
+  // Full-width and above the flow: the physical description leads the sheet rather
+  // than getting buried mid-column.
+  const identity = renderIdentity(model) || '';
+  if (flow.length === 0 && wideBlocks.length === 0 && !identity) return null;
+  return `<div class="gurps-sheet">${identity}<div class="flow">${flow.join('\n')}</div>${wideBlocks.join('\n')}</div>`;
 }
 
 function buildCombat(model, sections) {

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -278,6 +278,8 @@ function parseSenses(model, sections, fm) {
     extractSubsectionHtml(sec.html, 'Senses and Checks') || '';
   for (const row of parseTableRows(subHtml)) {
     if (isHeaderRow(row)) continue;   // not slice(1): a header-less table keeps its first row
+    // Senses tables also use headers isHeaderRow doesn't know (`Sense | Check`).
+    if (/^senses?$/i.test(row[0] || '') && /^(check|value|score|roll)s?$/i.test(row[1] || '')) continue;
     if (row.length >= 2 && row[0]) model.senses[row[0]] = row[1];
   }
 }

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -33,7 +33,7 @@ function isHeaderRow(row) {
   if (row.length < 2) return false;
   const c0 = row[0].toLowerCase();
   const c1 = row[1].toLowerCase();
-  return /^(characteristic|attribute|trait|name)$/.test(c0) || /^(value|score)$/.test(c1);
+  return /^(characteristic|attribute|trait|name|field)$/.test(c0) || /^(value|score|detail)$/.test(c1);
 }
 
 function parseAttributes(model, sections, fm) {
@@ -232,22 +232,35 @@ const IDENTITY_SUBSECTIONS = [
 ];
 
 function parseIdentity(model, sections, fm) {
-  const fmSource = fm.appearance || fm.identity;
-  if (fmSource && typeof fmSource === 'object' && !Array.isArray(fmSource)) {
-    for (const [k, v] of Object.entries(fmSource)) model.identity[k] = String(v);
-    return;
+  // Frontmatter: objects merge in (appearance, then identity); a plain string
+  // becomes the band's Appearance/Identity entry instead of shadowing the
+  // other key (`||` used to consume the slot and drop the object silently).
+  let fromFmObject = false;
+  for (const [key, label] of [['appearance', 'Appearance'], ['identity', 'Identity']]) {
+    const src = fm[key];
+    if (src && typeof src === 'object' && !Array.isArray(src)) {
+      for (const [k, v] of Object.entries(src)) model.identity[k] = String(v);
+      fromFmObject = true;
+    } else if (typeof src === 'string' && src.trim()) {
+      model.identity[label] = src.trim();
+    }
   }
+  if (fromFmObject) return;
   const sec = findSectionByTitle(sections, 'stat sheet');
   if (!sec) return;
-  let subHtml = '';
+  // Merge EVERY recognised sub-table: the aliases are alternative names sheets
+  // use, not a priority list — a sheet carrying both `Appearance & Social` and
+  // `Physical Description` renders all of it. Columns beyond the second are
+  // kept, joined onto the value.
   for (const title of IDENTITY_SUBSECTIONS) {
-    subHtml = extractSubsectionHtml(sec.html, title);
-    if (subHtml) break;
-  }
-  if (!subHtml) return;
-  for (const row of parseTableRows(subHtml)) {
-    if (isHeaderRow(row)) continue;
-    if (row.length >= 2 && row[0] && row[1]) model.identity[row[0]] = row[1];
+    const subHtml = extractSubsectionHtml(sec.html, title);
+    if (!subHtml) continue;
+    for (const row of parseTableRows(subHtml)) {
+      if (isHeaderRow(row)) continue;
+      if (row.length >= 2 && row[0] && row[1]) {
+        model.identity[row[0]] = row.slice(1).filter(c => c && c.trim()).join(' — ');
+      }
+    }
   }
 }
 
@@ -261,8 +274,10 @@ function parseSenses(model, sections, fm) {
   // `Appearance & Social` belongs to parseIdentity — reading it here labelled every
   // sheet's physical description "Senses & Checks".
   const subHtml = extractSubsectionHtml(sec.html, 'Senses') ||
-    extractSubsectionHtml(sec.html, 'Senses & Checks') || '';
-  for (const row of parseTableRows(subHtml).slice(1)) {
+    extractSubsectionHtml(sec.html, 'Senses & Checks') ||
+    extractSubsectionHtml(sec.html, 'Senses and Checks') || '';
+  for (const row of parseTableRows(subHtml)) {
+    if (isHeaderRow(row)) continue;   // not slice(1): a header-less table keeps its first row
     if (row.length >= 2 && row[0]) model.senses[row[0]] = row[1];
   }
 }

--- a/tools/publish/lib/templates/gurps/parse.js
+++ b/tools/publish/lib/templates/gurps/parse.js
@@ -223,6 +223,34 @@ function parseTraits(model, sections, fm) {
   }
 }
 
+// Height/weight/eyes/hair and the rest of the physical description. Sheets carry
+// it as a `### Appearance & Social` sub-table under `## Stat Sheet`; these aliases
+// cover the other names sheets use for the same table.
+const IDENTITY_SUBSECTIONS = [
+  'Appearance & Social', 'Appearance and Social', 'Appearance',
+  'Physical Description', 'Description', 'Identity',
+];
+
+function parseIdentity(model, sections, fm) {
+  const fmSource = fm.appearance || fm.identity;
+  if (fmSource && typeof fmSource === 'object' && !Array.isArray(fmSource)) {
+    for (const [k, v] of Object.entries(fmSource)) model.identity[k] = String(v);
+    return;
+  }
+  const sec = findSectionByTitle(sections, 'stat sheet');
+  if (!sec) return;
+  let subHtml = '';
+  for (const title of IDENTITY_SUBSECTIONS) {
+    subHtml = extractSubsectionHtml(sec.html, title);
+    if (subHtml) break;
+  }
+  if (!subHtml) return;
+  for (const row of parseTableRows(subHtml)) {
+    if (isHeaderRow(row)) continue;
+    if (row.length >= 2 && row[0] && row[1]) model.identity[row[0]] = row[1];
+  }
+}
+
 function parseSenses(model, sections, fm) {
   if (fm.senses && typeof fm.senses === 'object') {
     for (const [k, v] of Object.entries(fm.senses)) model.senses[k] = String(v);
@@ -230,8 +258,10 @@ function parseSenses(model, sections, fm) {
   }
   const sec = findSectionByTitle(sections, 'stat sheet');
   if (!sec) return;
-  const subHtml = extractSubsectionHtml(sec.html, 'Appearance & Social') ||
-    extractSubsectionHtml(sec.html, 'Senses') || '';
+  // `Appearance & Social` belongs to parseIdentity — reading it here labelled every
+  // sheet's physical description "Senses & Checks".
+  const subHtml = extractSubsectionHtml(sec.html, 'Senses') ||
+    extractSubsectionHtml(sec.html, 'Senses & Checks') || '';
   for (const row of parseTableRows(subHtml).slice(1)) {
     if (row.length >= 2 && row[0]) model.senses[row[0]] = row[1];
   }
@@ -919,6 +949,7 @@ function parseGurps(frontmatter, sections) {
   parseSkills(model, secs, fm);
   parseTechniques(model, secs, fm);
   parseTraits(model, secs, fm);
+  parseIdentity(model, secs, fm);
   parseSenses(model, secs, fm);
   parseDefenses(model, secs, fm);
   parseEncumbrance(model, secs, fm);

--- a/tools/publish/lib/templates/gurps/tables.js
+++ b/tools/publish/lib/templates/gurps/tables.js
@@ -16,9 +16,14 @@ function decodeEntities(text) {
         const cp = body[1] === 'x' || body[1] === 'X'
           ? parseInt(body.slice(2), 16)
           : parseInt(body.slice(1), 10);
-        return Number.isInteger(cp) && cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : whole;
+        const valid = Number.isInteger(cp) && cp > 0 && cp <= 0x10ffff
+          && !(cp >= 0xd800 && cp <= 0xdfff);   // lone surrogates are not scalar values
+        return valid ? String.fromCodePoint(cp) : whole;
       }
-      const named = NAMED_ENTITIES[body.toLowerCase()];
+      const key = body.toLowerCase();
+      // own-property only: '&constructor;' must not stringify Object.prototype members
+      const named = Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, key)
+        ? NAMED_ENTITIES[key] : undefined;
       return named === undefined ? whole : named;
     },
   );

--- a/tools/publish/lib/templates/gurps/tables.js
+++ b/tools/publish/lib/templates/gurps/tables.js
@@ -1,7 +1,9 @@
 // Table cells arrive as rendered HTML, so their text still carries entities
 // (`&quot;`, `&amp;`, `&#39;`). Blocks escape again on the way out, so a height of
 // `6'2"` reached the page as the literal `6&quot;`. Decode at the parse boundary:
-// everything downstream treats a cell as plain text.
+// everything downstream treats a cell as plain text. (The named table covers
+// what the markdown renderer actually emits — its own escape set — plus
+// numeric/hex forms; other named entities pass through as literal text.)
 const NAMED_ENTITIES = {
   amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: '\u00a0',
 };

--- a/tools/publish/lib/templates/gurps/tables.js
+++ b/tools/publish/lib/templates/gurps/tables.js
@@ -1,3 +1,27 @@
+// Table cells arrive as rendered HTML, so their text still carries entities
+// (`&quot;`, `&amp;`, `&#39;`). Blocks escape again on the way out, so a height of
+// `6'2"` reached the page as the literal `6&quot;`. Decode at the parse boundary:
+// everything downstream treats a cell as plain text.
+const NAMED_ENTITIES = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: '\u00a0',
+};
+
+function decodeEntities(text) {
+  return String(text == null ? '' : text).replace(
+    /&(#\d+|#x[0-9a-f]+|[a-z][a-z0-9]*);/gi,
+    (whole, body) => {
+      if (body[0] === '#') {
+        const cp = body[1] === 'x' || body[1] === 'X'
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10);
+        return Number.isInteger(cp) && cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : whole;
+      }
+      const named = NAMED_ENTITIES[body.toLowerCase()];
+      return named === undefined ? whole : named;
+    },
+  );
+}
+
 function parseTableRows(html) {
   const rows = [];
   const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
@@ -7,7 +31,7 @@ function parseTableRows(html) {
     const cellRegex = /<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi;
     let cellMatch;
     while ((cellMatch = cellRegex.exec(rowMatch[1])) !== null) {
-      cells.push(cellMatch[1].replace(/<[^>]+>/g, '').trim());
+      cells.push(decodeEntities(cellMatch[1].replace(/<[^>]+>/g, '')).trim());
     }
     if (cells.length > 0) rows.push(cells);
   }
@@ -82,4 +106,4 @@ function extractSubsectionHtml(sectionHtml, subsectionTitle) {
   return match ? match[1] : '';
 }
 
-module.exports = { parseTableRows, parseTables, countTables, normalizeTitle, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings };
+module.exports = { decodeEntities, parseTableRows, parseTables, countTables, normalizeTitle, findSectionByTitle, extractSubsectionHtml, topLevelHtml, aboveSubheadings };

--- a/tools/publish/node_modules/.cache/wrangler/pages.json
+++ b/tools/publish/node_modules/.cache/wrangler/pages.json
@@ -1,0 +1,4 @@
+{
+  "account_id": "1f9bb275dcf2dfed029f66892e5e63e4",
+  "project_name": "gurps-special-forces"
+}

--- a/tools/publish/node_modules/.cache/wrangler/pages.json
+++ b/tools/publish/node_modules/.cache/wrangler/pages.json
@@ -1,4 +1,0 @@
-{
-  "account_id": "1f9bb275dcf2dfed029f66892e5e63e4",
-  "project_name": "gurps-special-forces"
-}

--- a/tools/publish/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/tools/publish/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.11","results":[[":test/change-request-logic.test.js",{"duration":0,"failed":true}],[":test/change-request-widget.test.js",{"duration":0,"failed":true}]]}

--- a/tools/publish/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/tools/publish/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.11","results":[[":test/change-request-logic.test.js",{"duration":0,"failed":true}],[":test/change-request-widget.test.js",{"duration":0,"failed":true}]]}

--- a/tools/publish/package.json
+++ b/tools/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-apprentice-publish",
-  "version": "1.11.26",
+  "version": "1.11.27",
   "description": "Static site generator for gm-apprentice campaign vaults",
   "main": "lib/index.js",
   "bin": {

--- a/tools/publish/test/unit/coc-layout.test.js
+++ b/tools/publish/test/unit/coc-layout.test.js
@@ -36,3 +36,13 @@ describe('buildSheet', () => {
     assert.ok(html.includes('coc-charsheet'));
   });
 });
+
+describe('pad2', () => {
+  const { pad2 } = require('../../lib/templates/coc/layout');
+  it('escapes non-numeric values (decodeEntities can hand it real markup)', () => {
+    assert.strictEqual(pad2('<img src=x>'), '&lt;img src=x&gt;');
+  });
+  it('still zero-pads small numbers', () => {
+    assert.strictEqual(pad2(7), '07');
+  });
+});

--- a/tools/publish/test/unit/gurps/blocks.equipment.test.js
+++ b/tools/publish/test/unit/gurps/blocks.equipment.test.js
@@ -109,3 +109,21 @@ describe('renderEquipment', () => {
     assert.ok(html.includes('<td>Iron</td>'), 'notes cell for Rations');
   });
 });
+
+describe('renderEquipment escaping', () => {
+  it('escapes the load-out name exactly once', () => {
+    const html = renderEquipment({
+      equipment: {
+        items: [],
+        loadouts: [{
+          name: 'Fitz & Co "Heavy"',
+          items: [{ qty: '1', name: 'Rope', cost: '$5', weight: '1 lb', location: null, notes: null }],
+          totalCost: '$5', totalWeight: '1 lb',
+        }],
+      },
+    });
+    assert.ok(html.includes('Load-Out: Fitz &amp; Co &quot;Heavy&quot;'),
+      'name should be escaped once');
+    assert.ok(!html.includes('&amp;amp;'), 'name must not be double-escaped');
+  });
+});

--- a/tools/publish/test/unit/gurps/blocks.identity.test.js
+++ b/tools/publish/test/unit/gurps/blocks.identity.test.js
@@ -145,3 +145,25 @@ describe('parseSenses aliases', () => {
     assert.strictEqual(model.senses.Vision, '13');
   });
 });
+
+describe('renderIdentity falsey values', () => {
+  it('keeps numeric 0 and boolean false', () => {
+    const html = renderIdentity({ identity: { Dependents: 0, Literate: false } });
+    assert.ok(html.includes('Dependents'));
+    assert.ok(html.includes('>0<'));
+    assert.ok(html.includes('Literate'));
+  });
+});
+
+describe('parseSenses header detection', () => {
+  it('does not store a "Sense | Check" header as a sense', () => {
+    const sheet = {
+      title: 'Stat Sheet', id: 'stat-sheet',
+      html: '<h3>Senses</h3><table><tr><td>Sense</td><td>Check</td></tr>' +
+            '<tr><td>Vision</td><td>13</td></tr></table>',
+    };
+    const model = parseGurps({}, [sheet]);
+    assert.strictEqual(model.senses.Vision, '13');
+    assert.ok(!('Sense' in model.senses));
+  });
+});

--- a/tools/publish/test/unit/gurps/blocks.identity.test.js
+++ b/tools/publish/test/unit/gurps/blocks.identity.test.js
@@ -1,0 +1,93 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { renderIdentity } = require('../../../lib/templates/gurps/blocks/identity');
+const { parseGurps } = require('../../../lib/templates/gurps/parse');
+const { buildSheet } = require('../../../lib/templates/gurps/layout');
+
+const appearanceSheet = {
+  title: 'Stat Sheet', id: 'stat-sheet',
+  html: '<h3>Primary Attributes</h3><table><tr><th>Attribute</th><th>Score</th></tr>' +
+        '<tr><td>ST</td><td>13</td></tr></table>' +
+        '<h3>Appearance &amp; Social</h3>' +
+        '<table><tr><th>Trait</th><th>Value</th></tr>' +
+        '<tr><td>Religion</td><td>None</td></tr>' +
+        '<tr><td>Height</td><td>6&#39;2&quot;</td></tr>' +
+        '<tr><td>Weight</td><td>215 lb</td></tr>' +
+        '<tr><td>Eyes</td><td>Pale grey</td></tr>' +
+        '<tr><td>Batch</td><td>MACE-06</td></tr></table>',
+};
+
+describe('renderIdentity', () => {
+  it('returns null when there is no identity data', () => {
+    assert.strictEqual(renderIdentity({ identity: {} }), null);
+    assert.strictEqual(renderIdentity({}), null);
+  });
+
+  it('drops keys whose value is blank', () => {
+    const html = renderIdentity({ identity: { Height: '6\'2"', Weight: '   ' } });
+    assert.ok(html.includes('Height'));
+    assert.ok(!html.includes('Weight'));
+  });
+
+  it('orders physical description ahead of the rest, extras last', () => {
+    const html = renderIdentity({
+      identity: { Religion: 'None', Batch: 'MACE-06', Height: '6\'2"', Eyes: 'Pale grey' },
+    });
+    const order = ['Height', 'Eyes', 'Religion', 'Batch'].map(k => html.indexOf(`>${k}<`));
+    assert.deepStrictEqual(order, [...order].sort((a, b) => a - b));
+    assert.ok(order.every(i => i > -1));
+  });
+
+  it('escapes values exactly once', () => {
+    const html = renderIdentity({ identity: { Height: '6\'2"' } });
+    assert.ok(html.includes('6\'2&quot;'));
+    assert.ok(!html.includes('&amp;quot;'));
+  });
+});
+
+describe('parseIdentity', () => {
+  it('reads the Appearance & Social sub-table into model.identity', () => {
+    const model = parseGurps({}, [appearanceSheet]);
+    assert.strictEqual(model.identity.Height, '6\'2"');
+    assert.strictEqual(model.identity.Weight, '215 lb');
+    assert.strictEqual(model.identity.Eyes, 'Pale grey');
+  });
+
+  it('drops the header row rather than the first real row', () => {
+    const model = parseGurps({}, [appearanceSheet]);
+    assert.strictEqual(model.identity.Religion, 'None');
+    assert.ok(!('Trait' in model.identity));
+  });
+
+  it('leaves senses empty when the sheet has no Senses sub-table', () => {
+    const model = parseGurps({}, [appearanceSheet]);
+    assert.deepStrictEqual(model.senses, {});
+  });
+
+  it('still reads a real Senses sub-table', () => {
+    const sheet = {
+      title: 'Stat Sheet', id: 'stat-sheet',
+      html: '<h3>Senses</h3><table><tr><th>Sense</th><th>Value</th></tr>' +
+            '<tr><td>Vision</td><td>13</td></tr></table>',
+    };
+    const model = parseGurps({}, [sheet]);
+    assert.strictEqual(model.senses.Vision, '13');
+    assert.deepStrictEqual(model.identity, {});
+  });
+
+  it('accepts an appearance object in frontmatter', () => {
+    const model = parseGurps({ appearance: { Height: '5\'6"', Eyes: 'Brown' } }, []);
+    assert.strictEqual(model.identity.Height, '5\'6"');
+  });
+});
+
+describe('identity band placement', () => {
+  it('renders full width above the two-column flow', () => {
+    const html = buildSheet(parseGurps({}, [appearanceSheet]));
+    const band = html.indexOf('identity-band');
+    const flow = html.indexOf('<div class="flow">');
+    assert.ok(band > -1, 'band renders');
+    assert.ok(flow > -1, 'flow renders');
+    assert.ok(band < flow, 'band precedes the flow');
+  });
+});

--- a/tools/publish/test/unit/gurps/blocks.identity.test.js
+++ b/tools/publish/test/unit/gurps/blocks.identity.test.js
@@ -91,3 +91,57 @@ describe('identity band placement', () => {
     assert.ok(band < flow, 'band precedes the flow');
   });
 });
+
+describe('parseIdentity completeness', () => {
+  it('merges every recognised identity sub-table, not just the first', () => {
+    const sheet = {
+      title: 'Stat Sheet', id: 'stat-sheet',
+      html: '<h3>Appearance &amp; Social</h3><table><tr><th>Trait</th><th>Value</th></tr>' +
+            '<tr><td>Height</td><td>6ft</td></tr></table>' +
+            '<h3>Physical Description</h3><table><tr><th>Trait</th><th>Value</th></tr>' +
+            '<tr><td>Hair</td><td>Black</td></tr></table>',
+    };
+    const model = parseGurps({}, [sheet]);
+    assert.strictEqual(model.identity.Height, '6ft');
+    assert.strictEqual(model.identity.Hair, 'Black');
+  });
+
+  it('a string appearance: does not shadow an identity: object', () => {
+    const model = parseGurps(
+      { appearance: 'Tall and weathered', identity: { Height: '6ft' } }, []);
+    assert.strictEqual(model.identity.Height, '6ft');
+    assert.strictEqual(model.identity.Appearance, 'Tall and weathered');
+  });
+
+  it('keeps columns beyond the second', () => {
+    const sheet = {
+      title: 'Stat Sheet', id: 'stat-sheet',
+      html: '<h3>Appearance &amp; Social</h3><table><tr><th>Trait</th><th>Value</th><th>Notes</th></tr>' +
+            '<tr><td>Hair</td><td>Black</td><td>greying</td></tr></table>',
+    };
+    const model = parseGurps({}, [sheet]);
+    assert.ok(model.identity.Hair.includes('Black'));
+    assert.ok(model.identity.Hair.includes('greying'));
+  });
+});
+
+describe('parseSenses aliases', () => {
+  it('reads a "Senses and Checks" heading', () => {
+    const sheet = {
+      title: 'Stat Sheet', id: 'stat-sheet',
+      html: '<h3>Senses and Checks</h3><table><tr><th>Sense</th><th>Value</th></tr>' +
+            '<tr><td>Vision</td><td>13</td></tr></table>',
+    };
+    const model = parseGurps({}, [sheet]);
+    assert.strictEqual(model.senses.Vision, '13');
+  });
+
+  it('does not drop the first senses row when there is no header row', () => {
+    const sheet = {
+      title: 'Stat Sheet', id: 'stat-sheet',
+      html: '<h3>Senses</h3><table><tr><td>Vision</td><td>13</td></tr></table>',
+    };
+    const model = parseGurps({}, [sheet]);
+    assert.strictEqual(model.senses.Vision, '13');
+  });
+});

--- a/tools/publish/test/unit/gurps/tables.test.js
+++ b/tools/publish/test/unit/gurps/tables.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { parseTableRows, findSectionByTitle, extractSubsectionHtml } = require('../../../lib/templates/gurps/tables');
+const { parseTableRows, findSectionByTitle, extractSubsectionHtml, decodeEntities } = require('../../../lib/templates/gurps/tables');
 
 describe('gurps/tables', () => {
   it('parses rendered table rows into cell-text arrays', () => {
@@ -51,5 +51,16 @@ describe('topLevelHtml (issue #82)', () => {
 
   it('is inert on a section with no table at all', () => {
     assert.strictEqual(topLevelHtml('<p>prose</p>'), '<p>prose</p>');
+  });
+});
+
+describe('decodeEntities', () => {
+  it('decodes named, decimal, and hex entities', () => {
+    assert.strictEqual(decodeEntities('6&#39;2&quot;'), '6\'2"');
+    assert.strictEqual(decodeEntities('Smith &amp; Wesson'), 'Smith & Wesson');
+    assert.strictEqual(decodeEntities('&#x41;&#66;'), 'AB');
+  });
+  it('leaves unknown entities untouched', () => {
+    assert.strictEqual(decodeEntities('&bogus; &notanentity'), '&bogus; &notanentity');
   });
 });

--- a/tools/publish/test/unit/gurps/tables.test.js
+++ b/tools/publish/test/unit/gurps/tables.test.js
@@ -64,3 +64,13 @@ describe('decodeEntities', () => {
     assert.strictEqual(decodeEntities('&bogus; &notanentity'), '&bogus; &notanentity');
   });
 });
+
+describe('decodeEntities hardening', () => {
+  const { decodeEntities } = require('../../../lib/templates/gurps/tables');
+  it('leaves surrogate code points literal', () => {
+    assert.strictEqual(decodeEntities('&#55296;'), '&#55296;');
+  });
+  it('does not stringify inherited object members as entities', () => {
+    assert.strictEqual(decodeEntities('&constructor;'), '&constructor;');
+  });
+});


### PR DESCRIPTION
Fixes the seven issues filed from the last game sessions (all but #185, which stays open — see below).

## publish

- **#187** — the GURPS physical description (`### Appearance & Social`) parsed as "Senses & Checks" mid-column; it now leads the sheet as a full-width identity band above the two-column flow, on every GURPS sheet. All recognised identity sub-tables merge (not just the first found), frontmatter strings and maps both contribute, extra columns are kept.
- **#188** — GURPS table cells were double-escaped (`6'2"` shipped as `6’2&quot;`); entities decode at the parse boundary so escaping happens once, at render. The single-escape invariant is now pinned by tests across the blocks, including the load-out heading.
- **#183** — `.hero-banner-overlay` swallowed clicks meant for the banner image; it's out of hit-testing now (interactive children restored), so the lightbox opens anywhere on the banner.

## mobrpg

- **#184** — image embeds are dropped at the push boundary instead of mangled into `!map.png` / `!697` junk landing in the world owner's review queue; new `sync --show-body` prints each push's exact outgoing markdown in the dry run.
- **#182** — a guessed location routing can no longer be learned back as canon: learning requires the determined block to agree with the node's `element_kind` and (via strict live listings) with the element's actual upstream kind, with loud degradation when the listing fails. `adopt` reports an exact-name match in the sibling location kind as its own `kind mismatch` outcome naming the route to fix.
- **#186** — `write` now refuses to overwrite existing vault notes unless `--overwrite`, counts what it skips and what it can't map; `link-orphans` fills (or inserts) the `parent_location:` scalar alongside the `part_of` edge and surfaces disagreeing authored values; README/llms.txt document all of it, including that `images` is pull-only (#185's interim note).

Two independent local review rounds ran against the full diff before push; their findings (a dead-code API-failure fallback that would have silently discarded ratified canon bindings, a reintroduced double-escape, embed-strip word-welding, and several silent drops) are fixed in the last two commits.

**#185** (image upload path) stays open: it needs the mobRPG upload endpoint mapped and a decision on whether attachments should flow through the suggestion review queue.

Tests: mobrpg 526/526, publish 1543/1543 (+18 new), schema/ontology validators, markdownlint.

Closes #182, closes #183, closes #184, closes #186, closes #187, closes #188.