### PR TITLE
ingest_survey: cast lists, session exports, saved web pages; single play hit is not a mixed document

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gm-apprentice",
   "description": "TTRPG Game Master skills for Claude -- rules validation, content generation, guided adventure creation, campaign organization, quality auditing, session prep, at-the-table play support, post-session wrap-up, vault ingestion of old campaign materials, and campaign site publishing",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "license": "CC-BY-SA-4.0 AND MIT",
   "author": {
     "name": "AntTheLimey"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.11] — 2026-09-08
+
+### Fixed
+
+- `ingest_survey.py` against a real vault's inbox (129 files, Canticle
+  field test): two published scenarios came out "Play fragment (mixed
+  content)" on a single dice mention and "Character sheet" on 84 NPC stat
+  lines; a gmassistant.app session export scored nothing and fell to
+  "Unclassified"; a saved web page was refused as an unrecognized
+  extension and its `_files/` folder produced a manual-read row per
+  stylesheet. Now: a lone play hit inside prep/research/recollection is
+  noise (two or more make a mixed document); three or more
+  characteristics rows (a line of primary attributes, one per NPC stat
+  block) are a cast list and propose Scenario prep, with `stat_blocks=N`
+  in the evidence, while a single sheet with stats spread over several
+  sections stays a Character sheet; a file with a `Date:` line,
+  `## Summary` and two of Memorable Moments / Scenes / NPCs / Locations /
+  Items, and no frontmatter, is `DECIDED` as "Session export (assistant
+  summary)"; `.html`/`.htm` is scored from its text with tags, scripts
+  and styles stripped (an unterminated `<script>`/`<style>` is reported
+  in the evidence rather than silently dropping the rest of the page); a
+  `<name>_files/` folder is one `DECIDED` row and its contents are never
+  listed. Eleven regression tests. Taxonomy gains the Session export and
+  Web page rows and the cast-list / single-hit rules; vault-ingest Phase
+  1 names the new `DECIDED` shapes and Phase 5 hands a Session export to
+  session-wrapup unchanged.
+
+---
+
 ## [1.9.10] — 2026-09-08
 
 ### Changed

--- a/skills/shared/scripts/ingest_survey.py
+++ b/skills/shared/scripts/ingest_survey.py
@@ -1,15 +1,28 @@
 #!/usr/bin/env python3
 """Classify vault-ingest source material without reading everything blind.
 
-Backs vault-ingest Phase 1 (`references/classification-taxonomy.md`). Three
-of the taxonomy's nine rows are decidable with zero content read (extension
-or existing frontmatter alone): Image/map, Spreadsheet/data, Session wrap-up.
-The other six — play transcript, play fragment, scenario prep,
+Backs vault-ingest Phase 1 (`references/classification-taxonomy.md`). Five
+of the taxonomy's rows are decidable without judgment — by extension,
+existing frontmatter, or a fixed heading signature: Image/map,
+Spreadsheet/data, Session wrap-up, Session export (a table assistant's
+summary: `## Summary` plus at least two of `## Memorable Moments` /
+`## Scenes` / `## NPCs` / `## Locations` / `## Items`, and no
+frontmatter), and a saved web page's `<name>_files/`
+companion folder (reported as one row, its scripts and stylesheets never
+listed). The other six — play transcript, play fragment, scenario prep,
 research/brainstorm, Keeper recollection, character sheet — are scored
 against the literal indicator phrases the taxonomy already names, with
-per-indicator hit counts and line numbers as evidence. Word/PDF files carry
-no stdlib text extraction here and are reported UNSCORED rather than guessed
-at.
+per-indicator hit counts and line numbers as evidence. A saved `.html`
+page is scored from its text with tags, scripts and styles stripped.
+Word/PDF files carry no stdlib text extraction here and are reported
+UNSCORED rather than guessed at.
+
+Two guards learned from a real inbox (2026-09-08): a single play hit in a
+document that otherwise reads as prep does not make it a mixed document
+(two or more do), and three or more characteristics rows — a line
+carrying three or more primary attributes, one per NPC stat block — are a
+scenario's cast list, a prep indicator, not one character's sheet (a
+sheet has one such row, however many sections its other stats sit in).
 
 This turns "read all source material" into "read the manifest, then read
 only the files the manifest flags as ambiguous."
@@ -31,11 +44,12 @@ and `.git` skipped) and prints one row per file:
 
   VERDICT<TAB>path<TAB>proposal<TAB>confidence<TAB>evidence
 
-VERDICT is DECIDED (extension or frontmatter alone settles it — zero
-content read), SCORED (content read, indicators counted, GM/model
+VERDICT is DECIDED (extension, frontmatter or heading signature settles it
+without judgment), SCORED (content read, indicators counted, GM/model
 confirmation still wanted), UNSCORED (binary/unsupported format — Word,
-PDF, VTT — needs a manual read), or ERROR (unreadable). A trailer line
-follows:
+PDF, VTT — needs a manual read), or ERROR (unreadable). A `<name>_files/`
+folder prints one DECIDED row with a trailing `/` and counts as one entry
+in the trailer. A trailer line follows:
 
   # N files: D decided, S scored, U unscored, E errors
 
@@ -69,6 +83,7 @@ import re
 import shutil
 import sys
 from collections.abc import Iterator
+from html.parser import HTMLParser
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -87,29 +102,129 @@ IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg", ".heic",
               ".tiff", ".tif", ".bmp", ".raw", ".cr2", ".nef", ".arw", ".dng"}
 SPREADSHEET_EXTS = {".csv", ".xls", ".xlsx"}
 TEXT_EXTS = {".md", ".markdown", ".txt"}
+# A page saved from the browser: scored from its text once tags, scripts
+# and styles are stripped (stdlib html.parser).
+HTML_EXTS = {".html", ".htm"}
 # Formats the "Supported formats" list names but stdlib cannot extract text
 # from — reported UNSCORED rather than guessed at.
 UNSCORED_EXTS = {".doc", ".docx", ".pdf", ".vtt"}
 
 SKIP_DIR_NAMES = {"_processed", "__pycache__", ".git"}
+# "Webpage, Complete" saves drop `<title>_files/` beside the page — scripts,
+# stylesheets, images the page pulled in. Not source material.
+ASSET_DIR_SUFFIX = "_files"
+
+# A table assistant's session export (gmassistant.app and the like): no
+# frontmatter, a `Date:` line in the first few lines, and these H2s.
+# `Summary` is required plus at least two of the others. GM-written prep
+# can use the same headings, so the Date: line is not optional.
+EXPORT_HEADINGS = ("Summary", "Memorable Moments", "Scenes", "NPCs",
+                   "Locations", "Items")
+H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+DATE_LINE_RE = re.compile(r"^Date:\s*\S")
+DATE_LINE_WINDOW = 10  # non-empty lines from the top to look in
+
+
+def _is_asset_dir(name: str) -> bool:
+    return name.endswith(ASSET_DIR_SUFFIX) and name != ASSET_DIR_SUFFIX
+
+
+def _hidden_or_skipped(rel_parts: tuple[str, ...]) -> bool:
+    if any(p.startswith(".") for p in rel_parts):
+        return True
+    return any(p in SKIP_DIR_NAMES for p in rel_parts[:-1])
 
 
 def walk(root: Path) -> list[Path]:
     """Every file under root, sorted, skipping hidden files/dirs (matching
     vaultlib.vault_files's own convention — a hidden file's own name, not
-    just a hidden parent dir, is skipped) and archive/junk dirs. Not
+    just a hidden parent dir, is skipped), archive/junk dirs, and anything
+    inside a `<name>_files/` companion folder (see `asset_dirs`). Not
     vault-scoped — DIR may be an external folder or `_inbox/`."""
     out = []
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
         rel_parts = path.relative_to(root).parts
-        if any(p.startswith(".") for p in rel_parts):
+        if _hidden_or_skipped(rel_parts):
             continue
-        if any(p in SKIP_DIR_NAMES for p in rel_parts[:-1]):
+        if any(_is_asset_dir(p) for p in rel_parts[:-1]):
             continue
         out.append(path)
     return out
+
+
+def asset_dirs(root: Path) -> list[tuple[Path, int]]:
+    """Every `<name>_files/` companion folder under root with its file
+    count, sorted — one survey row each instead of one per asset."""
+    out = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_dir() or not _is_asset_dir(path.name):
+            continue
+        rel_parts = path.relative_to(root).parts
+        if _hidden_or_skipped(rel_parts + ("",)):
+            continue
+        if any(_is_asset_dir(p) for p in rel_parts[:-1]):
+            continue  # nested inside another asset folder
+        n = sum(1 for p in path.rglob("*") if p.is_file())
+        out.append((path, n))
+    return out
+
+
+class _TextOnly(HTMLParser):
+    """Collect a page's visible text, one line per block, dropping the
+    contents of <script> and <style>. `unterminated` is set when the
+    document ends inside one of those — everything after the open tag was
+    dropped, and the caller says so rather than scoring the remnant as if
+    it were the whole page."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.parts: list[str] = []
+        self._skip = 0
+        self.unterminated = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style"):
+            self._skip += 1
+        elif tag in ("p", "div", "br", "li", "tr", "h1", "h2", "h3", "h4",
+                     "h5", "h6", "table", "section", "article"):
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style") and self._skip:
+            self._skip -= 1
+
+    def handle_data(self, data):
+        if not self._skip:
+            self.parts.append(data)
+
+    def close(self) -> None:
+        super().close()
+        self.unterminated = self._skip > 0
+
+
+def html_text(raw: str) -> tuple[str, bool]:
+    """(visible text, unterminated-script-or-style flag)."""
+    p = _TextOnly()
+    p.feed(raw)
+    p.close()
+    lines = [ln.strip() for ln in "".join(p.parts).splitlines()]
+    return "\n".join(ln for ln in lines if ln), p.unterminated
+
+
+def export_signature(text: str) -> list[str]:
+    """The EXPORT_HEADINGS present as H2s, in canonical order, if the file
+    has a `Date:` line near the top, `Summary`, and at least two of the
+    other headings; else []."""
+    head = [ln for ln in text.splitlines() if ln.strip()][:DATE_LINE_WINDOW]
+    if not any(DATE_LINE_RE.match(ln) for ln in head):
+        return []
+    found = {m.group(1).strip() for m in H2_RE.finditer(text)}
+    hits = [h for h in EXPORT_HEADINGS if h in found]
+    if "Summary" in hits and len(hits) >= 3:
+        return hits
+    return []
 
 
 # --------------------------------------------------------------------------
@@ -183,19 +298,42 @@ CONDITIONAL_RE = re.compile(
     r"\bwould\b|\bshould\b|\bcould\b|\bmight\b|\bif\b", re.IGNORECASE)
 
 
+# A characteristics row: one line carrying this many distinct primary
+# attributes ("STR 45 CON 50 SIZ 55 ..." / "ST 11 DX 12 IQ 13 HT 12"). A
+# sheet has one per character; a scenario's cast list has one per NPC.
+# Derived stats (HP/MP/SAN) and a skills table's Attr column never make
+# a row, so a sheet with stats spread over several sections still counts
+# as one block.
+PRIMARY_ATTR_RE = re.compile(
+    r"\b(STR|CON|SIZ|DEX|INT|POW|APP|EDU|ST|DX|IQ|HT|"
+    r"Strength|Dexterity|Constitution|Intelligence|Wisdom|Charisma)"
+    r"[\s*:=|]*\d{1,3}\b")
+CHAR_ROW_MIN_ATTRS = 3
+# This many characteristics rows are a cast list, not one character.
+CAST_LIST_BLOCKS = 3
+# Play hits below this, in a document that otherwise reads as prep,
+# research or recollection, are noise (one "rolled a 96" in a published
+# scenario's chase rules), not a play fragment.
+MIXED_MIN_PLAY = 2
+
+
 def score(text: str) -> tuple[dict[str, int], dict[str, list[int]],
-                              tuple[int, int]]:
-    """(counts, evidence-lines, (past, conditional) tense tally).
+                              tuple[int, int], int]:
+    """(counts, evidence-lines, (past, conditional) tense tally,
+    stat-block count).
 
     `counts` is the true per-indicator hit total, uncovered by any cap —
     `propose` decides on this. `evidence` is the same indicators' line
     numbers capped at 3 each, for the report only; a file with forty stat
     lines and one with three both show "(L6,7,8)", but their counts (40 vs
-    3) still differ and drive different confidence.
+    3) still differ and drive different confidence. The stat-block count
+    is how many characteristics rows the file has (see PRIMARY_ATTR_RE) —
+    the cast-list signal.
     """
     lines = text.splitlines()
     counts: dict[str, int] = {name: 0 for name, _ in INDICATORS}
     evidence: dict[str, list[int]] = {name: [] for name, _ in INDICATORS}
+    stat_blocks = 0
     for lineno, line in enumerate(lines, start=1):
         for name, pattern in INDICATORS:
             # findall, not search: a stat block routinely packs several
@@ -207,19 +345,27 @@ def score(text: str) -> tuple[dict[str, int], dict[str, list[int]],
                 counts[name] += n
                 if len(evidence[name]) < 3:
                     evidence[name].append(lineno)
+        if len(set(PRIMARY_ATTR_RE.findall(line))) >= CHAR_ROW_MIN_ATTRS:
+            stat_blocks += 1
     past = sum(len(PAST_TENSE_RE.findall(line)) for line in lines)
     conditional = sum(len(CONDITIONAL_RE.findall(line)) for line in lines)
-    return counts, evidence, (past, conditional)
+    return counts, evidence, (past, conditional), stat_blocks
 
 
-def propose(counts: dict[str, int]) -> tuple[str, str]:
-    """(classification, confidence) from true indicator counts."""
+def propose(counts: dict[str, int], stat_blocks: int = 0) -> tuple[str, str]:
+    """(classification, confidence) from true indicator counts and the
+    number of characteristics rows (stat blocks) in the file."""
     play = sum(counts[k] for k in
                ("play_dice", "play_dialogue", "play_vitals", "play_combat"))
     prep = sum(counts[k] for k in ("prep_conditional", "prep_directive"))
     research = counts["research_qa"]
     keeper = counts["keeper_recollection"]
     charsheet = counts["charsheet_stats"]
+    cast_list = stat_blocks >= CAST_LIST_BLOCKS
+    non_play = prep or research or keeper or cast_list
+    # A lone play hit inside prep/research/recollection is noise, not a
+    # fragment — it neither makes the document mixed nor a transcript.
+    play_signal = play >= MIXED_MIN_PLAY or (play and not non_play)
 
     # Tested first, ahead of both the charsheet-dominance rule and the
     # plain play-transcript rule: a stat block embedded in prep notes (an
@@ -227,21 +373,26 @@ def propose(counts: dict[str, int]) -> tuple[str, str]:
     # charsheet_stats hits than the document has play hits, but that does
     # not make the whole file a character sheet — it makes it a mixed
     # document that also happens to contain a stat block. Any document
-    # with play indicators AND at least one of prep/research/keeper wins
-    # the mixed-content verdict outright, regardless of how the charsheet
-    # count compares to play.
-    if play and (prep or research or keeper):
+    # with a play signal AND at least one of prep/research/keeper/cast
+    # list wins the mixed-content verdict outright, regardless of how the
+    # charsheet count compares to play.
+    if play_signal and non_play:
         return ("Play fragment (mixed content — consider a section "
                 "split)", "medium")
+    # A cast list — one characteristics row per NPC — is the taxonomy's
+    # "NPC stat blocks without play context" prep indicator, and outranks
+    # the sheet rule however many stat hits it totals.
+    if cast_list:
+        return "Scenario prep", "high"
     # A character sheet's attribute block routinely trips a handful of
     # play-shaped patterns (a stray "HP 12", a "round" in prose) without
     # being one — structured stats dominating the line count is the
     # stronger signal, so this is tested before the plain play rule.
-    if charsheet >= 3 and charsheet > play:
+    if charsheet >= 3 and charsheet > play and not cast_list:
         return "Character sheet", "high" if charsheet >= 6 else "medium"
-    if play:
+    if play_signal:
         return "Play transcript", "high" if play >= 3 else "medium"
-    if charsheet >= 3:
+    if charsheet >= 3 and not cast_list:
         return "Character sheet", "high" if charsheet >= 6 else "medium"
     if prep:
         return "Scenario prep", "high" if prep >= 2 else "medium"
@@ -253,10 +404,12 @@ def propose(counts: dict[str, int]) -> tuple[str, str]:
 
 
 def evidence_text(counts: dict[str, int], evidence: dict[str, list[int]],
-                  tense: tuple[int, int]) -> str:
+                  tense: tuple[int, int], stat_blocks: int = 0) -> str:
     parts = [f"{name}={counts[name]}" + (f"(L{','.join(map(str, lines))})"
                                           if lines else "")
              for name, lines in evidence.items() if counts[name]]
+    if counts["charsheet_stats"]:
+        parts.append(f"stat_blocks={stat_blocks}")
     parts.append(f"tense: past={tense[0]} conditional={tense[1]}")
     return "; ".join(parts)
 
@@ -276,7 +429,7 @@ def survey_row(root: Path, path: Path) -> tuple[str, str, str, str, str]:
     if ext in SPREADSHEET_EXTS:
         return "DECIDED", rel, "Spreadsheet/data", "high", f"ext={ext}"
 
-    if ext not in TEXT_EXTS:
+    if ext not in TEXT_EXTS and ext not in HTML_EXTS:
         if ext in UNSCORED_EXTS:
             return ("UNSCORED", rel, "-", "-",
                     f"{ext} requires a manual read (no stdlib extractor)")
@@ -288,15 +441,28 @@ def survey_row(root: Path, path: Path) -> tuple[str, str, str, str, str]:
     except OSError as e:
         return "ERROR", rel, "-", "-", f"unreadable ({e.__class__.__name__})"
 
-    fm = extract_frontmatter(text)
-    if fm is not None and entity_type(fm) in WRAP_UP_TYPES:
-        return ("DECIDED", rel, "Session wrap-up", "high",
-                f"frontmatter type: {entity_type(fm)}")
+    prefix = ""
+    if ext in HTML_EXTS:
+        text, unterminated = html_text(text)
+        prefix = "html text extracted; "
+        if unterminated:
+            prefix += ("unterminated <script>/<style> — content after it "
+                       "not read; ")
+    else:
+        fm = extract_frontmatter(text)
+        if fm is not None and entity_type(fm) in WRAP_UP_TYPES:
+            return ("DECIDED", rel, "Session wrap-up", "high",
+                    f"frontmatter type: {entity_type(fm)}")
+        if fm is None:
+            headings = export_signature(text)
+            if headings:
+                return ("DECIDED", rel, "Session export (assistant summary)",
+                        "high", "headings: " + ", ".join(headings))
 
-    counts, evidence, tense = score(text)
-    proposal, confidence = propose(counts)
+    counts, evidence, tense, stat_blocks = score(text)
+    proposal, confidence = propose(counts, stat_blocks)
     return ("SCORED", rel, proposal, confidence,
-            evidence_text(counts, evidence, tense))
+            prefix + evidence_text(counts, evidence, tense, stat_blocks))
 
 
 def run_survey(root: Path) -> int:
@@ -304,6 +470,11 @@ def run_survey(root: Path) -> int:
         print(f"ERROR: not a directory: {root}", file=sys.stderr)
         return 2
     decided = scored = unscored = errors = 0
+    for d, n in asset_dirs(root):
+        rel = d.relative_to(root).as_posix() + "/"
+        print(f"DECIDED\t{rel}\tWeb page assets (companion folder)\thigh\t"
+              f"{n} files — not source material")
+        decided += 1
     for path in walk(root):
         verdict, rel, proposal, confidence, evidence = survey_row(root, path)
         print(f"{verdict}\t{rel}\t{proposal}\t{confidence}\t{evidence}")

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -90,12 +90,14 @@ Run `python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/ingest_survey.py"
 <source-dir>` before reading anything. Rows settled by extension,
 existing frontmatter or a fixed heading signature (images,
 spreadsheets, wrap-ups, a table assistant's session export, a
-saved page's `_files/` folder) print `DECIDED`; the rest print
-`SCORED` with per-indicator hit counts, line numbers, a proposed
-classification and a confidence — read the file yourself only
-to confirm or override a `SCORED` row, not to classify from
+saved page's `_files/` folder) print `DECIDED`; readable text
+prints `SCORED` with per-indicator hit counts, line numbers, a
+proposed classification and a confidence — read the file yourself
+only to confirm or override a `SCORED` row, not to classify from
 scratch. An `UNSCORED` row (Word/PDF/VTT — no stdlib text
-extractor) still needs a manual read. Read
+extractor) still needs a manual read; an `ERROR` row is a file
+the script could not open — report it to the GM, never guess at
+it. Read
 `references/classification-taxonomy.md` for the full taxonomy
 and heuristics behind the proposal.
 
@@ -204,13 +206,8 @@ Read `references/synthesis-templates.md` for the output format.
    author only the fragment-derived text and the seams. Synthesis
    assembles fragments — it does not re-voice writing that is
    already written. (rationale: `shared/content-fidelity.md`)
-   A `Session export` item (a table assistant's summary) is
-   already a finished Play Notes file: copy it into place with its
-   `## Summary` / `## Memorable Moments` / `## Scenes` / `## NPCs`
-   headings intact and skip synthesis and the Keeper Interview for
-   it — session-wrapup detects that shape by its headings and
-   adopts the Summary verbatim; reformatting it here would
-   silently send it down the rewriting path instead.
+   A `Session export` row is copied into place, not synthesized —
+   `references/synthesis-templates.md` § Synthesis Rules, rule 7.
 3. Follow `session-wrapup` workflow to produce the Wrap-Up
    file and create/update entities
 4. For each PC active during the ingested period, write a

--- a/skills/vault-ingest/SKILL.md
+++ b/skills/vault-ingest/SKILL.md
@@ -87,9 +87,10 @@ exist, process each through Phases 3-6 before the next
 ### Phase 1: Survey & Classify
 
 Run `python3 "${CLAUDE_PLUGIN_ROOT}/skills/shared/scripts/ingest_survey.py"
-<source-dir>` before reading anything. Three of the nine
-taxonomy rows resolve with zero content read (extension or
-existing frontmatter alone) and print `DECIDED`; the rest print
+<source-dir>` before reading anything. Rows settled by extension,
+existing frontmatter or a fixed heading signature (images,
+spreadsheets, wrap-ups, a table assistant's session export, a
+saved page's `_files/` folder) print `DECIDED`; the rest print
 `SCORED` with per-indicator hit counts, line numbers, a proposed
 classification and a confidence — read the file yourself only
 to confirm or override a `SCORED` row, not to classify from
@@ -203,6 +204,13 @@ Read `references/synthesis-templates.md` for the output format.
    author only the fragment-derived text and the seams. Synthesis
    assembles fragments — it does not re-voice writing that is
    already written. (rationale: `shared/content-fidelity.md`)
+   A `Session export` item (a table assistant's summary) is
+   already a finished Play Notes file: copy it into place with its
+   `## Summary` / `## Memorable Moments` / `## Scenes` / `## NPCs`
+   headings intact and skip synthesis and the Keeper Interview for
+   it — session-wrapup detects that shape by its headings and
+   adopts the Summary verbatim; reformatting it here would
+   silently send it down the rewriting path instead.
 3. Follow `session-wrapup` workflow to produce the Wrap-Up
    file and create/update entities
 4. For each PC active during the ingested period, write a

--- a/skills/vault-ingest/references/classification-taxonomy.md
+++ b/skills/vault-ingest/references/classification-taxonomy.md
@@ -16,8 +16,8 @@ distinct section within a document gets one classification.
 | Image/map | Visual reference material — portraits, scene art, location shots, maps | Attachment — no canon status | Binary file (jpg, png, webp, gif, svg, heic, raw, tiff, bmp); classify then process per `image-handling.md` |
 | Spreadsheet/data | Tracking sheets, encounter tables | DRAFT — classify by content | Tabular data, formulas, tracking columns |
 | Session wrap-up | Existing Wrap-Up file from a prior session | AUTHORITATIVE | Contains Narrative Recap, PC Carry-Forward, World State sections; `type: session_wrap` frontmatter |
-| Session export | A table assistant's summary of a played session (gmassistant.app and the like) — the source a Wrap-Up is adopted from | AUTHORITATIVE once the GM confirms it; hand to session-wrapup | No frontmatter; title, `Date:` line, `## Summary` plus `## Memorable Moments` / `## Scenes` / `## NPCs` / `## Locations` / `## Items` |
-| Web page (saved) | A page saved from the browser — a campaign-site NPC record, a wiki article | Classify by content, as the text it carries | `.html`; scored from its text with tags stripped. Its `<name>_files/` companion folder (scripts, stylesheets) is not source material — one row, never read |
+| Session export | A table assistant's summary of a played session (gmassistant.app and the like) — the source a Wrap-Up is adopted from | AUTHORITATIVE once the GM confirms it; hand to session-wrapup | No frontmatter; a `Date:` line near the top; `## Summary` plus at least two of `## Memorable Moments` / `## Scenes` / `## NPCs` / `## Locations` / `## Items` |
+| Web page (saved) | A page saved from the browser — a campaign-site NPC record, a wiki article | Classify by content, as the text it carries | `.html` / `.htm`; scored from its text with tags, scripts and styles stripped. Its `<name>_files/` companion folder (scripts, stylesheets) is not source material — one row, never read |
 
 ## Key Heuristics
 

--- a/skills/vault-ingest/references/classification-taxonomy.md
+++ b/skills/vault-ingest/references/classification-taxonomy.md
@@ -16,6 +16,8 @@ distinct section within a document gets one classification.
 | Image/map | Visual reference material — portraits, scene art, location shots, maps | Attachment — no canon status | Binary file (jpg, png, webp, gif, svg, heic, raw, tiff, bmp); classify then process per `image-handling.md` |
 | Spreadsheet/data | Tracking sheets, encounter tables | DRAFT — classify by content | Tabular data, formulas, tracking columns |
 | Session wrap-up | Existing Wrap-Up file from a prior session | AUTHORITATIVE | Contains Narrative Recap, PC Carry-Forward, World State sections; `type: session_wrap` frontmatter |
+| Session export | A table assistant's summary of a played session (gmassistant.app and the like) — the source a Wrap-Up is adopted from | AUTHORITATIVE once the GM confirms it; hand to session-wrapup | No frontmatter; title, `Date:` line, `## Summary` plus `## Memorable Moments` / `## Scenes` / `## NPCs` / `## Locations` / `## Items` |
+| Web page (saved) | A page saved from the browser — a campaign-site NPC record, a wiki article | Classify by content, as the text it carries | `.html`; scored from its text with tags stripped. Its `<name>_files/` companion folder (scripts, stylesheets) is not source material — one row, never read |
 
 ## Key Heuristics
 
@@ -30,9 +32,16 @@ distinct section within a document gets one classification.
 **Prep indicators** (without play indicators = prep):
 - "If the investigators..." (conditional)
 - Multiple alternative outcomes listed
-- NPC stat blocks without play context
+- NPC stat blocks without play context — three or more characteristics
+  rows (a line of primary attributes, one per stat block) are a cast
+  list (a published scenario's Dramatis Personae), not one character's
+  sheet, however many sections a single sheet spreads its stats over
 - "The GM should..." or "At this point..."
 - Handout text not confirmed as found by players
+
+A single play indicator inside a document that otherwise reads as prep
+(one "rolled a 96" in a scenario's chase rules) is noise, not a play
+fragment. Two or more make it a mixed document.
 
 **Research indicators:**
 - Q&A format about historical facts or worldbuilding

--- a/skills/vault-ingest/references/synthesis-templates.md
+++ b/skills/vault-ingest/references/synthesis-templates.md
@@ -109,6 +109,17 @@ content, not live capture.
    keeper interview reveals a scene structure, use it. If not,
    organize by topic or entity cluster.
 
+7. **A Session export is not synthesized.** A survey row
+   `DECIDED` as "Session export (assistant summary)" — a table
+   assistant's own write-up with `## Summary`, `## Memorable
+   Moments`, `## Scenes`, `## NPCs` headings — is already a
+   finished Play Notes file. Copy it into place with those
+   headings intact and skip synthesis and the Keeper Interview
+   for it. session-wrapup detects that shape by its
+   `## Memorable Moments` heading and adopts the Summary verbatim
+   (its gmassistant.app path); reformatting the export here would
+   silently send it down the rewriting path instead.
+
 ## Character Story Backstory Entries
 
 In addition to Play Notes, Phase 5 produces a consolidated

--- a/tests/test_ingest_survey.py
+++ b/tests/test_ingest_survey.py
@@ -200,6 +200,174 @@ class ScoredTests(ScriptCase):
         self.assertNotIn("Character sheet", out)
 
 
+class RealInboxShapeTests(ScriptCase):
+    """Shapes found in a real vault's `_inbox/_processed/` (Canticle field
+    test, 2026-09-08) that the scorer got wrong or could not place."""
+
+    def test_assistant_session_export_is_decided_by_heading_signature(self):
+        # A gmassistant.app export: no frontmatter, a Date: line, and the
+        # Summary / Memorable Moments / Scenes / NPCs headings. It is the
+        # source a wrap-up is adopted from, and it used to come out
+        # "Unclassified — read manually" because a narrative summary has
+        # no dice-roll phrasing to score.
+        self.write("session-Jul 2nd, 2026.md", (
+            "# Alexandria's Embrace\n\nDate: Jul 2nd, 2026\n\n"
+            "## Summary\nThe morning after their first night in Alexandria "
+            "the party gathered for breakfast.\n\n"
+            "## Memorable Moments\n- Rosa's lace.\n\n"
+            "## Scenes\n- The bathhouse.\n\n"
+            "## NPCs\n- Rosa, the widow from Trieste.\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("DECIDED\tsession-Jul 2nd, 2026.md\t"
+                      "Session export (assistant summary)\thigh\t"
+                      "headings: Summary, Memorable Moments, Scenes, NPCs",
+                      out)
+
+    def test_single_play_hit_does_not_make_prep_a_mixed_document(self):
+        # A published scenario with one line mentioning a roll used to be
+        # flagged "Play fragment (mixed content)" on that single hit, over
+        # three Keeper directives and a page of NPC stat blocks.
+        self.write("scenario.md", (
+            "## The Rectory\n\nKeeper Background\n\n"
+            "The Keeper should read this aloud. At this point the "
+            "investigators arrive.\nThe GM should note the weather.\n\n"
+            "#### Rev. Ashdown\nSTR 45 CON 50 SIZ 55 DEX 60 INT 50\n\n"
+            "#### Mrs. Pell\nSTR 45 CON 50 SIZ 55 DEX 60 INT 50\n\n"
+            "#### The Thing in the Crypt\nSTR 80 CON 65 SIZ 60 DEX 70 INT 40\n\n"
+            "#### Dunn the Ostler\nSTR 55 CON 60 SIZ 65 DEX 50 INT 55\n\n"
+            "If a player rolled a 96 on the chaise, the horse bolts.\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tscenario.md\tScenario prep\thigh", out)
+        self.assertNotIn("mixed content", out)
+        self.assertNotIn("Character sheet", out)
+
+    def test_npc_cast_list_under_many_headings_is_prep_not_a_sheet(self):
+        # Stat blocks under four different named headings are a scenario's
+        # cast list — the taxonomy's own "NPC stat blocks without play
+        # context" prep indicator — not one character's sheet, however
+        # many stat hits they add up to.
+        self.write("cast.md", (
+            "## Dramatis Personae\n\n"
+            "#### Captain Marlow\nSTR 70 CON 60 SIZ 65 DEX 55 INT 60\n\n"
+            "#### The Veiled Lady\nSTR 40 CON 50 SIZ 45 DEX 75 INT 80\n\n"
+            "#### Dr. Penrose\nSTR 50 CON 55 SIZ 60 DEX 50 INT 85\n\n"
+            "#### The Engine\nSTR 90 CON 90 SIZ 90 DEX 10 INT 30\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tcast.md\tScenario prep\thigh", out)
+        self.assertIn("stat_blocks=4", out)
+        self.assertNotIn("Character sheet", out)
+
+    def test_cast_list_with_real_play_hits_is_mixed_not_a_transcript(self):
+        # A cast list is prep evidence. Add genuine play hits (two or more)
+        # and the document is mixed — the cast-list signal must not be
+        # dropped just because no "If the investigators" phrase is present.
+        self.write("notes.md", (
+            "#### Captain Marlow\nSTR 70 CON 60 SIZ 65 DEX 55 INT 60\n\n"
+            "#### The Veiled Lady\nSTR 40 CON 50 SIZ 45 DEX 75 INT 80\n\n"
+            "#### Dr. Penrose\nSTR 50 CON 55 SIZ 60 DEX 50 INT 85\n\n"
+            "Georgiana rolled a 12 and failed her Spot Hidden at the "
+            "door.\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("Play fragment (mixed content", out)
+        self.assertNotIn("Play transcript", out)
+
+    def test_stats_under_one_or_two_headings_are_still_a_sheet(self):
+        self.write("pc.md", (
+            "# Dr. Helena Voss\n\n## Characteristics\n"
+            "STR 45 CON 50 SIZ 55 DEX 60 INT 70 POW 65\n\n"
+            "## Derived Stats\nHP 10 MP 13 SAN 65\n\n"
+            "## Skills\nLibrary Use 70%, Spot Hidden 55%\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tpc.md\tCharacter sheet\thigh", out)
+
+    def test_one_pc_sheet_with_three_stat_sections_is_still_a_sheet(self):
+        # A single sheet routinely spreads stats over three sections
+        # (characteristics, combat, magic). Counting headings called that a
+        # cast list. Only a characteristics row per entry — three or more
+        # primary attributes on one line — marks a separate stat block.
+        self.write("pc3.md", (
+            "## Characteristics\nSTR 45 CON 50 SIZ 55 DEX 60 INT 70 POW 65\n\n"
+            "## Combat\nHP 12 DB +1\n\n"
+            "## Magic\nMP 13 SAN 65\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tpc3.md\tCharacter sheet\thigh", out)
+        self.assertIn("stat_blocks=1", out)
+
+    def test_gurps_sheet_with_attr_column_skills_table_is_still_a_sheet(self):
+        # The repo's own GURPS template shape: a primary-attribute line,
+        # a secondary line, and a skills table whose Attr column repeats
+        # DX/IQ/HT once per row. Three sections with stat hits, one sheet.
+        self.write("gurps-pc.md", (
+            "### Primary Attributes\nST 11 DX 12 IQ 13 HT 12\n\n"
+            "### Secondary Characteristics\nHP 11 FP 12\n\n"
+            "## Skills\n| Skill | Attr | Level |\n|---|---|---|\n"
+            "| Fast-Draw | DX | 12 |\n| Research | IQ | 13 |\n"
+            "| Hiking | HT | 12 |\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tgurps-pc.md\tCharacter sheet\thigh", out)
+        self.assertIn("stat_blocks=1", out)
+
+    def test_export_signature_requires_a_date_line(self):
+        # GM-written prep can use Summary / Scenes / NPCs as headings too.
+        # Without the export's Date: line it is scored like any other
+        # document, never DECIDED past review.
+        self.write("prep.md", (
+            "# The Rectory Job\n\n## Summary\nThe party is hired to look "
+            "into the rectory.\n\n## Scenes\n- Arrival\n- The cellar\n\n"
+            "## NPCs\n- The rector\n"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tprep.md\t", out)
+        self.assertNotIn("Session export", out)
+
+    def test_unterminated_script_is_reported_not_silently_dropped(self):
+        self.write("broken.html", (
+            "<html><body><script>var a = 1;\n"
+            "<p>STR 50 CON 60 SIZ 55 DEX 65 INT 70 POW 60</p></body></html>"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tbroken.html\t", out)
+        self.assertIn("unterminated <script>/<style>", out)
+
+    def test_saved_web_page_is_scored_from_its_text(self):
+        # A page saved from the browser (an NPC record from a campaign
+        # site) used to be UNSCORED "unrecognized extension '.html'" — its
+        # text is right there once the tags are stripped.
+        self.write("npc.html", (
+            "<html><head><title>Dr. Hargreaves</title>"
+            "<style>.x{color:red}</style><script>var a=1;</script></head>"
+            "<body><h1>Dr. Ambrose Hargreaves</h1>"
+            "<p>STR 50 CON 60 SIZ 55 DEX 65 INT 70 POW 60</p>"
+            "<p>HP 12 MP 12 SAN 60</p></body></html>"
+        ))
+        out = self.run_script(str(self.tmp))
+        self.assertIn("SCORED\tnpc.html\tCharacter sheet\thigh", out)
+        self.assertIn("html text extracted", out)
+
+    def test_saved_page_companion_folder_is_one_row_not_one_per_asset(self):
+        # "Webpage, Complete" saves drop a `<name>_files/` folder of
+        # scripts and stylesheets beside the page. Those are not source
+        # material and nobody should be told to read a stylesheet.
+        self.write("npc.html", "<html><body><p>nothing</p></body></html>")
+        self.write("Dr Hargreaves _ mobRPG_files/main.css", ".x{}")
+        self.write("Dr Hargreaves _ mobRPG_files/main.js", "var a;")
+        self.write("Dr Hargreaves _ mobRPG_files/js", "var b;")
+        out = self.run_script(str(self.tmp))
+        self.assertIn("DECIDED\tDr Hargreaves _ mobRPG_files/\t"
+                      "Web page assets (companion folder)\thigh\t"
+                      "3 files — not source material", out)
+        self.assertNotIn("main.css", out)
+        self.assertIn("# 2 files: 1 decided, 1 scored, 0 unscored, 0 errors",
+                      out)
+
+
 class BenchmarkInboxTests(unittest.TestCase):
     """Regression pins for the three real vault-ingest benchmark fixtures —
     see tests/proof-runs/mechanization/ground-truth/q5-expected.md for the


### PR DESCRIPTION

### Fixed

- `ingest_survey.py` against a real vault's inbox (129 files, Canticle
  field test): two published scenarios came out "Play fragment (mixed
  content)" on a single dice mention and "Character sheet" on 84 NPC stat
  lines; a gmassistant.app session export scored nothing and fell to
  "Unclassified"; a saved web page was refused as an unrecognized
  extension and its `_files/` folder produced a manual-read row per
  stylesheet. Now: a lone play hit inside prep/research/recollection is
  noise (two or more make a mixed document); three or more
  characteristics rows (a line of primary attributes, one per NPC stat
  block) are a cast list and propose Scenario prep, with `stat_blocks=N`
  in the evidence, while a single sheet with stats spread over several
  sections stays a Character sheet; a file with a `Date:` line,
  `## Summary` and two of Memorable Moments / Scenes / NPCs / Locations /
  Items, and no frontmatter, is `DECIDED` as "Session export (assistant
  summary)"; `.html`/`.htm` is scored from its text with tags, scripts
  and styles stripped (an unterminated `<script>`/`<style>` is reported
  in the evidence rather than silently dropping the rest of the page); a
  `<name>_files/` folder is one `DECIDED` row and its contents are never
  listed. Eleven regression tests. Taxonomy gains the Session export and
  Web page rows and the cast-list / single-hit rules; vault-ingest Phase
  1 names the new `DECIDED` shapes and Phase 5 hands a Session export to
  session-wrapup unchanged.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added classification for saved web pages and session exports.
  - Improved recognition of cast lists, HTML content, and companion asset folders.
  - Session exports can now be copied directly into Play Notes without additional synthesis.

- **Bug Fixes**
  - Reduced false classifications from isolated play indicators and incomplete HTML.
  - Improved handling of session export headings and date information.

- **Documentation**
  - Updated classification guidance and release notes for version 1.9.11.
  - Added regression coverage for new classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->