### PR TITLE
Mechanization: delete the prose the scripts replaced; Python 3 required

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the manifest tool shows drift and the exclude-versus-missing call is
   the GM's; run `explain` before `doctor --site` for a single-file
   question.
+- `session_context.py` reported every later session index in the
+  chapter as "unplayed", including ones already played. Later unplayed
+  indexes keep the existing `Note:`; a later session that is already
+  played now gets its own `Note:` saying the selection may be stale.
 - The benchmark fixture vault (`tests/benchmark-campaign/`) gains a
   `_meta/vault-config.md` and its three wrap-ups are migrated to the
   1.9.5 template, so the version gate returns OK and the wrap-up check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.10] — 2026-09-08
+
+### Changed
+
+- **Python 3 is now a required dependency.** The bundled utilities under
+  `skills/shared/scripts/` are standard-library only and need no
+  packages, but the skills no longer carry a by-hand alternative for
+  anything a script does. README updated accordingly.
+- `shared/vault-access.md` cut from 18.3 kB to ~5 kB: the routing table,
+  invocation examples and the post-write validation rule stay; the
+  per-script description paragraphs are replaced by "run it with
+  `--help`". Each script's `--help` was checked against the paragraph it
+  replaces and extended where a flag, row vocabulary, exit code, or
+  how-to-act rule was missing. The proof run
+  (`tests/proof-runs/mechanization/`, v1.9.9 vs v1.9.4 vs prose-stripped)
+  showed the one skill that reads this file ran 27% cheaper and 51%
+  faster without those paragraphs, opening a third fewer files.
+- session-prep now scopes its opening moves to the question asked: the
+  version gate always runs, but the read-set bundle, Reconcile and the
+  vault-wide checks run only for a full prep invocation. A narrow
+  question (document-chain status, thread ages, one plan's conformance)
+  runs the one script that answers it and offers the next step instead
+  of taking it. Fixes the drift the proof run measured on a status
+  question (on-question 2/2 → 1/2 in v1.9.9).
+
+### Removed
+
+- Every "Fallback without python" block across `campaign-organizer`,
+  `campaign-qa` (SKILL.md, `graph-health.md`, `wrapup-conformance.md`),
+  `publish-site`, `session-play`, `session-prep`, `session-wrapup`,
+  `the-midwife` and `vault-ingest`, the manual read-set list in
+  session-prep's Context Source, and the no-python paragraph in
+  `vault-access.md`.
+
+---
+
 ## [1.9.9] — 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session-prep's Context Source, and the no-python paragraph in
   `vault-access.md`.
 
+### Fixed
+
+- `ingest_survey.py` misclassified two of the three benchmark inbox
+  files (surfaced by the proof run). The `charsheet_stats` indicator
+  now matches stats laid out in markdown tables (`| STR | 45 |`) and as
+  bold labels (`**STR:** 50`), not only bare `STR 50`; and a document with play indicators alongside prep, research or
+  Keeper-recollection indicators is proposed as "Play fragment (mixed
+  content — consider a section split)" even when an embedded NPC stat
+  block outscores the play hits — a stat block inside prep notes does
+  not make the file a character sheet. Regression tests run the script
+  over `tests/benchmark-campaign/_inbox/`.
+- `gm-publish sheet show --help`, `manifest --help` and `explain --help`
+  now carry the how-to-act rules the deleted `vault-access.md` prose
+  held: prefer the player-safe view whenever the audience is a player;
+  the manifest tool shows drift and the exclude-versus-missing call is
+  the GM's; run `explain` before `doctor --site` for a single-file
+  question.
+- The benchmark fixture vault (`tests/benchmark-campaign/`) gains a
+  `_meta/vault-config.md` and its three wrap-ups are migrated to the
+  1.9.5 template, so the version gate returns OK and the wrap-up check
+  reports no ERRORs. The deliberate defects the QA benchmarks rely on
+  are untouched.
+
 ---
 
 ## [1.9.9] — 2026-09-07

--- a/README.md
+++ b/README.md
@@ -145,10 +145,13 @@ whenever you want the graph view, backlinks, and a vault UI at the table;
 nothing requires it.
 
 The bundled utilities under `skills/shared/scripts/` give the skills
-ranked search, link-graph audits, schema validation, and more — Python 3
-standard library only, no packages to install. macOS and most Linux ship
-Python 3 already; on Windows, `winget install python`. Python 3 is a
-required dependency of this plugin.
+ranked search, link-graph audits, schema validation, and more — Python
+3.10 or later, standard library only, no packages to install. Python 3 is
+a required dependency of this plugin. The skills invoke it as `python3`
+from Claude Code's Bash tool, which on Windows is Git Bash: macOS and
+most Linux ship `python3` already; on Windows, install Python from the
+Microsoft Store, whose `python3` alias Git Bash finds on PATH (the
+python.org installer provides only `python` and `py`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,11 @@ plugins, or app dependencies. Open it in [Obsidian](https://obsidian.md)
 whenever you want the graph view, backlinks, and a vault UI at the table;
 nothing requires it.
 
-Bundled vault utilities under `skills/shared/scripts/` (Python 3 standard
-library, no install) give the skills ranked search, link-graph audits, and
-schema validation — `vault_search.py`, `graph_check.py`, `vault_check.py`,
-`session_context.py`, and `stamp_entities.py`. Skills invoke them
-automatically when `python3` is on your PATH and fall back to plain search
-when it isn't (macOS and most Linux ship Python 3; on Windows,
-`winget install python`).
+The bundled utilities under `skills/shared/scripts/` give the skills
+ranked search, link-graph audits, schema validation, and more — Python 3
+standard library only, no packages to install. macOS and most Linux ship
+Python 3 already; on Windows, `winget install python`. Python 3 is a
+required dependency of this plugin.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ decision rather than pure score.
   (18.3 kB → ~5 kB, each script's `--help` verified to carry what the
   deleted paragraph said), and session-prep's opening routing scoped to
   the question asked so a status question no longer drifts into a wrap-up
-  audit. plugin v1.9.10
+  audit. PR #200, plugin v1.9.10
 - ~~Mechanization Slice C: ingest survey + image ingestion~~ — Two new
   scripts from the Tier 2 rows of `docs/mechanization-analysis.md` (#12–13),
   turning vault-ingest Phase 1 from "read all source material" into "read

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,16 @@ decision rather than pure score.
 
 ## Completed
 
+- ~~Mechanization prose deletion~~ — The follow-through the proof run
+  (`tests/proof-runs/mechanization/`, v1.9.9 vs v1.9.4 vs prose-stripped:
+  -25% uncached tokens, quality 5.30 → 5.80/6, and a further -15% tokens /
+  -38% wall clock with the prose stripped) said to do: Python 3 made a
+  required dependency, every "Fallback without python" block deleted,
+  `shared/vault-access.md` cut to the routing table plus "run `--help`"
+  (18.3 kB → ~5 kB, each script's `--help` verified to carry what the
+  deleted paragraph said), and session-prep's opening routing scoped to
+  the question asked so a status question no longer drifts into a wrap-up
+  audit. plugin v1.9.10
 - ~~Mechanization Slice C: ingest survey + image ingestion~~ — Two new
   scripts from the Tier 2 rows of `docs/mechanization-analysis.md` (#12–13),
   turning vault-ingest Phase 1 from "read all source material" into "read

--- a/docs/mechanization-analysis.md
+++ b/docs/mechanization-analysis.md
@@ -228,9 +228,8 @@ What it would cost, concretely:
   run needs a bootstrap step the skill must perform before its first real
   call, a version-pairing scheme with the plugin version, and a trust story.
 - **The scripts are living documents.** They change every couple of weeks and
-  the model edits them in-session. A Go binary cannot be hot-patched, needs a
-  toolchain and a CI cross-compile stage per release, and has no "try `python`
-  if `python3` is missing" degradation.
+  the model edits them in-session. A Go binary cannot be hot-patched and needs
+  a toolchain and a CI cross-compile stage per release.
 - **Rewrite cost with no functional gain.** ~10k lines of Python and ~9.4k
   lines of tests to port before any new capability lands.
 - **The biggest mechanization target can't move.** Twenty of the candidates
@@ -253,10 +252,11 @@ nominally offer:
    PCs). This is where the "stdlib only" pain actually lives.
 2. **Type-check in CI.** `mypy --strict` on the shared scripts costs one CI
    step and buys most of what static typing would.
-3. **Keep the Python floor at 3.10** with `from __future__ import annotations`,
-   and keep the documented degradation path (no `python3` → prose fallback)
-   honest by making every prose site *invoke* the script rather than restate
-   it, so the fallback is the only place the restatement lives.
+3. **Keep the Python floor at 3.10** with `from __future__ import annotations`.
+   Python 3 is now a required dependency of the plugin (no-python prose
+   fallback removed); make every prose site *invoke* the script rather than
+   restate it, so the script's own `--help` is the only place that detail
+   lives.
 
 Revisit Go only if a roadmap item needs a long-running server binary that
 cannot be a Cloudflare Worker, or if the plugin's primary audience becomes

--- a/skills/campaign-organizer/SKILL.md
+++ b/skills/campaign-organizer/SKILL.md
@@ -102,10 +102,7 @@ row and tell the GM to update the plugin; do not proceed.
 `ERROR` → report the row; the plugin install is broken — do not
 proceed. No verdict row and a `not a directory` error on stderr
 means the vault path is wrong — ask the GM for it rather than
-proceeding. Fallback without python: read `gm_apprentice_version`
-from `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
+proceeding.
 
 This check runs once per session on first vault contact. It
 does not apply during first-time vault setup (when `_meta/` is
@@ -261,8 +258,7 @@ three-state responses (canon / ignore / defer).
    run hygiene checks.
 7. **Update index** — Full rebuild of `_meta/index.md`: run
    `python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/index_build.py" <vault>`,
-   show the diff summary, then re-run with `--write`. Fallback without
-   python: `references/index-template.md`.
+   show the diff summary, then re-run with `--write`.
 8. **Report** — Counts, stubs, relationships, graph health.
 
 ### Dissect
@@ -291,8 +287,7 @@ three-state responses (canon / ignore / defer).
    `python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/index_build.py" <vault>`,
    show the diff summary, then `--write`. It's the same command as
    Organize's full rebuild — the script is idempotent, so there is no
-   separate incremental mode. Fallback without python:
-   `references/index-template.md`.
+   separate incremental mode.
 7. **Report** — Extracted, stubbed, needs attention.
 
 ### Weave
@@ -314,8 +309,7 @@ Follow `references/world-validation.md`.
    `python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/index_build.py" <vault>`,
    show the diff summary, then `--write`. It's the same command as
    Organize's full rebuild — the script is idempotent, so there is no
-   separate incremental mode. Fallback without python:
-   `references/index-template.md`.
+   separate incremental mode.
 7. **Graph audit** — Read `references/graph-hygiene.md` and
    run full hygiene check.
 

--- a/skills/campaign-organizer/references/index-template.md
+++ b/skills/campaign-organizer/references/index-template.md
@@ -1,7 +1,7 @@
 # Index Template for `_meta/index.md`
 
 `index_build.py` generates this file; the structure below is its output
-contract and the no-python fallback.
+contract.
 
 ```markdown
 ---

--- a/skills/campaign-qa/SKILL.md
+++ b/skills/campaign-qa/SKILL.md
@@ -68,10 +68,7 @@ the row and tell the GM to update the plugin; do not proceed.
 `ERROR` → report the row; the plugin install is broken — do not
 proceed. No verdict row and a `not a directory` error on stderr
 means the vault path is wrong — ask the GM for it rather than
-proceeding. Fallback without python: read `gm_apprentice_version`
-from `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
+proceeding.
 
 Audits run the same procedures on any vault folder — only
 the tools differ. The procedures in `references/checks/`

--- a/skills/campaign-qa/references/checks/graph-health.md
+++ b/skills/campaign-qa/references/checks/graph-health.md
@@ -16,8 +16,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/graph_check.py" \
 It reports orphans, unresolved links, dead ends, and
 ambiguous bare links in one pass (see
 `shared/vault-access.md` for options such as `--folder`
-and `--exclude`). Use the manual steps below only if Python
-is unavailable, and flag that fallback in results.
+and `--exclude`).
 
 ### Step 1: Enumerate Entities and Links
 
@@ -34,9 +33,7 @@ Read all entity files in scope. For each, extract:
 from the graph and probably forgotten.
 
 **Broken links:** what `graph_check.py unresolved` reports —
-wiki-links that point to files that don't exist. Fallback
-without python: search for `[[...]]` patterns across all
-files, then verify each linked target file exists.
+wiki-links that point to files that don't exist.
 
 **Ambiguous links:** what `graph_check.py ambiguous` reports —
 wiki-links using a bare basename that matches more than one
@@ -46,15 +43,12 @@ are added — so this is not a broken link, it's a wrong one
 waiting to happen. Most common cause: Session Wrap-Up files
 still on the pre-migration `Session_NN_Wrap_Up.md` pattern (no
 chapter number) after a second chapter reused a session
-number. Fallback without python: build a basename → file-list
-index across the whole vault, then flag every bare `[[...]]`
-target whose basename maps to more than one file.
+number.
 
 **Index drift:** what `vault_check.py index` reports — files
 not referenced from `_meta/index.md`, and index entries whose
 target file no longer exists. The fix is `index_build.py
 <vault> --write`, never a hand edit to `_meta/index.md`.
-Fallback without python: `campaign-organizer/references/index-template.md`.
 
 **Mirrored edges (duplicates, not gaps):** Storage is
 single-direction (`shared/entity-schema.md`, "Relationship
@@ -96,13 +90,6 @@ configured — draft entities), so this check only flags content
 that would actually reach the site.
 Severity: Critical if the vault has `publish.site_dir`
 configured (it's actually publishing); Warning otherwise.
-
-Fallback without python: search every file for headings (any
-level) and bold-paragraph lines (`**Text:**` with no `#`) whose
-text contains one of the keywords above — case-insensitive —
-and for each match, check whether it sits inside a
-`## GM Notes` section or a `<!-- gm-only -->`/`<!-- spoiler -->`
-fence.
 
 ### Step 3: Schema Compliance
 

--- a/skills/campaign-qa/references/checks/graph-health.md
+++ b/skills/campaign-qa/references/checks/graph-health.md
@@ -14,9 +14,8 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/graph_check.py" \
 ```
 
 It reports orphans, unresolved links, dead ends, and
-ambiguous bare links in one pass (see
-`shared/vault-access.md` for options such as `--folder`
-and `--exclude`).
+ambiguous bare links in one pass (`graph_check.py --help`
+for `--folder` and `--exclude`).
 
 ### Step 1: Enumerate Entities and Links
 

--- a/skills/campaign-qa/references/checks/name-similarity.md
+++ b/skills/campaign-qa/references/checks/name-similarity.md
@@ -3,8 +3,8 @@
 The name similarity check identifies entity names that are
 duplicates, near-duplicates, or confusingly similar.
 
-**Preferred procedure:** run the bundled utility and triage
-its output with the GM:
+**Procedure:** run the bundled utility and triage its output
+with the GM:
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_check.py" \
@@ -21,47 +21,14 @@ Structural documents and document-chain
 families are already filtered out. Your judgment still decides
 which pairs are intentional (married couples, senior/junior)
 versus confusing, and which sound-alikes matter — the script
-does not know which NPCs share a scene (Step 4). Use the manual
-steps below only if Python is unavailable.
+does not know which NPCs share a scene (Step 1).
 
-### Step 1: Collect All Names
-
-Build a complete list of entity names and aliases from the
-vault. For each, record:
-- Canonical name
-- All aliases (from frontmatter `aliases` field)
-- File path
-- Entity type
-
-Enumerate all entity files and read frontmatter from each to
-build this list.
-
-### Step 2: Exact Duplicate Check
-
-Look for entities that share a canonical name or where one
-entity's alias matches another's canonical name. These are
-likely the same entity with two files.
-
-### Step 3: Edit Distance Check
-
-Compare all name pairs. Flag pairs where:
-- Levenshtein distance ≤ 2 (e.g., "Herzfeld" vs "Herzberg")
-- Names differ only in common variations (Dr./Doctor,
-  von/Van, -burg/-berg, -feld/-stein)
-- First or last name matches but the other differs slightly
-
-For large entity sets, limit comparisons to entities of
-the same type to avoid false positives (an NPC named
-"Vienna" vs the location "Vienna" is expected overlap, not
-a duplicate).
-
-### Step 4: Phonetic Similarity Check
+### Step 1: Cross-Type and Untyped Sound-Alikes
 
 At the table, players hear names spoken aloud. The script's
 `PHONETIC` rows cover the consonant-skeleton and misheard-
-consonant cases within an entity type. When working manually —
-or for the cross-type and untyped pairs the script skips —
-flag:
+consonant cases within an entity type. For the cross-type and
+untyped pairs it skips, flag:
 - Same consonant skeleton (remove vowels and compare)
 - Rhyming names
 - Names sharing first syllable and similar length
@@ -73,7 +40,7 @@ in the same scene. Two NPCs named "Adler" and "Adlar" in
 different factions is a problem; "Adler" in Vienna and
 "Adley" in Calcutta is less so.
 
-### Step 5: Compile Findings
+### Step 2: Compile Findings
 
 For each similarity found:
 1. Note both entities, their types, and their files

--- a/skills/campaign-qa/references/checks/wrapup-conformance.md
+++ b/skills/campaign-qa/references/checks/wrapup-conformance.md
@@ -20,24 +20,14 @@ frontmatter backfills, the Keeper-facing sibling H2 re-nest, the
 `<!-- gm-only -->` fence, and the recap/template heading
 variants — the dry-run rows print `WOULD-FIX`; on GM
 confirmation, re-run with `wrapup --fix` (`FIXED` rows apply
-them). Fallback without python: apply the Structural steps in
-`shared/migrations.md`'s 1.9.5 entry by hand — it's the same
-frontmatter-backfill and re-nest procedure this check mechanizes.
+them).
 The steps below cover what the script leaves as judgment calls:
 dateless Reconciliation Context, unreconciled promotion, Section
 order drift, Keeper Checklist semantics, PC Carry-Forward format,
 and filename rename with relinks (filename renames are never
 automatic).
 
-### Step 1: Enumerate Wrap-Ups
-
-Search for files whose frontmatter `type` is `session_wrap`,
-`session-wrap-up`, or `session-wrapup`. Frontmatter is
-authoritative — do not rely on filenames; real vaults contain
-`Session NN - Title - Wrap-Up.md`, `Session_NN_Wrap_Up.md`, and
-chapter-level variants that a filename glob misses.
-
-### Step 2: Frontmatter Conformance
+### Step 1: Frontmatter Conformance
 
 `vault_check.py wrapup` backfills the mechanical fields against
 the spec's frontmatter block — `session:` link derivation
@@ -67,7 +57,7 @@ surfaces but doesn't resolve:
   date) or the status was stamped prematurely (demote to DRAFT
   and queue for reconcile).
 
-### Step 3: Structure Conformance (publish safety)
+### Step 2: Structure Conformance (publish safety)
 
 Classify every H2 first. **Player-facing H2s are exactly**
 `## Narrative Recap` (and its recap variants) and
@@ -122,7 +112,7 @@ calls:
   of `#### [[PC Name]] (Player)` blocks — Info, opt-in; the fix
   re-headings each PC's existing bullets without rewording them.
 
-### Step 4: Filename Conformance
+### Step 3: Filename Conformance
 
 Filename should be `Chapter_CC_Session_NN_Wrap_Up.md`
 (zero-padded, no title). Drifted names — Warning, **opt-in on a

--- a/skills/publish-site/SKILL.md
+++ b/skills/publish-site/SKILL.md
@@ -34,10 +34,6 @@ and tell the GM to update the plugin; do not proceed. `ERROR` →
 report the row; the plugin install is broken — do not proceed.
 No verdict row and a `not a directory` error on stderr means the
 vault path is wrong — ask the GM for it rather than proceeding.
-Fallback without python: read `gm_apprentice_version` from
-`_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
 
 ## The build tool
 

--- a/skills/session-play/SKILL.md
+++ b/skills/session-play/SKILL.md
@@ -17,8 +17,7 @@ to the Play Notes file for note capture.
 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/session_context.py" <vault>
 --play` — the plan brief (intent, scene titles with type/objective/setup,
 NPC table, world state, contingency triggers, end objectives). Open the
-Plan file itself only when a scene needs its full text. Fallback: read
-the Plan (`type: session-plan`) directly.
+Plan file itself only when a scene needs its full text.
 
 **Version check:** On first invocation run `python3
 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_check.py" <vault>
@@ -30,10 +29,7 @@ proceeding with play support; resume after it completes. `AHEAD`
 proceed. `ERROR` → report the row; the plugin install is broken —
 do not proceed. No verdict row and a `not a directory` error on
 stderr means the vault path is wrong — ask the GM for it rather than
-proceeding. Fallback without python: read `gm_apprentice_version`
-from `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
+proceeding.
 
 **Trigger phrases:** "we're playing now", "quick question",
 "during the session", "I need a [NPC/location]", "give me

--- a/skills/session-prep/SKILL.md
+++ b/skills/session-prep/SKILL.md
@@ -30,10 +30,17 @@ announce the row and tell the GM to update the plugin; do not
 proceed. `ERROR` → report the row; the plugin install is broken —
 do not proceed. No verdict row and a `not a directory` error on
 stderr means the vault path is wrong — ask the GM for it rather than
-proceeding. Fallback without python: read `gm_apprentice_version`
-from `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
+proceeding.
+
+**Scope to the question.** The version gate always runs; everything
+after it is scoped to what the GM asked. "Prep my session" walks the
+whole workflow below. A narrow question — a status check, "what
+changed", "did we skip anything", one conformance check — runs the
+single script that answers it and reports, then stops: document-chain
+status → `vault_check.py <vault> sessions`; thread ages →
+`session_context.py <vault> --threads`; a plan's conformance →
+`plan_check.py <plan>`. No read-set bundle, no Reconcile, no checks
+the GM didn't ask for. Offer the next step in one line — don't take it.
 
 **Document chain:** Read `shared/session-document-chain.md`.
 Session-prep writes Plan files and updates the session index.
@@ -61,7 +68,7 @@ section above.
 the Plan file before proceeding. The Plan file is the
 persistent artifact — conversation is ephemeral.
 
-## Context Source
+## Context Source — opening move of a prep invocation
 
 **Gather the standard read-set in ONE call** before any
 individual reads:
@@ -73,23 +80,10 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/session_context.py" <vault-
 It emits the last Wrap-Up, every active PC's `## Current
 Status` block, the upcoming session's existing Plan, deferred
 world flags, and the campaign overview — replacing a dozen-plus
-separate reads (see `shared/vault-access.md`). If Python is
-unavailable, fall back to the manual read pattern — it must
-cover the same set:
+separate reads.
 
-1. Last session's Wrap-Up file — primary context. Read its
-   `### Handoff to session-prep` (under `## GM Notes`) first —
-   it states where, when, and in what state the next session
-   opens — then What Carries Forward and World State
-2. PC roster — always, including each active PC's `## Current Status`
-   block (Location, Condition, Carrying, Open threads, Knows (exclusive))
-3. The upcoming session's Plan file, if one exists
-4. `_World/_flags.md` — Deferred section
-5. The campaign overview (current game date, campaign state)
-
-**After the bundle either way:** vault dives are targeted
-reads only, proportional to upcoming session complexity, not
-campaign size.
+**After the bundle:** vault dives are targeted reads only,
+proportional to upcoming session complexity, not campaign size.
 
 ### Personal Reference Files
 
@@ -101,9 +95,9 @@ faction rosters, NPC references, location atmosphere.
 
 ## Phase 1: Reconcile (conditional)
 
-Runs when the `Just played:` header line from `session_context.py`
-shows `status: wrap-up` (no separate index read). Skip for first
-sessions or when already `reviewed`.
+Runs in a prep invocation when the `Just played:` header line from
+`session_context.py` shows `status: wrap-up` (no separate index read).
+Skip for first sessions or when already `reviewed`.
 
 **Invoke `shared/reconcile.md`.** Reconcile walks the GM through
 reviewing the Wrap-Up, promotes canon status, and handles
@@ -236,10 +230,6 @@ plans found for this chapter" — and do not write it up as a
 vault gap. A Gap/Action asserting no plan entities exist is a
 claim about the vault, and it is false whenever the design is
 sitting in a directory this step failed to open.
-
-Fallback without python: read `Chapters/{chapter}/Planning/` directly
-(stamped plan entities), plus `_midwife/index.md` and each adventure's
-own `index.md` by hand.
 
 ## Phase 2: Prep Forward — Creative Planning (elicited)
 

--- a/skills/session-wrapup/SKILL.md
+++ b/skills/session-wrapup/SKILL.md
@@ -20,10 +20,7 @@ announce the row and tell the GM to update the plugin; do not
 proceed. `ERROR` → report the row; the plugin install is broken —
 do not proceed. No verdict row and a `not a directory` error on
 stderr means the vault path is wrong — ask the GM for it rather than
-proceeding. Fallback without python: read `gm_apprentice_version`
-from `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
+proceeding.
 
 **Document chain:** Read `shared/session-document-chain.md`.
 Session-wrapup reads the Play Notes file and writes the Wrap-Up

--- a/skills/shared/canon-status.md
+++ b/skills/shared/canon-status.md
@@ -38,7 +38,7 @@ never write them.
 
 **Mechanised:** `stamp_entities.py <vault> --repair-canon
 [--write]` applies exactly this; the cases below are its
-specification and the no-python fallback.
+specification.
 
 This is the single authoritative repair algorithm. The 1.8.0
 migration sweep, campaign-qa's Legacy Canon Field Repair check,

--- a/skills/shared/scripts/index_build.py
+++ b/skills/shared/scripts/index_build.py
@@ -599,8 +599,7 @@ def _read_existing(index_path: Path) -> tuple[str, str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Derive _meta/index.md from a vault scan.")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("vault", type=Path)
     parser.add_argument("--write", action="store_true",
                         help="apply the rendered index (default: dry run)")

--- a/skills/shared/scripts/ingest_survey.py
+++ b/skills/shared/scripts/ingest_survey.py
@@ -160,10 +160,17 @@ INDICATORS: list[tuple[str, re.Pattern]] = [
         r"\bI remember\b|\bI recall\b|\bthe group did\b", re.IGNORECASE,
     )),
     ("charsheet_stats", re.compile(
+        # Between the label and its number, a sheet may have nothing but
+        # whitespace ("STR 50"), a colon/equals ("STR: 50"), Markdown bold
+        # wrapping the label with the closer landing *before* the number
+        # ("**STR:** 50"), or a table pipe cell boundary ("| STR | 50 |").
+        # All of those are just punctuation/whitespace noise around the
+        # number, so one permissive class covers every shape instead of
+        # requiring the label to be followed directly by the digits.
         r"\b(?:STR|DEX|CON|INT|POW|APP|SIZ|EDU|HP|MP|SAN|ST|DX|IQ|HT)"
-        r"\s*[:=]?\s*\d{1,3}\b"
+        r"[\s*:=|]*\d{1,3}\b"
         r"|\b(?:Strength|Dexterity|Constitution|Intelligence|Wisdom|"
-        r"Charisma|Hit Points?|Sanity)\s*[:=]?\s*\d{1,3}\b",
+        r"Charisma|Hit Points?|Sanity)[\s*:=|]*\d{1,3}\b",
     )),
 ]
 
@@ -214,16 +221,25 @@ def propose(counts: dict[str, int]) -> tuple[str, str]:
     keeper = counts["keeper_recollection"]
     charsheet = counts["charsheet_stats"]
 
-    # Tested before play: a character sheet's attribute block routinely
-    # trips a handful of play-shaped patterns (a stray "HP 12", a "round"
-    # in prose) without being one — structured stats dominating the line
-    # count is the stronger signal.
+    # Tested first, ahead of both the charsheet-dominance rule and the
+    # plain play-transcript rule: a stat block embedded in prep notes (an
+    # NPC profile with a `STR 60, CON 70, ...` block, say) can rack up more
+    # charsheet_stats hits than the document has play hits, but that does
+    # not make the whole file a character sheet — it makes it a mixed
+    # document that also happens to contain a stat block. Any document
+    # with play indicators AND at least one of prep/research/keeper wins
+    # the mixed-content verdict outright, regardless of how the charsheet
+    # count compares to play.
+    if play and (prep or research or keeper):
+        return ("Play fragment (mixed content — consider a section "
+                "split)", "medium")
+    # A character sheet's attribute block routinely trips a handful of
+    # play-shaped patterns (a stray "HP 12", a "round" in prose) without
+    # being one — structured stats dominating the line count is the
+    # stronger signal, so this is tested before the plain play rule.
     if charsheet >= 3 and charsheet > play:
         return "Character sheet", "high" if charsheet >= 6 else "medium"
     if play:
-        if prep or research or keeper:
-            return ("Play fragment (mixed content — consider a section "
-                    "split)", "medium")
         return "Play transcript", "high" if play >= 3 else "medium"
     if charsheet >= 3:
         return "Character sheet", "high" if charsheet >= 6 else "medium"

--- a/skills/shared/scripts/session_context.py
+++ b/skills/shared/scripts/session_context.py
@@ -29,8 +29,10 @@ Each section is headed with its source path; missing pieces are
 reported, not fatal. A `Note:` line in the header means read before
 trusting: it appears for an ambiguous `last_session` pointer (one
 that resolves to nothing, to several sessions, or to a session
-number present in more than one chapter) and when a later session
-index existed but was ignored as unplayed. Confirm a `Note:` with
+number present in more than one chapter), when a later session
+index existed but was ignored as unplayed, and when the campaign
+overview's `asOfSession` names a different chapter from the one the
+selected session sits in. Confirm a `Note:` with
 the GM — a wrong bundle reads exactly as authoritative as a right
 one.
 """

--- a/skills/shared/scripts/session_context.py
+++ b/skills/shared/scripts/session_context.py
@@ -30,7 +30,9 @@ reported, not fatal. A `Note:` line in the header means read before
 trusting: it appears for an ambiguous `last_session` pointer (one
 that resolves to nothing, to several sessions, or to a session
 number present in more than one chapter), when a later session
-index existed but was ignored as unplayed, and when the campaign
+index in the same chapter was ignored as unplayed, when a later
+session in the same chapter is already played (the selection may be
+stale), and when the campaign
 overview's `asOfSession` names a different chapter from the one the
 selected session sits in. Confirm a `Note:` with
 the GM — a wrong bundle reads exactly as authoritative as a right
@@ -376,12 +378,20 @@ def select_session(files, session_arg: int | None) -> tuple[dict | None, list[st
                 f"this bundle.")
 
     if chosen:
-        pending = sorted(s["n"] for s in sessions
-                         if s["n"] > current and s["chapter"] == chapter)
-        if pending:
+        later = [s for s in sessions
+                 if s["n"] > current and s["chapter"] == chapter]
+        unplayed = sorted(s["n"] for s in later if not s["played"])
+        played_later = sorted(s["n"] for s in later if s["played"])
+        if unplayed:
             warnings.append(
-                f"Note: session index(es) {pending} exist "
+                f"Note: session index(es) {unplayed} exist "
                 f"with unplayed status — ignored for 'just played'.")
+        if played_later:
+            warnings.append(
+                f"Note: session(s) {played_later} in this chapter are "
+                f"numbered after the selected one and carry a played "
+                f"status — the selection may be stale; verify before "
+                f"trusting this bundle.")
 
     return chosen, warnings
 
@@ -442,7 +452,8 @@ def main() -> int:
     mode.add_argument("--threads", action="store_true",
                       help="print the Session Context header and Threads "
                            "report only: each active PC's Open threads aged "
-                           "against the Wrap-Up's Unresolved Threads, "
+                           "against the Wrap-Ups' Unresolved Threads and "
+                           "PC Carry-Forward bullets, "
                            "age=N sessions since last touched, STALE at "
                            "age >= 3 (a candidate, not a verdict — resolve, "
                            "advance, or retire is the GM's call)")

--- a/skills/shared/scripts/session_context.py
+++ b/skills/shared/scripts/session_context.py
@@ -26,7 +26,13 @@ chapter — the bundle says so rather than choosing quietly: a wrong
 bundle is worse than no bundle, because it reads as authoritative.
 
 Each section is headed with its source path; missing pieces are
-reported, not fatal.
+reported, not fatal. A `Note:` line in the header means read before
+trusting: it appears for an ambiguous `last_session` pointer (one
+that resolves to nothing, to several sessions, or to a session
+number present in more than one chapter) and when a later session
+index existed but was ignored as unplayed. Confirm a `Note:` with
+the GM — a wrong bundle reads exactly as authoritative as a right
+one.
 """
 
 from __future__ import annotations
@@ -432,7 +438,12 @@ def main() -> int:
     mode.add_argument("--play", action="store_true",
                       help="print only the upcoming (or --session) Play Brief")
     mode.add_argument("--threads", action="store_true",
-                      help="print the Session Context header and Threads report only")
+                      help="print the Session Context header and Threads "
+                           "report only: each active PC's Open threads aged "
+                           "against the Wrap-Up's Unresolved Threads, "
+                           "age=N sessions since last touched, STALE at "
+                           "age >= 3 (a candidate, not a verdict — resolve, "
+                           "advance, or retire is the GM's call)")
     args = ap.parse_args()
     if not args.vault.is_dir():
         print(f"error: not a directory: {args.vault}", file=sys.stderr)

--- a/skills/shared/scripts/vault_check.py
+++ b/skills/shared/scripts/vault_check.py
@@ -1175,7 +1175,7 @@ def check_pc_body(vault: Path, folder: str | None = None) -> list[str]:
 # --------------------------------------------------------------------------
 # Session Wrap-Up conformance
 #
-# Mechanises campaign-qa/references/checks/wrapup-conformance.md Steps 1–3
+# Mechanises campaign-qa/references/checks/wrapup-conformance.md Steps 1-3
 # and, as `--fix`, the structural half of the 1.9.4 → 1.9.5 migration. The
 # failure this exists to prevent is narrow and expensive: a Keeper-facing
 # `## Open Questions for Reconcile` sits beside `## Narrative Recap` rather

--- a/skills/shared/scripts/vault_check.py
+++ b/skills/shared/scripts/vault_check.py
@@ -30,6 +30,33 @@ line as `LEVEL<TAB>path<TAB>message`.
 Levels: ERROR (schema violation), WARNING (needs GM attention),
 INFO (context the auditing skill should triage, not a defect).
 
+`gm-leak` skips by frontmatter, not path: a `type:` of
+`session-plan`, `session-play-notes`, `plan`, or `meta` is never
+published and always skipped, even under `_meta/`; `publish: none`
+pages are skipped and `publish: stub` pages are scanned only over
+the sections they ship. ERROR is an orphan `<!-- /gm-only -->`
+closer (everything above it publishes) or a bold-wrapped excluded
+heading like `### **GM Notes**`; WARNING is an unclosed opener or a
+published heading whose title contains an exclude-list entry or
+Keeper keyword; INFO is a Keeper-facing bold label or callout —
+prose the GM has to judge, not auto-movable.
+
+`pc-body` runs over every `type: pc` sheet except `*_Story.md`
+companions and `publish: none` pages. ERROR is `## Current Status`
+sitting inside a gm-only/spoiler fence; WARNING is `## Current
+Status` coming after `## Notes`/`## GM Notes`, not being an H2, or a
+duplicated H2; INFO is the block missing, having no labelled
+fields, or the first body H2 not being `## Stat Sheet`.
+
+`wrapup` checks conformance against `shared/templates/session-wrap.md`:
+frontmatter backfills, an ERROR on a Keeper-facing sibling H2 that
+would publish, the single `<!-- gm-only -->` fence around `## GM
+Notes`, recap-heading and template-heading variants, and the
+filename pattern. A gm-only fence that is unbalanced or crosses a
+player-facing section boundary gets its frontmatter backfilled and
+its body left alone, for the GM to fix by hand; filename renames
+are never automatic.
+
 `wrapup` is the one command that can write. It prints its findings
 first and then a repair row per action — `WOULD-FIX` on a dry run,
 `FIXED` when `--fix` applies them, `UNCHANGED` for a conformant
@@ -1148,7 +1175,7 @@ def check_pc_body(vault: Path, folder: str | None = None) -> list[str]:
 # --------------------------------------------------------------------------
 # Session Wrap-Up conformance
 #
-# Mechanises campaign-qa/references/checks/wrapup-conformance.md Steps 2–4
+# Mechanises campaign-qa/references/checks/wrapup-conformance.md Steps 1–3
 # and, as `--fix`, the structural half of the 1.9.4 → 1.9.5 migration. The
 # failure this exists to prevent is narrow and expensive: a Keeper-facing
 # `## Open Questions for Reconcile` sits beside `## Narrative Recap` rather

--- a/skills/shared/vault-access.md
+++ b/skills/shared/vault-access.md
@@ -1,7 +1,7 @@
 # Vault Access Reference
 
 Read this file to determine how to access the campaign vault.
-Vault access is plain filesystem tools plus two bundled
+Vault access is plain filesystem tools plus bundled
 utilities. There is no server, no app dependency, and no
 separate "Obsidian mode" — the vault is a folder of markdown,
 and Obsidian is a viewer the user may or may not have open.
@@ -45,48 +45,9 @@ utility does it in one pass (benchmarked: under a second and
 a few hundred tokens, versus 50–125s and ~50k tokens for
 per-query approaches).
 
-`gm-publish sheet show --pc <name> --player-safe` is the
-player-safe data boundary for answering a player's question
-about their own sheet: it prints the sheet with everything the
-published site strips already gone (excluded sections,
-gm-only/spoiler blocks, HTML comments, excluded callouts,
-gm_only relationship edges, excluded frontmatter fields).
-Prefer it over reading the vault sheet directly whenever the
-audience is a player, not the GM.
-
-`gm-publish update-pin --site <dir>` repoints a published
-site's renderer dependency at the newest plugin-cache version
-and runs `npm install` — a plugin update never touches a
-site's pin on its own, so a site keeps building with the old
-renderer until this runs. `--check` reports the drift and
-exits 1 without changing anything; pair a real run with
-`deploy`. `gm-publish manifest diff` classifies every vault
-file with the same decision the build makes and lists what
-`_meta/publish-manifest.md` doesn't yet mention, with the
-bucket, code, and reason for each; `manifest apply --publish
-PATH / --exclude "PATH=reason" / --decide PATH [--prune]`
-moves entries between sections and rewrites the file — which
-files are correctly excluded versus missing is the GM's call,
-this only shows the drift. `gm-publish deploy --verify` builds
-the site and pushes it to the configured host, then fetches the
-live URL up to three times 20s apart; a site still propagating
-is reported, not failed. `gm-publish doctor --site` audits the
-vault instead of the machine — stale build-tool pin, folders
-missing from `folderMap`, files with no `type:`, portraits
-pointing at absent images, dead wikilinks, manifest entries
-whose file is gone, played sessions in no manifest section —
-and exits 1 only on an error, never a warning. `gm-publish
-explain PATH` prints the chain the build walks for one file
-(directory, type, publish mode, auto-exclusion, canon status,
-manifest section) and the verdict — where it publishes, or
-which rule stopped it — plus the H2 sections stripped and how
-many gm-only blocks it carries; run it before `doctor --site`
-when the question is about one specific file rather than the
-whole vault.
-
 ## Bundled Utilities
 
-Both live in `skills/shared/scripts/`, stdlib-only Python 3.
+All live in `skills/shared/scripts/`, stdlib-only Python 3.
 From a plugin install, invoke via the plugin root:
 
 ```bash
@@ -100,206 +61,13 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_search.py" \
   <vault-path> "what happened after the duel" --limit 5 --context
 ```
 
-`graph_check.py` commands: `orphans`, `unresolved`,
-`deadends`, `backlinks NAME`, `ambiguous`, `all`; options
-`--folder SUB` and repeatable `--exclude GLOB`. Output is a
-`# count: N` header then one vault-relative path per line.
-It handles aliases, `[[Name|alias]]`, `[[Name#heading]]`,
-embeds, quoted frontmatter links, and space/underscore/case
-variants.
-
-`vault_search.py` is index-free BM25 — no index to build or
-go stale. `--context` prints the best-matching line per hit.
-Use it for prose queries; plain Grep is cheaper for exact
-terms.
-
-`vault_check.py` commands: `frontmatter` (schema validation:
-required fields, enums, legacy fields, unquoted frontmatter
-links), `names` (duplicate and confusable entity names and
-aliases), `index` (`_meta/index.md` drift, both directions),
-`stale-drafts`, `changed --since N` (entities touched at or
-after session N — the incremental-audit scope),
-`relationships` (every `relationships[].type` checked against
-the sanctioned predicate vocabulary), `sessions` (each
-session index's plan/play-notes/wrap-up document chain,
-declared vs. derived status), `gm-leak [--folder SUB]`
-(publish-safety scan of every publishable file's body — the
-skip is by frontmatter, not by path: a `type:` of
-`session-plan`, `session-play-notes`, `plan` or `meta` is
-skipped as never-published, so an `_meta/` page carrying some
-other type is still scanned; `publish: none` pages are
-skipped and `publish: stub` pages are scanned only over the
-sections they ship: ERROR
-for an orphan `<!-- /gm-only -->` closer — everything above it
-publishes — or a bold-wrapped excluded heading like `###
-**GM Notes**`; WARNING for an unclosed opener or a published
-heading whose title contains an exclude-list entry or Keeper
-keyword; INFO for a Keeper-facing bold label or callout),
-`pc-body [--folder SUB]` (for every `type: pc` sheet except
-`*_Story.md` companions and `publish: none` pages;
-fence-balance rows are reported here too: ERROR when `##
-Current Status` sits inside a gm-only/spoiler fence; WARNING
-when it comes after `## Notes`/`## GM Notes`, is not an H2, or
-an H2 is duplicated; INFO when the block is missing, has no
-labelled fields, or the first H2 isn't `## Stat Sheet`),
-`wrapup [--file REL] [--fix]` (Wrap-Up conformance against
-`shared/templates/session-wrap.md`: frontmatter backfills,
-ERROR on a Keeper-facing sibling H2 that would publish, the
-single `<!-- gm-only -->` fence around `## GM Notes`, recap-
-heading and template-heading variants, filename pattern —
-`--fix` applies the mechanical set including the re-nest;
-dry-run rows print `WOULD-FIX`, `--fix` prints `FIXED`,
-`UNCHANGED` means the repaired text is byte-identical to what
-is on disk; a file whose gm-only fence is unbalanced or crosses
-a player-facing section boundary gets its frontmatter
-backfilled and its body left alone, for the GM to fix by hand;
-filename renames are never automatic), `all`. `all` runs
-`sessions`, `gm-leak`, `pc-body`, and `wrapup` (without
-`--fix`) alongside the rest — never `version` or `active-pcs`,
-which are gates, not reports, and sit outside it: `version`
-prints one row whose first column is a verdict token (OK /
-MISMATCH / AHEAD / SETUP / ERROR) and exits 1 on
-MISMATCH/AHEAD/ERROR — run it on the first invocation of any
-vault-aware skill; `active-pcs` emits the session skills'
-opening roster read.
-Findings are `LEVEL<TAB>path<TAB>message`; fix every ERROR,
-triage WARNINGs with the GM, treat INFO as context.
-
-`session_context.py <vault>` emits the session-prep read-set
-in one call: latest Wrap-Up, active PC `## Current Status`
-blocks, the upcoming session's Plan, deferred world flags,
-campaign overview — each section tagged with its source path.
-Drill into individual files only where the digest shows the
-need.
-
-Which session counts as "just played" comes from the campaign
-overview's `last_session`, falling back to the most recent
-`play_date` — not the highest `session_number`, which is not a
-campaign-wide ordinal in a vault whose numbering restarts each
-chapter. The session-anchored lookups — the wrap-up and the
-upcoming plan — are then scoped to that session's chapter. The
-rest of the bundle stays vault-wide, as it should: active PCs,
-deferred flags, and the campaign overview are not per-chapter.
-
-**A `Note:` line in the header means read before trusting.** It
-appears when the choice was ambiguous (a `last_session` pointer
-that resolves to nothing or to several files, a session number
-present in more than one chapter) and when later session
-indexes were ignored as unplayed. Confirm it with the GM: a
-wrong bundle reads exactly as authoritative as a right one.
-
-`--play` narrows the bundle to just the upcoming (or
-`--session N`) session's Plan — the at-table brief when the
-Current Status and deferred-flags digest isn't needed.
-`--threads` narrows it to the Session Context header plus a
-Threads report: each active PC's `Open threads` bullets aged
-against the Wrap-Up's Unresolved Threads, `age=N` sessions
-since the thread was last touched and `STALE` at age >= 3. A
-`STALE` row is a candidate, not a verdict — resolve, advance,
-or retire is the GM's call.
-
-`index_build.py <vault> [--write] [--date YYYY-MM-DD]` derives
-a fresh `_meta/index.md` from the vault's own frontmatter —
-chapters, every session and scene nested under its chapter,
-session-chain documents nested under their session, `*_Story.md`
-companions nested under their PC, and every `type: plan` entity
-in its own section. Default is a dry-run: a unified diff against
-the file on disk (or the whole rendered text if none exists yet)
-plus a `# entities: N narrative: M stubs: K` summary line;
-`--write` applies it, preserving the existing file's line
-endings. A document it can't place — an orphaned session-chain
-doc, a Story file with no matching PC — surfaces under `##
-Stubs (Needs Attention)` instead of being dropped. The dry-run
-diff is the confirmation prompt: review it before `--write`.
-
-`plan_check.py PLAN.md [--headless] [--inventory] [--state]
-[--json]` is the Session Plan conformance check for
-session-prep's rules and `shared/session-principles.md`, run
-against one file. Default output is finding rows as
-`LEVEL<TAB>locus<TAB>message` plus a `# errors: N warnings: N
-info: N` summary; `--inventory` lists template-H2 presence and
-word counts instead, `--state` prints the prep-state marker's
-tokens, `--json` emits all three as one object. Exit 1 on any
-ERROR. ERROR means fix it before the Plan ships; WARNING is the
-GM's call — fix it or knowingly carry it forward; INFO is
-context (a placeholder heading, a long scene) worth a glance,
-not a blocker.
-
-`plans_index.py <vault> [--chapter "Chapter N - Title"]
-[--against NAME ...] [--json]` bundles session-prep's Forward
-Design read into one call: every `type: plan` entity under a
-chapter's `Planning/` folder, and which `_midwife/` adventure
-directory an in-progress chapter continues. `--chapter` narrows
-both halves to one chapter; `--against NAME` (repeatable) adds
-an Overlap section for Planning/ entries naming that
-participant or location. Exit is always 0 — when the midwife
-manifest can't resolve to a single adventure, that's a report
-for the GM to settle, not an error to fix.
-
-`stamp_entities.py <vault> FILE... [--session SESSION]
-[--date YYYY-MM-DD] [--retag OLD=NEW]` batch-stamps
-`asOfSession`, `lastUpdated`, and a chapter-tag swap across
-files — `--session` and `--date` are now independent, so
-either can be given alone. SESSION is written verbatim — a
-label (`"Chapter 4, Session 9"`) or a bare number — and a file
-already using the other shape is refused unless
-`--force-shape`. It also takes `--set KEY=VALUE` (repeatable;
-any other top-level or one-level dotted field — the fields
-with their own flags below are refused, dotted forms
-included), `--increment
-KEY` (repeatable; +1 on an integer counter, and refused on
-those same fields), `--promote`
-(canon_status DRAFT/absent → AUTHORITATIVE; STUB and
-SUPERSEDED are refused), `--reconciled YYYY-MM-DD`, and
-`--supersede-by "[[Winner]]"` (canon_status → SUPERSEDED plus
-`superseded_by`, mutually exclusive with `--promote`).
-`--repair-canon [FILE...] [--write]` applies the legacy
-canon-key repair from `shared/canon-status.md`: renames a lone
-`source_confidence`/`confidence` to `canon_status`, deletes it
-when it agrees, and on disagreement keeps `canon_status`,
-drops the legacy line, and reports a CONFLICT for the GM to
-confirm; with no FILE it sweeps the whole vault, `_Templates/`
-and `_meta/` included, and runs on its own — never combined
-with a stamping action in the same call. Dry-run by default —
-review the plan, then re-run with `--write`. It touches only
-the targeted frontmatter lines; everything else is preserved
-byte-for-byte.
-
-`ingest_survey.py DIR` turns vault-ingest Phase 1 from "read all source
-material" into "read the manifest, then read only what it flags." Three of
-the nine taxonomy rows resolve with zero content read — Image/map and
-Spreadsheet/data by extension, Session wrap-up by existing `type:`
-frontmatter — and print `DECIDED`. The rest print `SCORED`, with
-per-indicator hit counts and line numbers (play, prep, research, Keeper-
-recollection, character-sheet phrases named in
-`classification-taxonomy.md`) plus a proposed classification and
-confidence — evidence for the model/GM to confirm or override, not a final
-verdict. A Word/PDF/VTT file prints `UNSCORED`: no stdlib text extractor
-exists for it, and it is never guessed at. `ingest_survey.py VAULT
---archive FILE... [--write]` implements Gotcha 5: moves a processed
-`_inbox/` file to `_inbox/_processed/<date>/`, preserving its subpath,
-refusing to delete or silently overwrite (a name collision gets a numeric
-suffix). FILE may be spelled vault-relative (`_inbox/notes/a.txt`),
-`_inbox/`-relative (`notes/a.txt`) or absolute; a path outside `_inbox/`
-or already under `_processed/` is refused. Dry-run by default, like every
-other mutating script here — `--write` applies the move.
-
-`ingest_images.py VAULT DIR [--execute]` is vault-ingest's image-handling
-procedure (`references/image-handling.md`) as a script rather than a
-file-by-file manual pass: slugify each image filename, match it against a
-vault entity's own slug (exact, then one suffix-strip), convert a
-non-web-safe format via `sips`/`magick` when available, file it under the
-right `_attachments/` subfolder, and decide portrait vs. body-embed — a
-lone match becomes the portrait, several matches for one entity give the
-unsuffixed one the portrait and embed the rest, all-suffixed with no
-default is left unset and reported `portrait-ambiguous` for the keeper
-interview, and an entity that already has a portrait never has it
-overwritten. A same-name file with different bytes at the destination, or
-two differently-named sources that slugify to the same destination, are
-both `DUP-FLAG`, never auto-resolved. Re-running `--execute` after a
-portrait is resolved by hand (`stamp_entities.py --set portrait=...`)
-picks up any outstanding body embeds for that entity. Dry-run by default;
-`--execute` writes.
+Every utility documents itself: run it with `--help` before its first
+use in a session — the flags, output rows, and exit codes live there,
+not in this file. Findings are `LEVEL<TAB>path<TAB>message`; fix every
+ERROR, triage WARNINGs with the GM, treat INFO as context. Mutating
+scripts are dry-run by default; `--write` / `--fix` / `--execute`
+applies. `gm-publish <subcommand> --help` does the same for the
+publish tool's subcommands.
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/vault_check.py" \
@@ -311,17 +79,6 @@ vault-ingest, campaign-organizer), run
 `vault_check.py frontmatter --folder <dir>` on what you
 touched and fix ERRORs before moving on — one deterministic
 call replaces re-reading files to self-check.
-
-If `python3` is not on PATH, try `python` (common on
-Windows; install from python.org or `winget install python`
-— the utilities are standard-library only). If neither
-exists, say so and fall back to Grep: literal search with
-synonyms for prose queries, `[[Name]]`-variant matching for
-backlinks, and manual schema checks. For the newer checks
-(`gm-leak`, `pc-body`, `wrapup`) the fallback is the prose
-procedure in the owning skill instead — read it and apply the
-same checks by eye. Flag the fallback in any audit results —
-Grep approximations can miscount.
 
 ## File Format
 

--- a/skills/the-midwife/SKILL.md
+++ b/skills/the-midwife/SKILL.md
@@ -58,10 +58,6 @@ and tell the GM to update the plugin; do not proceed. `ERROR` →
 report the row; the plugin install is broken — do not proceed.
 No verdict row and a `not a directory` error on stderr means the
 vault path is wrong — ask the GM for it rather than proceeding.
-Fallback without python: read `gm_apprentice_version` from
-`_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
 
 ## Content Management
 

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -66,10 +66,7 @@ announce the row and tell the GM to update the plugin; do not
 proceed. `ERROR` → report the row; the plugin install is broken —
 do not proceed. No verdict row and a `not a directory` error on
 stderr means the vault path is wrong — ask the GM for it rather than
-proceeding. Fallback without python: read `gm_apprentice_version`
-from `_meta/vault-config.md` and `current_version` from
-`shared/migrations.md` (frontmatter only) and compare
-component-by-component as numbers — `1.8.9` is older than `1.8.15`.
+proceeding.
 
 ## Gotchas
 

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 01 - The Missing Professor - Wrap-Up.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 01 - The Missing Professor - Wrap-Up.md
@@ -1,25 +1,33 @@
 ---
-type: session-wrap-up
+type: session_wrap
 session: "[[Session 01 - The Missing Professor]]"
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
 canon_status: AUTHORITATIVE
 created_by: session-wrapup
 tags: []
+session_number: 1
+play_date: null
+in_game_date: null
+reconciled: null
 ---
 
 # Session 1: The Missing Professor
 
-## Session Summary
+## Narrative Recap
 
 The investigators were brought together by Dr. Albert Wilmarth, a colleague of the missing [[Professor Ashford]] at Miskatonic University. Wilmarth explained that Ashford had been increasingly reclusive in the weeks before his disappearance, obsessing over a manuscript he'd acquired from an estate sale. On the morning of October 12th, his housekeeper [[Mrs Whitmore]] found his study torn apart and the professor gone.
 
-## Key Events
+<!-- gm-only -->
 
-### The Briefing (Miskatonic Faculty Club)
+## GM Notes
+
+### Key Events
+
+#### The Briefing (Miskatonic Faculty Club)
 Dr. Wilmarth met the investigators over coffee and laid out what he knew. Ashford had been a steady, methodical scholar for thirty years — the sudden change in behavior was alarming. Wilmarth mentioned that Ashford had been attending meetings of some "gentlemen's fraternal order" in Kingsport but didn't know which one. He asked the investigators to succeed where [[Inspector Crane]] and the police had so far failed.
 
-### Interview with Mrs Whitmore (Ashford Residence)
+#### Interview with Mrs Whitmore (Ashford Residence)
 [[Mrs Whitmore]] was still visibly shaken. She described the professor's decline: the sleepless nights, the refusal to eat, the muttering in what she thought might be Latin. On the morning of the 12th, she arrived at 7:00 AM to find the front door ajar, the study in disarray, and Ashford gone.
 
 Key details from the interview:
@@ -28,7 +36,7 @@ Key details from the interview:
 - Nothing appeared to be stolen, though papers were scattered everywhere.
 - Ashford had recently installed a new lock on his desk drawer.
 
-### Examining the Study
+#### Examining the Study
 The investigators searched [[Ashford Study]] thoroughly.
 
 **Mal Bridges** (Spot Hidden 70% — succeeded): Found that the desk drawer's new lock concealed a false bottom. Inside was the [[Coded Letter]] — a single page of text in what appeared to be a substitution cipher, folded around a hand-drawn map of the Kingsport waterfront with warehouse 7 circled.
@@ -37,30 +45,32 @@ The investigators searched [[Ashford Study]] thoroughly.
 
 **Dr. Voss** (Medicine — succeeded): Noted that the cot in the study had sheets soaked with night sweats. A half-empty bottle of laudanum sat on the desk. Ashford was self-medicating for something — anxiety, insomnia, or possibly something worse.
 
-### Meeting Tommy Flanagan (The Red Hook Tavern)
+#### Meeting Tommy Flanagan (The Red Hook Tavern)
 Mal's underworld contacts led the group to [[Tommy Flanagan]], a wiry, fast-talking informant who works the margins of Kingsport's criminal economy. Mal found him at his usual booth in the Red Hook, nursing a whiskey.
 
 Tommy confirmed that there had been "unusual activity" at the docks recently — crates arriving on unmarked boats in the small hours, taken to warehouse 7 by men who "don't look like regular longshoremen." He'd been keeping his distance because the men gave him a bad feeling. For $20 (reluctantly paid by Dr. Voss), Tommy agreed to keep his eyes open and report back.
 
 Tommy also mentioned a name: the [[Order of the Silver Twilight]]. He called them "rich men playing at being wizards" but admitted that people who crossed them tended to have bad luck.
 
-### Police Station (Brief Visit)
+#### Police Station (Brief Visit)
 The investigators spoke with [[Inspector Crane]] at the Kingsport police station. Crane was polite but dismissive — he believed Ashford had likely wandered off in a state of nervous exhaustion and would turn up. He showed no interest in the coded letter or the occult angle. "Professors get strange notions," he said. "They read too many books."
 
-## Session End State
+### Session End State
 - The [[Coded Letter]] is in the investigators' possession but not yet decoded.
 - [[Tommy Flanagan]] is established as a contact and expects to be paid for further information.
 - The investigators plan to decode the letter and investigate the docks.
 - [[Inspector Crane]] is not expected to be helpful.
 
-## Sanity and Health
+### Sanity and Health
 - No SAN losses this session.
 - No injuries.
 - Dr. Voss spent $20 from her personal funds on Tommy's information.
 
-## Open Threads
+### Open Threads
 1. Decode the [[Coded Letter]] — what does it say?
 2. Investigate warehouse 7 at the docks.
 3. Identify the "tall, gaunt visitor" — likely [[Brother Ezra]].
 4. Learn more about the [[Order of the Silver Twilight]].
 5. [[Tommy Flanagan]] will report back if he sees anything new at the docks.
+
+<!-- /gm-only -->

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 02 - The Docks at Night - Wrap-Up.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 02 - The Docks at Night - Wrap-Up.md
@@ -1,39 +1,48 @@
 ---
-type: session-wrap-up
+type: session_wrap
 session: "[[Session 02 - The Docks at Night]]"
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
 canon_status: AUTHORITATIVE
 created_by: session-wrapup
 tags: []
+session_number: 2
+play_date: null
+in_game_date: null
+source_document: "[[Session 02 - The Docks at Night - Play Notes]]"
+reconciled: null
 ---
 
 # Session 2: The Docks at Night
 
-## Session Summary
+## Narrative Recap
 
 The investigators, having partially decoded the [[Coded Letter]], headed to [[Kingsport Docks]] to investigate warehouse 7. The night turned dangerous when they encountered [[Brother Ezra]] and narrowly escaped a pursuit through the fog-shrouded waterfront. They recovered physical evidence — crates marked with the [[Strange Symbol]] — but more questions than answers.
 
-## Key Events
+<!-- gm-only -->
 
-### Decoding the Letter (Ashford Residence, afternoon)
+## GM Notes
+
+### Key Events
+
+#### Decoding the Letter (Ashford Residence, afternoon)
 **Rev. Silas Marsh** (Library Use 50% — succeeded) spent the morning at the Miskatonic library researching the cipher. It was a Vigenere cipher with the key word GLAAKI. The decoded letter, written by Ashford, read:
 
 > *"The deliveries continue on the 17th and 20th. Warehouse 7. They do not know I have seen the inner sanctum — the chamber beneath the old church where they keep the greater texts. I must retrieve the Revelations before the new moon. If I fail, what they intend to summon will not be confined to the angles between. God help us all. — H.A."*
 
 This confirmed the connection between the dock deliveries, the [[Order of the Silver Twilight]], and some kind of underground chamber. The reference to "the old church" was vague — several churches in Kingsport could qualify.
 
-### Staking Out the Docks (Evening, October 17th)
+#### Staking Out the Docks (Evening, October 17th)
 The investigators arrived at [[Kingsport Docks]] at dusk. The waterfront was thick with fog rolling in off the harbor. They positioned themselves with sight lines on warehouse 7.
 
 At approximately 9:00 PM, a small launch appeared out of the fog and moored at dock 7. Three men began unloading wooden crates — heavy, about three feet long, unmarked except for a symbol painted in red on each lid.
 
-### Encounter with Brother Ezra
+#### Encounter with Brother Ezra
 As the investigators watched, a fourth figure emerged from the warehouse — tall, gaunt, dressed in a dark coat. This matched [[Mrs Whitmore]]'s description of Ashford's visitor. **Dr. Voss** (Psychology — succeeded) noted that the man moved with an unsettling, almost mechanical precision, and the dock workers deferred to him with visible fear.
 
 The investigators attempted to get closer. **Mal Bridges** (Stealth 55% — failed) knocked over a coil of rope. Brother Ezra's head snapped toward the sound with inhuman speed. He shouted something in a language none of the investigators recognized, and the dock workers scattered.
 
-### The Chase
+#### The Chase
 [[Brother Ezra]] pursued the investigators through the fog. Despite his gaunt frame, he moved with terrifying speed, closing distance in ways that seemed to violate normal physics. The chase wound through the narrow alleys between warehouses.
 
 - **Mal** (DEX check — succeeded) vaulted a fence and circled back toward dock 7.
@@ -42,32 +51,34 @@ The investigators attempted to get closer. **Mal Bridges** (Stealth 55% — fail
 
 Brother Ezra eventually broke off the pursuit and vanished into the fog near the old quarter of town.
 
-### Examining the Evidence
+#### Examining the Evidence
 Returning cautiously to dock 7, the investigators found that the launch was gone and most of the crates had been removed. Two crates remained, apparently dropped during the confusion.
 
 Inside the crates: packed straw surrounding carefully wrapped stone tablets. The tablets were carved with the [[Strange Symbol]] — the same eye-within-crescent found in Ashford's notes — along with extensive text in an unknown script.
 
 Prof Crain witnessed something at dock 7 last Tuesday and may have more information about the regular delivery schedule.
 
-### Reporting to Inspector Crane
+#### Reporting to Inspector Crane
 The investigators reported the incident to [[Inspector Crane]] the following morning. Crane took notes but was skeptical. "You're telling me a thin man outran three able-bodied people in the fog? Perhaps you'd been drinking." He agreed to send a constable to check the warehouse but seemed to treat it as a low priority.
 
-## Session End State
+### Session End State
 - Two stone tablets in the investigators' possession.
 - [[Brother Ezra]] has seen the investigators' faces — they are now known to the cult.
 - The [[Coded Letter]] has been decoded, revealing references to "the inner sanctum" beneath "the old church."
 - Dockmaster Hayes has been identified as a potential new contact.
 - [[Inspector Crane]] remains unhelpful.
 
-## Sanity and Health
+### Sanity and Health
 - Dr. Voss: lost 3 SAN (witnessing Brother Ezra's inhuman features). Current SAN: 52.
 - Mal Bridges: minor bruise on right arm from the chase. No HP loss.
 - Rev. Marsh: gained 1 Cthulhu Mythos from examining the stone tablets. Lost 1 SAN from the same.
 
-## Open Threads
+### Open Threads
 1. Identify "the old church" referenced in the coded letter — where is the inner sanctum?
 2. Follow up with Dockmaster Hayes about the delivery schedule.
 3. What are the stone tablets? Can the script be translated?
 4. [[Brother Ezra]] now knows the investigators — expect retaliation.
 5. Is [[Inspector Crane]] merely incompetent, or is he actively obstructing?
 6. [[Dr. Marsh]] — who is this? How do they connect to the case?
+
+<!-- /gm-only -->

--- a/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning - Wrap-Up.md
+++ b/tests/benchmark-campaign/Chapters/Chapter 1/Sessions/Session 04 - The Reckoning - Wrap-Up.md
@@ -1,33 +1,43 @@
 ---
-type: session-wrap-up
+type: session_wrap
 session: "[[Session 04 - The Reckoning]]"
 chapter: "[[Chapter 1 - The Ashford Case]]"
 campaign: "The Ashford Case"
 canon_status: AUTHORITATIVE
 created_by: session-wrapup
 tags: []
+session_number: 4
+play_date: null
+in_game_date: null
+reconciled: null
 ---
 
 # Session 4: The Reckoning
 
-## Session Summary
+## Narrative Recap
 
 The investigators confronted [[Father Blackwood]] at [[The Old Mill]] after tracing the cult's supply route from [[Kingsport Docks]]. The confrontation revealed Blackwood's true allegiance to the [[Order of the Silver Twilight]] and his role in [[Professor Ashford]]'s disappearance.
 
-## Key Events
+<!-- gm-only -->
 
-### The Mill Approach (afternoon)
+## GM Notes
+
+### Key Events
+
+#### The Mill Approach (afternoon)
 The party scouted [[The Old Mill]] from a distance, confirming activity inside. [[The Hooded Figure]] was spotted entering through a side door.
 
-### The Confrontation
+#### The Confrontation
 Direct confrontation with [[Father Blackwood]], who attempted to complete a ritual. The investigators disrupted the ceremony but Blackwood escaped into the tunnels beneath the mill.
 
-## Entities Introduced
+### Entities Introduced
 
 - [[Father Blackwood]] — revealed as cult leader (supersedes earlier version)
 - [[The Old Mill]] — cult meeting site, tunnels beneath
 
-## Next Session Hooks
+### Next Session Hooks
 
 - Pursue Blackwood through the tunnel network
 - The ritual was partially completed — consequences unknown
+
+<!-- /gm-only -->

--- a/tests/benchmark-campaign/_meta/vault-config.md
+++ b/tests/benchmark-campaign/_meta/vault-config.md
@@ -1,0 +1,8 @@
+---
+type: meta
+gm_apprentice_version: "1.9.10"
+publish:
+  system: "coc-7e"
+---
+
+Vault config for the benchmark-campaign fixture.

--- a/tests/test_ingest_survey.py
+++ b/tests/test_ingest_survey.py
@@ -165,6 +165,60 @@ class ScoredTests(ScriptCase):
         out = self.run_script(str(self.tmp))
         self.assertIn("SCORED\tworldbuilding.md\tResearch/brainstorm", out)
 
+    def test_bold_label_stats_count_as_charsheet_indicators(self):
+        # A sheet that bolds its labels ("**STR:** 50") used to score zero
+        # charsheet_stats hits — the regex required a label to be followed
+        # directly by optional `:`/`=` then digits, and the closing `**`
+        # sat in between and blocked the match.
+        self.write("bold-sheet.md", (
+            "**STR:** 50\n"
+            "**DEX:** 60\n"
+            "**Hit Points:** 12\n"
+            "**Sanity:** 60\n"
+            "Skills: Library Use 70%, Spot Hidden 55%, Psychology 40%\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tbold-sheet.md\tCharacter sheet", out)
+        # Exactly the four bold-label lines count — the percentage-suffixed
+        # "Skills: ... 70%" line (line 5) must not itself count.
+        self.assertIn("charsheet_stats=4(L1,2,3)", out)
+
+    def test_statblock_inside_prep_notes_is_not_misread_as_character_sheet(self):
+        # A stat block embedded in prep notes used to outscore the play
+        # indicators and win "Character sheet" outright — the mixed
+        # verdict must win whenever play indicators AND at least one of
+        # prep/research/keeper are both present, regardless of the
+        # charsheet count.
+        self.write("prep-with-statblock.md", (
+            "If the investigators explore the shrine, they find the "
+            "altar.\n"
+            "NPC stat block: STR 60, CON 70, SIZ 65, DEX 85, HP 13\n"
+            "Georgiana rolled a 12 and failed her Spot Hidden.\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("Play fragment (mixed content", out)
+        self.assertNotIn("Character sheet", out)
+
+
+class BenchmarkInboxTests(unittest.TestCase):
+    """Regression pins for the three real vault-ingest benchmark fixtures —
+    see tests/proof-runs/mechanization/ground-truth/q5-expected.md for the
+    hand-verified reading these proposals are checked against."""
+
+    def test_benchmark_inbox_classifications(self):
+        inbox = ROOT / "tests" / "benchmark-campaign" / "_inbox"
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), str(inbox)],
+            capture_output=True, text=True, timeout=60)
+        self.assertEqual(proc.returncode, 0,
+                          f"stdout={proc.stdout}\nstderr={proc.stderr}")
+        out = proc.stdout
+        self.assertIn("SCORED\tcharacter-sheet.md\tCharacter sheet", out)
+        self.assertIn(
+            "SCORED\tmixed-source.md\tPlay fragment (mixed content — "
+            "consider a section split)", out)
+        self.assertIn("SCORED\told-session-notes.md\tPlay transcript", out)
+
 
 class TrailerTests(ScriptCase):
     def test_trailer_counts_every_verdict(self):

--- a/tests/test_vault_utilities.py
+++ b/tests/test_vault_utilities.py
@@ -182,6 +182,20 @@ for expect, present, label in [
 ]:
     check(f"session_context: {label}", [expect in ctx], [present])
 
+# A later session that is already PLAYED is not "unplayed" — it means the
+# selection (here an explicit --session 1 behind played session 2) may be
+# stale, and the Note has to say so rather than mislabel it.
+ctx_s1 = "\n".join(run("session_context.py", "--session", "1",
+                       vault=PREP_VAULT))
+check("session_context: later played session gets its own stale Note",
+      ["session(s) [2] in this chapter are numbered after the selected one "
+       "and carry a played status" in ctx_s1,
+       "session index(es) [3] exist with unplayed status" in ctx_s1,
+       "session index(es) [2" in ctx_s1],
+      [True, True, False])
+check("session_context: default selection reports no played-later Note",
+      ["carry a played status" in ctx], [False])
+
 # --- session_context.py with per-chapter session numbering (#162) ---
 #
 # Chapter 3 ran to Session 14; Chapter 4 restarted and is at Session 07. A

--- a/tools/publish/bin/gm-publish.js
+++ b/tools/publish/bin/gm-publish.js
@@ -96,7 +96,9 @@ source file, exactly as it sits on disk. --player-safe prints the sheet with
 everything the published site strips already gone — excluded sections (GM
 Notes and friends), gm-only and spoiler blocks, HTML comments, excluded
 callouts, gm_only relationship edges and excluded frontmatter fields — so it
-is the sheet a player can see, not a reminder to look away.
+is the sheet a player can see, not a reminder to look away. Prefer it over
+reading the vault sheet directly whenever the audience is a player, not
+the GM.
 
   --pc <name>        Which PC: file name, title, or frontmatter name
   --player-safe      Print only what a player can see
@@ -110,7 +112,8 @@ gm-apprentice-publish manifest <diff|apply> [options]
 Compares the publish manifest (_meta/publish-manifest.md) with what is actually
 in the vault, and edits it. "diff" classifies every vault file with the same
 decision the build makes, so a file it calls "publish" is a file the build
-publishes.
+publishes. The tool only shows the drift — which files are correctly
+excluded versus missing is the GM's call.
 
   manifest diff [--config <path>] [--json]
                      List files the manifest does not mention (with the bucket,
@@ -130,6 +133,8 @@ Prints the chain the build walks for one file — directory, type, publish mode,
 auto-exclusion, canon status, manifest section — and then the build's own
 verdict: where it publishes, or which rule stopped it. Follows with the H2
 sections stripped on publish and how many gm-only blocks the file carries.
+Run it before "doctor --site" when the question is about one specific file
+rather than the whole vault.
 
   gm-apprentice-publish explain "Sessions/Session 7.md"
 

--- a/tools/publish/test/cli/help-cli-smoke.test.js
+++ b/tools/publish/test/cli/help-cli-smoke.test.js
@@ -28,11 +28,11 @@ const CASES = {
   'setup-status-bar': [/setup-status-bar \[--config/, /--config <path>/],
   'setup-inbox': [/setup-inbox \[--config/, /--config <path>/],
   flush: [/flush \[--config/, /--dry-run/],
-  sheet: [/sheet show --pc <name>/, /--player-safe/, /--json/],
+  sheet: [/sheet show --pc <name>/, /--player-safe/, /--json/, /whenever the audience is a player/],
   'update-pin': [/update-pin \[--site <dir>\]/, /--check/],
-  manifest: [/manifest <diff\|apply>/, /--prune/],
+  manifest: [/manifest <diff\|apply>/, /--prune/, /is the GM's call/],
   deploy: [/deploy \[--config <path>\] \[--verify\]/, /--dry-run/, /--no-build/],
-  explain: [/explain <vault-relative path>/, /gm-only blocks/],
+  explain: [/explain <vault-relative path>/, /gm-only blocks/, /before "doctor --site"/],
 };
 
 describe('CLI: gm-publish <cmd> --help is per-subcommand', () => {
@@ -62,6 +62,7 @@ describe('CLI: gm-publish <cmd> --help is per-subcommand', () => {
     const r = await runIn(['sheet', 'show', '--help']);
     assert.strictEqual(r.code, 0);
     assert.match(r.stdout, /sheet show --pc <name>/);
+    assert.match(r.stdout, /whenever the audience is a player/);
     assert.doesNotMatch(r.stdout, /Static site generator/);
   });
 


### PR DESCRIPTION

### Changed

- **Python 3 is now a required dependency.** The bundled utilities under
  `skills/shared/scripts/` are standard-library only and need no
  packages, but the skills no longer carry a by-hand alternative for
  anything a script does. README updated accordingly.
- `shared/vault-access.md` cut from 18.3 kB to ~5 kB: the routing table,
  invocation examples and the post-write validation rule stay; the
  per-script description paragraphs are replaced by "run it with
  `--help`". Each script's `--help` was checked against the paragraph it
  replaces and extended where a flag, row vocabulary, exit code, or
  how-to-act rule was missing. The proof run
  (`tests/proof-runs/mechanization/`, v1.9.9 vs v1.9.4 vs prose-stripped)
  showed the one skill that reads this file ran 27% cheaper and 51%
  faster without those paragraphs, opening a third fewer files.
- session-prep now scopes its opening moves to the question asked: the
  version gate always runs, but the read-set bundle, Reconcile and the
  vault-wide checks run only for a full prep invocation. A narrow
  question (document-chain status, thread ages, one plan's conformance)
  runs the one script that answers it and offers the next step instead
  of taking it. Fixes the drift the proof run measured on a status
  question (on-question 2/2 → 1/2 in v1.9.9).

### Removed

- Every "Fallback without python" block across `campaign-organizer`,
  `campaign-qa` (SKILL.md, `graph-health.md`, `wrapup-conformance.md`),
  `publish-site`, `session-play`, `session-prep`, `session-wrapup`,
  `the-midwife` and `vault-ingest`, the manual read-set list in
  session-prep's Context Source, and the no-python paragraph in
  `vault-access.md`.

### Fixed

- `ingest_survey.py` misclassified two of the three benchmark inbox
  files (surfaced by the proof run). The `charsheet_stats` indicator
  now matches stats laid out in markdown tables (`| STR | 45 |`) and as
  bold labels (`**STR:** 50`), not only bare `STR 50`; and a document with play indicators alongside prep, research or
  Keeper-recollection indicators is proposed as "Play fragment (mixed
  content — consider a section split)" even when an embedded NPC stat
  block outscores the play hits — a stat block inside prep notes does
  not make the file a character sheet. Regression tests run the script
  over `tests/benchmark-campaign/_inbox/`.
- `gm-publish sheet show --help`, `manifest --help` and `explain --help`
  now carry the how-to-act rules the deleted `vault-access.md` prose
  held: prefer the player-safe view whenever the audience is a player;
  the manifest tool shows drift and the exclude-versus-missing call is
  the GM's; run `explain` before `doctor --site` for a single-file
  question.
- The benchmark fixture vault (`tests/benchmark-campaign/`) gains a
  `_meta/vault-config.md` and its three wrap-ups are migrated to the
  1.9.5 template, so the version gate returns OK and the wrap-up check
  reports no ERRORs. The deliberate defects the QA benchmarks rely on
  are untouched.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Python 3 is now required for bundled utilities and skill workflows.
  - Utility documentation now directs users to built-in `--help` guidance.
  - Session preparation focuses follow-up work on the question asked.
  - Publishing command help includes clearer usage details.

- **Bug Fixes**
  - Improved survey ingestion classification for formatted stat blocks and mixed play content.
  - Updated benchmark fixtures and validation coverage.

- **Documentation**
  - Updated README, changelog, roadmap, and workflow guidance for version 1.9.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->